### PR TITLE
feat(SLHDSA): formalize quantitative d1 EUF-CMA security surface

### DIFF
--- a/HashSig.lean
+++ b/HashSig.lean
@@ -11,6 +11,7 @@ public import HashSig.SLHDSA.C13.WotsC
 public import HashSig.SLHDSA.C13.Xmss
 public import HashSig.SLHDSA.Concrete.Instance
 public import HashSig.SLHDSA.Concrete.Keccak
+public import HashSig.SLHDSA.Concrete.Security
 public import HashSig.SLHDSA.Concrete.Sha2
 public import HashSig.SLHDSA.Encoding
 public import HashSig.SLHDSA.Fors

--- a/HashSig.lean
+++ b/HashSig.lean
@@ -23,6 +23,8 @@ public import HashSig.SLHDSA.RandomOracle
 public import HashSig.SLHDSA.Scheme
 public import HashSig.SLHDSA.Security
 public import HashSig.SLHDSA.Security.ReductionBound
+public import HashSig.SLHDSA.Security.TargetProfile
+public import HashSig.SLHDSA.Security.Targets
 public import HashSig.SLHDSA.Wots
 public import HashSig.SLHDSA.WotsChecksum
 public import HashSig.SLHDSA.Xmss

--- a/HashSig.lean
+++ b/HashSig.lean
@@ -21,6 +21,7 @@ public import HashSig.SLHDSA.Primitives
 public import HashSig.SLHDSA.RandomOracle
 public import HashSig.SLHDSA.Scheme
 public import HashSig.SLHDSA.Security
+public import HashSig.SLHDSA.Security.ReductionBound
 public import HashSig.SLHDSA.Wots
 public import HashSig.SLHDSA.WotsChecksum
 public import HashSig.SLHDSA.Xmss

--- a/HashSig/SLHDSA/Address.lean
+++ b/HashSig/SLHDSA/Address.lean
@@ -136,6 +136,53 @@ def compressSha2 (a : Adrs) : List Byte :=
   toBytesBE a.layer 1 ++ toBytesBE a.tree 8 ++ toBytesBE a.type 1 ++
     toBytesBE a.word1 4 ++ toBytesBE a.word2 4 ++ toBytesBE a.word3 4
 
+/-- Four-byte big-endian encoding is injective on the 32-bit range. -/
+theorem toBytesBE_four_injective_of_lt {x y : ℕ}
+    (hx : x < 4294967296) (hy : y < 4294967296)
+    (h : toBytesBE x 4 = toBytesBE y 4) : x = y := by
+  simp only [toBytesBE, List.range_succ_eq_map, List.map_cons, List.cons.injEq] at h
+  norm_num at h
+  rcases h with ⟨h3, h2, h1, h0⟩
+  have h3' := congrArg UInt8.toNat h3
+  have h2' := congrArg UInt8.toNat h2
+  have h1' := congrArg UInt8.toNat h1
+  have h0' := congrArg UInt8.toNat h0
+  simp at h3' h2' h1' h0'
+  omega
+
+/-- SHA address compression is injective between addresses with a common layer/tree/type header
+provided their three type-dependent words are in the 32-bit range retained by `ADRSc`.  This is
+the reusable restricted-injectivity fact needed by the reachable SLH-DSA target families; it does
+not claim false global injectivity of the compressed address. -/
+theorem compressSha2_injective_of_header_eq {a b : Adrs}
+    (hlayer : a.layer = b.layer) (htree : a.tree = b.tree) (htype : a.type = b.type)
+    (ha1 : a.word1 < 4294967296) (hb1 : b.word1 < 4294967296)
+    (ha2 : a.word2 < 4294967296) (hb2 : b.word2 < 4294967296)
+    (ha3 : a.word3 < 4294967296) (hb3 : b.word3 < 4294967296)
+    (h : a.compressSha2 = b.compressSha2) : a = b := by
+  have hwords :
+      toBytesBE a.word1 4 ++ toBytesBE a.word2 4 ++ toBytesBE a.word3 4 =
+        toBytesBE b.word1 4 ++ toBytesBE b.word2 4 ++ toBytesBE b.word3 4 := by
+    simpa [compressSha2, hlayer, htree, htype] using h
+  have h1 : toBytesBE a.word1 4 = toBytesBE b.word1 4 := by
+    have := congrArg (List.take 4) hwords
+    simpa [toBytesBE] using this
+  have hw1 : a.word1 = b.word1 := toBytesBE_four_injective_of_lt ha1 hb1 h1
+  rw [hw1] at hwords
+  simp only [List.append_assoc] at hwords
+  have htail := List.append_cancel_left hwords
+  have h2 : toBytesBE a.word2 4 = toBytesBE b.word2 4 := by
+    have := congrArg (List.take 4) htail
+    simpa [toBytesBE] using this
+  have hw2 : a.word2 = b.word2 := toBytesBE_four_injective_of_lt ha2 hb2 h2
+  rw [hw2] at htail
+  have h3 : toBytesBE a.word3 4 = toBytesBE b.word3 4 :=
+    List.append_cancel_left htail
+  have hw3 : a.word3 = b.word3 := toBytesBE_four_injective_of_lt ha3 hb3 h3
+  cases a
+  cases b
+  simp_all only
+
 end Adrs
 
 end SLHDSA

--- a/HashSig/SLHDSA/Concrete/Instance.lean
+++ b/HashSig/SLHDSA/Concrete/Instance.lean
@@ -177,6 +177,10 @@ instance : SampleableType shaPrimitives.SkSeed := inferInstanceAs (SampleableTyp
 instance : SampleableType shaPrimitives.SkPrf := inferInstanceAs (SampleableType (Bytes 16))
 instance : SampleableType shaPrimitives.PkSeed := inferInstanceAs (SampleableType (Bytes 16))
 instance : SampleableType shaPrimitives.Y := inferInstanceAs (SampleableType (Bytes 16))
+instance : Inhabited shaPrimitives.Y := inferInstanceAs (Inhabited (Bytes 16))
+instance : Fintype shaPrimitives.Y := inferInstanceAs (Fintype (Bytes 16))
+instance : DecidableEq shaPrimitives.PkSeed := inferInstanceAs (DecidableEq (Bytes 16))
+instance : DecidableEq shaPrimitives.AdrsKey := inferInstanceAs (DecidableEq (Bytes 22))
 instance : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16))
 
 /-- **Perfect completeness at the concrete SHA2-128-24 bundle.** This specializes the

--- a/HashSig/SLHDSA/Concrete/Instance.lean
+++ b/HashSig/SLHDSA/Concrete/Instance.lean
@@ -124,6 +124,18 @@ def shaPrimitives : Primitives slhdsaSha2_128_24 where
   Hmsg := shaHmsg
   yToBytes := fun y => y
 
+/-- The supported SHA2-128-24 WOTS message encoding is injective.  Its 16-byte node is encoded as
+exactly 64 base-4 digits, so `base2b` consumes all 128 bits and performs no truncation. -/
+theorem shaPrimitives_wotsMessageEncodingInjective :
+    shaPrimitives.core.WotsMessageEncodingInjective := by
+  intro x y h
+  apply Vector.toList_inj.mp
+  apply base2b_two_injective_of_length 16
+  · exact x.2
+  · exact y.2
+  · simpa [wotsMsgDigitsCore, shaPrimitives, slhdsaSha2_128_24,
+      ParameterSet.params, Params.len1] using h
+
 /-! ### Fixed-width signature decoding (FIPS 205 Fig 17 wire format) -/
 
 /-- Decode the 3856-byte signature `R ‖ SIG_FORS ‖ SIG_HT` (FORS: `k` trees of

--- a/HashSig/SLHDSA/Concrete/Instance.lean
+++ b/HashSig/SLHDSA/Concrete/Instance.lean
@@ -178,7 +178,6 @@ instance : SampleableType shaPrimitives.SkPrf := inferInstanceAs (SampleableType
 instance : SampleableType shaPrimitives.PkSeed := inferInstanceAs (SampleableType (Bytes 16))
 instance : SampleableType shaPrimitives.Y := inferInstanceAs (SampleableType (Bytes 16))
 instance : Inhabited shaPrimitives.Y := inferInstanceAs (Inhabited (Bytes 16))
-instance : Fintype shaPrimitives.Y := inferInstanceAs (Fintype (Bytes 16))
 instance : DecidableEq shaPrimitives.PkSeed := inferInstanceAs (DecidableEq (Bytes 16))
 instance : DecidableEq shaPrimitives.AdrsKey := inferInstanceAs (DecidableEq (Bytes 22))
 instance : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16))

--- a/HashSig/SLHDSA/Concrete/Security.lean
+++ b/HashSig/SLHDSA/Concrete/Security.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 
 module
 public import HashSig.SLHDSA.Concrete.Instance
-public import HashSig.SLHDSA.Security.Targets
+public import HashSig.SLHDSA.Security.ReductionBound
 
 /-!
 # Concrete SHA2-128-24 security side conditions
@@ -23,7 +23,7 @@ globally injective, but all coordinates retained by those families fit in its 32
 
 namespace SLHDSA.Concrete
 
-open SLHDSA
+open SLHDSA ENNReal
 
 /-- Lift restricted injectivity of the list-valued `ADRSc` encoding to its fixed-width vector. -/
 theorem shaAdrsKey_injective_of_header_eq {a b : Adrs}
@@ -226,5 +226,92 @@ theorem shaPrimitives_d1TargetTweakSeparation :
     shaAdrsKey_injective_on_d1WotsTcrAddressSpace
     shaAdrsKey_injective_on_d1WotsPkAddresses
     shaAdrsKey_injective_on_d1XmssTreeAddresses
+
+/-! ## Concrete reduction certificate and headline bounds -/
+
+/-- Package the remaining probabilistic reduction obligations into the generic certificate for
+the supported SHA2-128-24 instance.  Parameter validity, WOTS encoding injectivity, and reachable
+`ADRSc` target separation are discharged by the concrete theorems above. -/
+def shaD1EufCmaReductionCertificate
+    (adv : EufCmaAdversary shaPrimitives)
+    {reds : D1ReductionAdversaries shaPrimitives}
+    (composition : D1CompositionCertificate slhdsaSha2_128_24
+      (concreteEufCmaAdvantage shaPrimitives adv) reds.advantages)
+    (openPreCounting : reds.OpenPreCountingStatement) :
+    D1EufCmaReductionCertificate shaPrimitives adv reds where
+  profile := Params.slhdsaSha2_128_24_d1SecurityProfile
+  wotsEncodingInjective := shaPrimitives_wotsMessageEncodingInjective
+  targetSeparation := shaPrimitives_d1TargetTweakSeparation
+  composition := composition
+  openPreCounting := openPreCounting
+
+/-- Concrete SHA2-128-24 EUF-CMA theorem.  Every representation-level condition is proved; the
+only inputs are the three program-level composition inequalities and the named OpenPRE fiber
+counting/coupling statement.  The WOTS coefficient specializes from `w - 2` to exactly `2`. -/
+theorem sha2_128_24_concreteEufCmaAdvantage_le_explicitLowLevelBound
+    (adv : EufCmaAdversary shaPrimitives)
+    (reds : D1ReductionAdversaries shaPrimitives)
+    (composition : D1CompositionCertificate slhdsaSha2_128_24
+      (concreteEufCmaAdvantage shaPrimitives adv) reds.advantages)
+    (openPreCounting : reds.OpenPreCountingStatement) :
+    concreteEufCmaAdvantage shaPrimitives adv ≤
+      (PRFScheme.prfAdvantageENNReal (skPrfScheme shaPrimitives) reds.skPrf +
+        PRFScheme.prfAdvantageENNReal (msgPrfScheme shaPrimitives) reds.msgPrf) +
+      (KeyedHash.ITSRAdvantage reds.hmsgItsr +
+        (TweakableHash.SM_DT_DSPR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toDSPR reds.forsOpenPre) +
+          3 * TweakableHash.SM_DT_TCR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toTCR reds.forsOpenPre)) +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsTreeTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsRootsTcr) +
+      ((2 * TweakableHash.SM_DT_UD_Advantage reds.wotsUd +
+          TweakableHash.SM_DT_TCR_Advantage reds.wotsTcr +
+          TweakableHash.SM_DT_PRE_Advantage reds.wotsPre) +
+        TweakableHash.SM_DT_TCR_Advantage reds.wotsPkTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.xmssTreeTcr) := by
+  have h := concreteEufCmaAdvantage_le_explicitLowLevelBound shaPrimitives adv reds
+    (shaD1EufCmaReductionCertificate adv composition openPreCounting)
+  norm_num [Params.w, slhdsaSha2_128_24, ParameterSet.params] at h
+  have hcoef : (4 : ℝ≥0∞) - 2 = 2 := by
+    change ((4 : ℕ) : ℝ≥0∞) - ((2 : ℕ) : ℝ≥0∞) = ((2 : ℕ) : ℝ≥0∞)
+    rw [← ENNReal.natCast_sub]
+  rw [hcoef] at h
+  exact h
+
+/-- Most-general concrete SHA2-128-24 SUF-CMA theorem currently justified: the complete EUF-CMA
+hash/PRF bound plus the exact residual probability of a new valid signature on an already signed
+message.  Bounding that final term is precisely the extra scheme-specific property needed beyond
+the cited EUF proof. -/
+theorem sha2_128_24_concreteStrongEufCmaAdvantage_le_explicitLowLevelBound_add_sameMessage
+    (adv : StrongEufCmaAdversary shaPrimitives)
+    (reds : D1ReductionAdversaries shaPrimitives)
+    (composition : D1CompositionCertificate slhdsaSha2_128_24
+      (concreteEufCmaAdvantage shaPrimitives adv.toUnforgeableAdv) reds.advantages)
+    (openPreCounting : reds.OpenPreCountingStatement) :
+    concreteStrongEufCmaAdvantage shaPrimitives adv ≤
+      (PRFScheme.prfAdvantageENNReal (skPrfScheme shaPrimitives) reds.skPrf +
+        PRFScheme.prfAdvantageENNReal (msgPrfScheme shaPrimitives) reds.msgPrf) +
+      (KeyedHash.ITSRAdvantage reds.hmsgItsr +
+        (TweakableHash.SM_DT_DSPR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toDSPR reds.forsOpenPre) +
+          3 * TweakableHash.SM_DT_TCR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toTCR reds.forsOpenPre)) +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsTreeTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsRootsTcr) +
+      ((2 * TweakableHash.SM_DT_UD_Advantage reds.wotsUd +
+          TweakableHash.SM_DT_TCR_Advantage reds.wotsTcr +
+          TweakableHash.SM_DT_PRE_Advantage reds.wotsPre) +
+        TweakableHash.SM_DT_TCR_Advantage reds.wotsPkTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.xmssTreeTcr) +
+      concreteSameMessageStrongAdvantage shaPrimitives adv := by
+  have h := concreteStrongEufCmaAdvantage_le_explicitLowLevelBound_add_sameMessage
+    shaPrimitives adv reds
+      (shaD1EufCmaReductionCertificate adv.toUnforgeableAdv composition openPreCounting)
+  norm_num [Params.w, slhdsaSha2_128_24, ParameterSet.params] at h
+  have hcoef : (4 : ℝ≥0∞) - 2 = 2 := by
+    change ((4 : ℕ) : ℝ≥0∞) - ((2 : ℕ) : ℝ≥0∞) = ((2 : ℕ) : ℝ≥0∞)
+    rw [← ENNReal.natCast_sub]
+  rw [hcoef] at h
+  exact h
 
 end SLHDSA.Concrete

--- a/HashSig/SLHDSA/Concrete/Security.lean
+++ b/HashSig/SLHDSA/Concrete/Security.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Concrete.Instance
+public import HashSig.SLHDSA.Security.Targets
+
+/-!
+# Concrete SHA2-128-24 security side conditions
+
+This module discharges the two representation-level hypotheses used by the generic `d = 1`
+SLH-DSA reduction: full-width WOTS message encoding (proved in `Concrete.Instance`) and separation
+of every reachable target tweak after FIPS 205 `ADRSc` compression.
+
+The latter statement is deliberately restricted to the seven target families.  `ADRSc` is not
+globally injective, but all coordinates retained by those families fit in its 32-bit words.
+-/
+
+@[expose] public section
+
+namespace SLHDSA.Concrete
+
+open SLHDSA
+
+/-- Lift restricted injectivity of the list-valued `ADRSc` encoding to its fixed-width vector. -/
+theorem shaAdrsKey_injective_of_header_eq {a b : Adrs}
+    (hlayer : a.layer = b.layer) (htree : a.tree = b.tree) (htype : a.type = b.type)
+    (ha1 : a.word1 < 4294967296) (hb1 : b.word1 < 4294967296)
+    (ha2 : a.word2 < 4294967296) (hb2 : b.word2 < 4294967296)
+    (ha3 : a.word3 < 4294967296) (hb3 : b.word3 < 4294967296)
+    (h : shaAdrsKey a = shaAdrsKey b) : a = b := by
+  apply Adrs.compressSha2_injective_of_header_eq hlayer htree htype ha1 hb1 ha2 hb2 ha3 hb3
+  simpa using congrArg Vector.toList h
+
+private theorem shaAdrsKey_injective_on_d1ForsLeafAddresses :
+    ∀ a ∈ slhdsaSha2_128_24.d1ForsLeafAddresses,
+      ∀ b ∈ slhdsaSha2_128_24.d1ForsLeafAddresses,
+        shaAdrsKey a = shaAdrsKey b → a = b := by
+  intro a ha b hb hab
+  obtain ⟨ai, hai, aj, haj, al, hal, rfl⟩ :
+      ∃ ai < slhdsaSha2_128_24.d1LeafCount,
+        ∃ aj < slhdsaSha2_128_24.k, ∃ al < slhdsaSha2_128_24.t,
+          forsNodeAdrs (forsAdrsOf ai) 0 (aj * slhdsaSha2_128_24.t + al) = a := by
+    simpa [Params.d1ForsLeafAddresses] using ha
+  obtain ⟨bi, hbi, bj, hbj, bl, hbl, rfl⟩ :
+      ∃ bi < slhdsaSha2_128_24.d1LeafCount,
+        ∃ bj < slhdsaSha2_128_24.k, ∃ bl < slhdsaSha2_128_24.t,
+          forsNodeAdrs (forsAdrsOf bi) 0 (bj * slhdsaSha2_128_24.t + bl) = b := by
+    simpa [Params.d1ForsLeafAddresses] using hb
+  apply shaAdrsKey_injective_of_header_eq <;>
+    simp [forsNodeAdrs, forsAdrsOf, Adrs.getKeyPairAddress,
+      Adrs.setTreeHeight, Adrs.setTreeIndex, Adrs.setKeyPairAddress,
+      Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero,
+      slhdsaSha2_128_24, ParameterSet.params, Params.d1LeafCount, Params.t] at * <;>
+    omega
+
+private theorem shaAdrsKey_injective_on_d1ForsRootsAddresses :
+    ∀ a ∈ slhdsaSha2_128_24.d1ForsRootsAddresses,
+      ∀ b ∈ slhdsaSha2_128_24.d1ForsRootsAddresses,
+        shaAdrsKey a = shaAdrsKey b → a = b := by
+  intro a ha b hb hab
+  obtain ⟨ai, hai, rfl⟩ : ∃ ai < slhdsaSha2_128_24.d1LeafCount,
+      forsPkAdrs (forsAdrsOf ai) = a := by
+    simpa [Params.d1ForsRootsAddresses] using ha
+  obtain ⟨bi, hbi, rfl⟩ : ∃ bi < slhdsaSha2_128_24.d1LeafCount,
+      forsPkAdrs (forsAdrsOf bi) = b := by
+    simpa [Params.d1ForsRootsAddresses] using hb
+  apply shaAdrsKey_injective_of_header_eq <;>
+    simp [forsPkAdrs, forsAdrsOf, Adrs.getKeyPairAddress,
+      Adrs.setKeyPairAddress, Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero,
+      slhdsaSha2_128_24, ParameterSet.params, Params.d1LeafCount] at * <;>
+    omega
+
+private theorem shaAdrsKey_injective_on_d1WotsPkAddresses :
+    ∀ a ∈ slhdsaSha2_128_24.d1WotsPkAddresses,
+      ∀ b ∈ slhdsaSha2_128_24.d1WotsPkAddresses,
+        shaAdrsKey a = shaAdrsKey b → a = b := by
+  intro a ha b hb hab
+  obtain ⟨ai, hai, rfl⟩ : ∃ ai < slhdsaSha2_128_24.d1LeafCount,
+      wotsPkAdrs (wotsLeafAdrs Adrs.zero ai) = a := by
+    simpa [Params.d1WotsPkAddresses] using ha
+  obtain ⟨bi, hbi, rfl⟩ : ∃ bi < slhdsaSha2_128_24.d1LeafCount,
+      wotsPkAdrs (wotsLeafAdrs Adrs.zero bi) = b := by
+    simpa [Params.d1WotsPkAddresses] using hb
+  apply shaAdrsKey_injective_of_header_eq <;>
+    simp [wotsPkAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress,
+      Adrs.setKeyPairAddress, Adrs.setTypeAndClear, Adrs.zero,
+      slhdsaSha2_128_24, ParameterSet.params, Params.d1LeafCount] at * <;>
+    omega
+
+private theorem shaAdrsKey_injective_on_d1WotsTcrAddressSpace :
+    ∀ a ∈ slhdsaSha2_128_24.d1WotsTcrAddressSpace,
+      ∀ b ∈ slhdsaSha2_128_24.d1WotsTcrAddressSpace,
+        shaAdrsKey a = shaAdrsKey b → a = b := by
+  intro a ha b hb hab
+  obtain ⟨ai, hai, ac, hac, astep, hastep, rfl⟩ :
+      ∃ ai < slhdsaSha2_128_24.d1LeafCount,
+        ∃ ac < slhdsaSha2_128_24.len, ∃ astep < slhdsaSha2_128_24.w - 1,
+          (wotsChainAdrs (wotsLeafAdrs Adrs.zero ai) ac).setHashAddress astep = a := by
+    simpa [Params.d1WotsTcrAddressSpace] using ha
+  obtain ⟨bi, hbi, bc, hbc, bstep, hbstep, rfl⟩ :
+      ∃ bi < slhdsaSha2_128_24.d1LeafCount,
+        ∃ bc < slhdsaSha2_128_24.len, ∃ bstep < slhdsaSha2_128_24.w - 1,
+          (wotsChainAdrs (wotsLeafAdrs Adrs.zero bi) bc).setHashAddress bstep = b := by
+    simpa [Params.d1WotsTcrAddressSpace] using hb
+  have hlen : slhdsaSha2_128_24.len = 68 := by decide
+  rw [hlen] at hac hbc
+  apply shaAdrsKey_injective_of_header_eq <;>
+    simp [wotsChainAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress, Adrs.setHashAddress,
+      Adrs.setChainAddress, Adrs.setKeyPairAddress, Adrs.setTypeAndClear, Adrs.zero,
+      slhdsaSha2_128_24, ParameterSet.params, Params.d1LeafCount, Params.len, Params.len1,
+      Params.len2, Params.w] at * <;>
+    omega
+
+private theorem shaAdrsKey_injective_on_d1WotsPreAddresses
+    (messageAt : ℕ → shaPrimitives.Y) :
+    ∀ a ∈ slhdsaSha2_128_24.d1WotsPreAddresses shaPrimitives.core messageAt,
+      ∀ b ∈ slhdsaSha2_128_24.d1WotsPreAddresses shaPrimitives.core messageAt,
+        shaAdrsKey a = shaAdrsKey b → a = b := by
+  intro a ha b hb hab
+  obtain ⟨ai, hai, ac, hac, hadigit, rfl⟩ :
+      ∃ ai < slhdsaSha2_128_24.d1LeafCount,
+        ∃ ac < slhdsaSha2_128_24.len,
+          chainStepsCore shaPrimitives.core (messageAt ai) ac ≠ 0 ∧
+            a = (wotsChainAdrs (wotsLeafAdrs Adrs.zero ai) ac).setHashAddress
+              (chainStepsCore shaPrimitives.core (messageAt ai) ac - 1) := by
+    simpa [Params.d1WotsPreAddresses] using ha
+  obtain ⟨bi, hbi, bc, hbc, hbdigit, rfl⟩ :
+      ∃ bi < slhdsaSha2_128_24.d1LeafCount,
+        ∃ bc < slhdsaSha2_128_24.len,
+          chainStepsCore shaPrimitives.core (messageAt bi) bc ≠ 0 ∧
+            b = (wotsChainAdrs (wotsLeafAdrs Adrs.zero bi) bc).setHashAddress
+              (chainStepsCore shaPrimitives.core (messageAt bi) bc - 1) := by
+    simpa [Params.d1WotsPreAddresses] using hb
+  have hadigitBound := chainStepsCore_lt shaPrimitives.core (messageAt ai) ac
+  have hbdigitBound := chainStepsCore_lt shaPrimitives.core (messageAt bi) bc
+  have hlen : slhdsaSha2_128_24.len = 68 := by decide
+  rw [hlen] at hac hbc
+  apply shaAdrsKey_injective_of_header_eq <;>
+    simp [wotsChainAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress, Adrs.setHashAddress,
+      Adrs.setChainAddress, Adrs.setKeyPairAddress, Adrs.setTypeAndClear, Adrs.zero,
+      slhdsaSha2_128_24, ParameterSet.params, Params.d1LeafCount, Params.w] at * <;>
+    omega
+
+private theorem shaAdrsKey_injective_on_d1ForsTreeAddresses :
+    ∀ a ∈ slhdsaSha2_128_24.d1ForsTreeAddresses,
+      ∀ b ∈ slhdsaSha2_128_24.d1ForsTreeAddresses,
+        shaAdrsKey a = shaAdrsKey b → a = b := by
+  intro a ha b hb hab
+  obtain ⟨ai, hai, aj, haj, azi, hazi, rfl⟩ :
+      ∃ ai < slhdsaSha2_128_24.d1LeafCount,
+        ∃ aj < slhdsaSha2_128_24.k,
+          ∃ azi ∈ perfectInternalCoords slhdsaSha2_128_24.a,
+            forsNodeAdrs (forsAdrsOf ai) azi.1
+              (aj * 2 ^ (slhdsaSha2_128_24.a - azi.1) + azi.2) = a := by
+    simpa [Params.d1ForsTreeAddresses] using ha
+  obtain ⟨bi, hbi, bj, hbj, bzi, hbzi, rfl⟩ :
+      ∃ bi < slhdsaSha2_128_24.d1LeafCount,
+        ∃ bj < slhdsaSha2_128_24.k,
+          ∃ bzi ∈ perfectInternalCoords slhdsaSha2_128_24.a,
+            forsNodeAdrs (forsAdrsOf bi) bzi.1
+              (bj * 2 ^ (slhdsaSha2_128_24.a - bzi.1) + bzi.2) = b := by
+    simpa [Params.d1ForsTreeAddresses] using hb
+  have ahle := perfectInternalCoords_height_le hazi
+  have bhle := perfectInternalCoords_height_le hbzi
+  have aidx := perfectInternalCoords_index_lt hazi
+  have bidx := perfectInternalCoords_index_lt hbzi
+  have apow : 2 ^ (slhdsaSha2_128_24.a - azi.1) ≤ 2 ^ slhdsaSha2_128_24.a :=
+    Nat.pow_le_pow_right (by omega) (Nat.sub_le _ _)
+  have bpow : 2 ^ (slhdsaSha2_128_24.a - bzi.1) ≤ 2 ^ slhdsaSha2_128_24.a :=
+    Nat.pow_le_pow_right (by omega) (Nat.sub_le _ _)
+  have aqpos : 0 < 2 ^ (slhdsaSha2_128_24.a - azi.1) := by positivity
+  have bqpos : 0 < 2 ^ (slhdsaSha2_128_24.a - bzi.1) := by positivity
+  norm_num [slhdsaSha2_128_24, ParameterSet.params] at haj hbj
+  have aword3 :
+      aj * 2 ^ (slhdsaSha2_128_24.a - azi.1) + azi.2 < 4294967296 := by
+    calc
+      _ < 6 * 2 ^ (slhdsaSha2_128_24.a - azi.1) := by nlinarith
+      _ ≤ 6 * 2 ^ slhdsaSha2_128_24.a := Nat.mul_le_mul_left 6 apow
+      _ < 4294967296 := by decide
+  have bword3 :
+      bj * 2 ^ (slhdsaSha2_128_24.a - bzi.1) + bzi.2 < 4294967296 := by
+    calc
+      _ < 6 * 2 ^ (slhdsaSha2_128_24.a - bzi.1) := by nlinarith
+      _ ≤ 6 * 2 ^ slhdsaSha2_128_24.a := Nat.mul_le_mul_left 6 bpow
+      _ < 4294967296 := by decide
+  apply shaAdrsKey_injective_of_header_eq <;>
+    simp [forsNodeAdrs, forsAdrsOf, Adrs.getKeyPairAddress,
+      Adrs.setTreeHeight, Adrs.setTreeIndex, Adrs.setKeyPairAddress,
+      Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero,
+      slhdsaSha2_128_24, ParameterSet.params, Params.d1LeafCount] at * <;>
+    omega
+
+private theorem shaAdrsKey_injective_on_d1XmssTreeAddresses :
+    ∀ a ∈ slhdsaSha2_128_24.d1XmssTreeAddresses,
+      ∀ b ∈ slhdsaSha2_128_24.d1XmssTreeAddresses,
+        shaAdrsKey a = shaAdrsKey b → a = b := by
+  intro a ha b hb hab
+  obtain ⟨azi, hazi, rfl⟩ := List.mem_map.mp ha
+  obtain ⟨bzi, hbzi, rfl⟩ := List.mem_map.mp hb
+  have ahle := perfectInternalCoords_height_le hazi
+  have bhle := perfectInternalCoords_height_le hbzi
+  have aidx := perfectInternalCoords_index_lt hazi
+  have bidx := perfectInternalCoords_index_lt hbzi
+  have apow : 2 ^ (slhdsaSha2_128_24.hp - azi.1) ≤ 2 ^ slhdsaSha2_128_24.hp :=
+    Nat.pow_le_pow_right (by omega) (Nat.sub_le _ _)
+  have bpow : 2 ^ (slhdsaSha2_128_24.hp - bzi.1) ≤ 2 ^ slhdsaSha2_128_24.hp :=
+    Nat.pow_le_pow_right (by omega) (Nat.sub_le _ _)
+  apply shaAdrsKey_injective_of_header_eq <;>
+    simp [xmssNodeAdrs, Adrs.setTreeHeight, Adrs.setTreeIndex, Adrs.setTypeAndClear,
+      Adrs.zero, slhdsaSha2_128_24, ParameterSet.params] at * <;>
+    omega
+
+/-- Every reachable `d = 1` target family has distinct encoded tweaks for the concrete
+SLH-DSA-SHA2-128-24 primitive bundle. -/
+theorem shaPrimitives_d1TargetTweakSeparation :
+    Primitives.D1TargetTweakSeparation shaPrimitives :=
+  Primitives.D1TargetTweakSeparation.ofInjOn shaPrimitives
+    shaAdrsKey_injective_on_d1ForsLeafAddresses
+    shaAdrsKey_injective_on_d1ForsTreeAddresses
+    shaAdrsKey_injective_on_d1ForsRootsAddresses
+    (fun messageAt => shaAdrsKey_injective_on_d1WotsPreAddresses messageAt)
+    shaAdrsKey_injective_on_d1WotsTcrAddressSpace
+    shaAdrsKey_injective_on_d1WotsPkAddresses
+    shaAdrsKey_injective_on_d1XmssTreeAddresses
+
+end SLHDSA.Concrete

--- a/HashSig/SLHDSA/Concrete/Security.lean
+++ b/HashSig/SLHDSA/Concrete/Security.lean
@@ -246,8 +246,9 @@ def shaD1EufCmaReductionCertificate
   openPreCounting := openPreCounting
 
 /-- Concrete SHA2-128-24 EUF-CMA theorem.  Every representation-level condition is proved; the
-only inputs are the three program-level composition inequalities and the named OpenPRE fiber
-counting/coupling statement.  The WOTS coefficient specializes from `w - 2` to exactly `2`. -/
+only inputs are the four explicit composition inequalities (top-level, M-FORS, XMSS, and WOTS)
+and the named OpenPRE fiber-counting/coupling statement.  The WOTS coefficient specializes from
+`w - 2` to exactly `2`. -/
 theorem sha2_128_24_concreteEufCmaAdvantage_le_explicitLowLevelBound
     (adv : EufCmaAdversary shaPrimitives)
     (reds : D1ReductionAdversaries shaPrimitives)

--- a/HashSig/SLHDSA/Concrete/Security.lean
+++ b/HashSig/SLHDSA/Concrete/Security.lean
@@ -11,9 +11,10 @@ public import HashSig.SLHDSA.Security.ReductionBound
 /-!
 # Concrete SHA2-128-24 security side conditions
 
-This module discharges the two representation-level hypotheses used by the generic `d = 1`
-SLH-DSA reduction: full-width WOTS message encoding (proved in `Concrete.Instance`) and separation
-of every reachable target tweak after FIPS 205 `ADRSc` compression.
+This module discharges the two representation-level gates packaged for the future `d = 1`
+SLH-DSA program-reduction constructors: full-width WOTS message encoding (proved in
+`Concrete.Instance`) and separation of every reachable target tweak after FIPS 205 `ADRSc`
+compression.  The current conditional bound records these facts but does not yet consume them.
 
 The latter statement is deliberately restricted to the seven target families.  `ADRSc` is not
 globally injective, but all coordinates retained by those families fit in its 32-bit words.
@@ -279,10 +280,10 @@ theorem sha2_128_24_concreteEufCmaAdvantage_le_explicitLowLevelBound
   rw [hcoef] at h
   exact h
 
-/-- Most-general concrete SHA2-128-24 SUF-CMA theorem currently justified: the complete EUF-CMA
-hash/PRF bound plus the exact residual probability of a new valid signature on an already signed
-message.  Bounding that final term is precisely the extra scheme-specific property needed beyond
-the cited EUF proof. -/
+/-- Most-general concrete SHA2-128-24 SUF-CMA theorem currently justified: the conditional
+EUF-CMA low-level hash/PRF expression plus the exact residual probability of a new valid signature
+on an already signed message.  Bounding that final term is precisely the extra scheme-specific
+property needed beyond the cited EUF proof. -/
 theorem sha2_128_24_concreteStrongEufCmaAdvantage_le_explicitLowLevelBound_add_sameMessage
     (adv : StrongEufCmaAdversary shaPrimitives)
     (reds : D1ReductionAdversaries shaPrimitives)

--- a/HashSig/SLHDSA/Concrete/Security.lean
+++ b/HashSig/SLHDSA/Concrete/Security.lean
@@ -26,6 +26,12 @@ namespace SLHDSA.Concrete
 
 open SLHDSA ENNReal
 
+/-- Proof-only finite enumeration of the 128-bit node space.  This must remain local to the
+noncomputable security layer: exporting the computable `Fintype (Bytes 16)` from
+`Concrete.Instance` makes native executables eagerly allocate all `2^128` nodes at startup. -/
+noncomputable local instance : Fintype shaPrimitives.Y :=
+  inferInstanceAs (Fintype (Bytes 16))
+
 /-- Lift restricted injectivity of the list-valued `ADRSc` encoding to its fixed-width vector. -/
 theorem shaAdrsKey_injective_of_header_eq {a b : Adrs}
     (hlayer : a.layer = b.layer) (htree : a.tree = b.tree) (htype : a.type = b.type)

--- a/HashSig/SLHDSA/Encoding.lean
+++ b/HashSig/SLHDSA/Encoding.lean
@@ -85,4 +85,87 @@ theorem base2b_lt (x : List Byte) (b outLen : ℕ) :
     · subst h; exact Nat.mod_lt _ (by positivity)
     · exact ih _ _ _ d h
 
+/-! ### Injectivity of the full-width two-bit encoding
+
+The supported SHA2-128-24 WOTS instance uses `b = 2` and emits four digits for every input byte.
+The next lemmas prove that this exact full-width specialization loses no information. -/
+
+private theorem base2bFill_of_le_bits (b bits total : ℕ) (xs : List Byte) (h : b ≤ bits) :
+    base2bFill b xs total bits = (xs, total, bits) := by
+  cases xs <;> simp [base2bFill, h]
+
+/-- The four most-significant-first two-bit digits of one byte. -/
+def byteTwoBitDigits (x : Byte) : List ℕ :=
+  [x.toNat >>> 6 % 4, x.toNat >>> 4 % 4, x.toNat >>> 2 % 4, x.toNat % 4]
+
+/-- Four two-bit digits determine the original byte. -/
+theorem byteTwoBitDigits_injective : Function.Injective byteTwoBitDigits := by
+  intro x y h
+  simp only [byteTwoBitDigits, List.cons.injEq] at h
+  rcases h with ⟨h6, h4, h2, h0⟩
+  apply UInt8.toNat_inj.mp
+  rw [Nat.shiftRight_eq_div_pow] at h6 h4 h2
+  norm_num at h6 h4 h2
+  have hx := x.toNat_lt
+  have hy := y.toNat_lt
+  omega
+
+private theorem base2bGo_two_chunk (n total : ℕ) (x : Byte) (xs : List Byte) :
+    base2bGo 2 (4 * (n + 1)) (x :: xs) total 0 =
+      byteTwoBitDigits x ++ base2bGo 2 (4 * n) xs (total * 256 + x.toNat) 0 := by
+  simp only [Nat.mul_add, Nat.mul_one]
+  simp only [base2bGo, base2bFill, nonpos_iff_eq_zero, OfNat.ofNat_ne_zero, ↓reduceIte,
+    zero_add, Nat.reduceLeDiff, base2bFill_of_le_bits, Nat.reduceSub, Nat.reducePow,
+    Std.le_refl, tsub_self, Nat.shiftRight_zero, byteTwoBitDigits, List.cons_append,
+    List.nil_append, List.cons.injEq, and_true]
+  repeat' rw [Nat.shiftRight_eq_div_pow]
+  norm_num
+  have hx := x.toNat_lt
+  constructor
+  · omega
+  constructor
+  · omega
+  constructor
+  · omega
+  · omega
+
+private theorem base2bGo_two_injective_of_length (n total : ℕ) :
+    ∀ xs ys : List Byte, xs.length = n → ys.length = n →
+      base2bGo 2 (4 * n) xs total 0 = base2bGo 2 (4 * n) ys total 0 → xs = ys := by
+  induction n generalizing total with
+  | zero =>
+      intro xs ys hxs hys _
+      rw [List.length_eq_zero_iff] at hxs hys
+      subst xs
+      subst ys
+      rfl
+  | succ n ih =>
+      intro xs ys hxs hys hout
+      cases xs with
+      | nil => simp at hxs
+      | cons x xs =>
+      cases ys with
+      | nil => simp at hys
+      | cons y ys =>
+      rw [base2bGo_two_chunk, base2bGo_two_chunk] at hout
+      have hdigits : byteTwoBitDigits x = byteTwoBitDigits y := by
+        have htake := congrArg (List.take 4) hout
+        simpa [byteTwoBitDigits] using htake
+      have hxy : x = y := byteTwoBitDigits_injective hdigits
+      subst y
+      have hrest :
+          base2bGo 2 (4 * n) xs (total * 256 + x.toNat) 0 =
+            base2bGo 2 (4 * n) ys (total * 256 + x.toNat) 0 := by
+        exact List.append_cancel_left hout
+      have hxs' : xs.length = n := by simpa using hxs
+      have hys' : ys.length = n := by simpa using hys
+      rw [ih (total := total * 256 + x.toNat) xs ys hxs' hys' hrest]
+
+/-- `base2b xs 2 (4 * n)` is injective on byte lists of length `n`: it emits the complete
+two-bit representation of every byte and therefore performs no truncation. -/
+theorem base2b_two_injective_of_length (n : ℕ) :
+    Set.InjOn (fun xs : List Byte => base2b xs 2 (4 * n)) {xs | xs.length = n} := by
+  intro xs hxs ys hys hout
+  exact base2bGo_two_injective_of_length n 0 xs ys hxs hys hout
+
 end SLHDSA

--- a/HashSig/SLHDSA/Hypertree.lean
+++ b/HashSig/SLHDSA/Hypertree.lean
@@ -283,6 +283,16 @@ theorem simulateQ_htSignM_withPublicHash (core : CorePrimitives p)
       htSign (PublicHash.withPublicHash core answer) msg sk pk adrs idxTree idxLeaf := by
   simp [htSign, PublicHash.impl_withPublicHash]
 
+/-- Canonical deterministic-handler parity for `d = 1` hypertree signing. -/
+@[simp]
+theorem simulateQ_htSignM (prims : Primitives p)
+    (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    simulateQ (PublicHash.impl prims)
+        (htSignM prims.core msg sk pk adrs idxTree idxLeaf :
+          OracleComp (publicHashSpec prims.core) (HtSigCore p prims.core)) =
+      htSign prims msg sk pk adrs idxTree idxLeaf := rfl
+
 @[simp]
 theorem simulateQ_htRootM_withPublicHash (core : CorePrimitives p)
     (answer : QueryImpl (publicHashSpec core) Id)
@@ -291,6 +301,15 @@ theorem simulateQ_htRootM_withPublicHash (core : CorePrimitives p)
         (htRootM core sk pk adrs idxTree : OracleComp (publicHashSpec core) core.Y) =
       htRoot (PublicHash.withPublicHash core answer) sk pk adrs idxTree := by
   simp [htRoot, PublicHash.impl_withPublicHash]
+
+/-- Canonical deterministic-handler parity for `d = 1` hypertree root generation. -/
+@[simp]
+theorem simulateQ_htRootM (prims : Primitives p)
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
+    simulateQ (PublicHash.impl prims)
+        (htRootM prims.core sk pk adrs idxTree :
+          OracleComp (publicHashSpec prims.core) prims.Y) =
+      htRoot prims sk pk adrs idxTree := rfl
 
 @[simp]
 theorem simulateQ_htPkFromSigM_withPublicHash (core : CorePrimitives p)
@@ -313,6 +332,16 @@ theorem simulateQ_htVerifyM_withPublicHash (core : CorePrimitives p)
           OracleComp (publicHashSpec core) Bool) =
       htVerify (PublicHash.withPublicHash core answer) msg sig pk adrs idxTree idxLeaf pkRoot := by
   simp [htVerify, PublicHash.impl_withPublicHash]
+
+/-- Canonical deterministic-handler parity for `d = 1` hypertree verification. -/
+@[simp]
+theorem simulateQ_htVerifyM (prims : Primitives p) [DecidableEq prims.Y]
+    (msg : prims.Y) (sig : HtSigCore p prims.core) (pk : prims.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : prims.Y) :
+    simulateQ (PublicHash.impl prims)
+        (htVerifyM prims.core msg sig pk adrs idxTree idxLeaf pkRoot :
+          OracleComp (publicHashSpec prims.core) Bool) =
+      htVerify prims msg sig pk adrs idxTree idxLeaf pkRoot := rfl
 
 /-! ### Correctness -/
 

--- a/HashSig/SLHDSA/RandomOracle.lean
+++ b/HashSig/SLHDSA/RandomOracle.lean
@@ -266,6 +266,17 @@ verification all use the same concrete primitive bundle. -/
     (concreteRuntime prims).evalSPMF oa =
       (liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims)) oa) : SPMF α) := rfl
 
+/-- The concrete public-hash runtime factors a final pure map out of observation.  This is the
+runtime law required by the generic EUF/SUF event-partition lemmas. -/
+theorem concreteRuntime_evalSPMF_bind_pure (prims : Primitives p)
+    {α β : Type} (f : α → β)
+    (oa : OracleComp (unifSpec + publicHashSpec prims.core) α) :
+    (concreteRuntime prims).evalSPMF (oa >>= fun x => pure (f x)) =
+      f <$> (concreteRuntime prims).evalSPMF oa := by
+  simp only [concreteRuntime_evalSPMF, simulateQ_bind, simulateQ_pure,
+    liftM_bind, liftM_pure, map_eq_bind_pure_comp]
+  congr 1
+
 end PublicHash
 
 /-! ### End-to-end shared-ROM completeness -/

--- a/HashSig/SLHDSA/RandomOracle.lean
+++ b/HashSig/SLHDSA/RandomOracle.lean
@@ -284,7 +284,7 @@ verification all use the same concrete primitive bundle. -/
 @[simp] theorem concreteRuntime_evalSPMF (prims : Primitives p)
     {α : Type} (oa : OracleComp (unifSpec + publicHashSpec prims.core) α) :
     (concreteRuntime prims).evalSPMF oa =
-      (liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims)) oa) : SPMF α) := rfl
+      liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims)) oa) := rfl
 
 /-- The concrete public-hash runtime factors a final pure map out of observation.  This is the
 runtime law required by the generic EUF/SUF event-partition lemmas. -/

--- a/HashSig/SLHDSA/RandomOracle.lean
+++ b/HashSig/SLHDSA/RandomOracle.lean
@@ -246,6 +246,26 @@ noncomputable def runtime (core : CorePrimitives p)
     ProbCompRuntime (OracleComp (unifSpec + publicHashSpec core)) :=
   runtimeWithCache core ∅
 
+/-- The shared lazy-public-hash runtime factors a final pure map out of observation. -/
+theorem runtimeWithCache_evalSPMF_bind_pure (core : CorePrimitives p)
+    [DecidableEq core.PkSeed] [DecidableEq core.AdrsKey] [DecidableEq core.Y]
+    [SampleableType core.Y] [SampleableType (Bytes p.m)]
+    (cache : PublicHash.Cache core) {α β : Type} (f : α → β)
+    (oa : OracleComp (unifSpec + publicHashSpec core) α) :
+    (runtimeWithCache core cache).evalSPMF (oa >>= fun x => pure (f x)) =
+      f <$> (runtimeWithCache core cache).evalSPMF oa :=
+  SPMFSemantics.withStateOracle_evalSPMF_bind_pure _ _ oa f
+
+/-- Empty-cache specialization of `runtimeWithCache_evalSPMF_bind_pure`. -/
+theorem runtime_evalSPMF_bind_pure (core : CorePrimitives p)
+    [DecidableEq core.PkSeed] [DecidableEq core.AdrsKey] [DecidableEq core.Y]
+    [SampleableType core.Y] [SampleableType (Bytes p.m)]
+    {α β : Type} (f : α → β)
+    (oa : OracleComp (unifSpec + publicHashSpec core) α) :
+    (runtime core).evalSPMF (oa >>= fun x => pure (f x)) =
+      f <$> (runtime core).evalSPMF oa :=
+  runtimeWithCache_evalSPMF_bind_pure core ∅ f oa
+
 /-- Deterministic public-hash runtime for concrete security games.  Uniform queries retain their
 ordinary probabilistic meaning, while every `Thash`/`H_msg` query is answered by the supplied
 primitive bundle.  Unlike `runtime`, this runtime contains no lazy random-oracle cache. -/

--- a/HashSig/SLHDSA/RandomOracle.lean
+++ b/HashSig/SLHDSA/RandomOracle.lean
@@ -246,6 +246,26 @@ noncomputable def runtime (core : CorePrimitives p)
     ProbCompRuntime (OracleComp (unifSpec + publicHashSpec core)) :=
   runtimeWithCache core ∅
 
+/-- Deterministic public-hash runtime for concrete security games.  Uniform queries retain their
+ordinary probabilistic meaning, while every `Thash`/`H_msg` query is answered by the supplied
+primitive bundle.  Unlike `runtime`, this runtime contains no lazy random-oracle cache. -/
+noncomputable def concreteRuntime (prims : Primitives p) :
+    ProbCompRuntime (OracleComp (unifSpec + publicHashSpec prims.core)) where
+  toSPMFSemantics :=
+    { Sem := ProbComp
+      instMonadSem := inferInstance
+      interpret := simulateQ' (unifFwdAnswerImpl (PublicHash.impl prims))
+      observe := fun mx => liftM mx }
+  toProbCompLift := ProbCompLift.ofMonadLift _
+
+/-- The deterministic runtime observes a whole oracle computation by one simulation with
+`unifFwdAnswerImpl`.  In particular, key generation, adversary calls, signing queries, and final
+verification all use the same concrete primitive bundle. -/
+@[simp] theorem concreteRuntime_evalSPMF (prims : Primitives p)
+    {α : Type} (oa : OracleComp (unifSpec + publicHashSpec prims.core) α) :
+    (concreteRuntime prims).evalSPMF oa =
+      (liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims)) oa) : SPMF α) := rfl
+
 end PublicHash
 
 /-! ### End-to-end shared-ROM completeness -/

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -71,6 +71,22 @@ structure SecretKeyCore (core : CorePrimitives p) where
 abbrev SignatureCore (p : Params) (core : CorePrimitives p) :=
   core.Y × ForsSigCore p core × HtSigCore p core
 
+namespace SignatureCore
+
+variable {core : CorePrimitives p}
+
+/-- A signature has the fixed authentication-path shape prescribed by the parameters: every
+FORS tree contributes exactly `a` sibling nodes and the single `d = 1` XMSS layer contributes
+exactly `h'` sibling nodes. The remaining components are already length-indexed by their types. -/
+def IsWellFormed (sig : SignatureCore p core) : Prop :=
+  (∀ i : Fin p.k, (sig.2.1[i.val]).2.length = p.a) ∧ sig.2.2.2.length = p.hp
+
+instance (sig : SignatureCore p core) : Decidable sig.IsWellFormed := by
+  unfold IsWellFormed
+  infer_instance
+
+end SignatureCore
+
 /-! ### Message-digest split (FIPS 205 §9) -/
 
 /-- Split the message digest into the FORS message `md` and the hypertree leaf index `idxLeaf`
@@ -123,12 +139,24 @@ def slhSignInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
 def slhVerifyInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
     (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) : m Bool := do
-  let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
-  let idxLeaf := (splitDigest p digest).2
-  let md := (splitDigest p digest).1
-  let fAdrs := forsAdrsOf idxLeaf
-  let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
-  htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot
+  if sig.IsWellFormed then
+    let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
+    let idxLeaf := (splitDigest p digest).2
+    let md := (splitDigest p digest).1
+    let fAdrs := forsAdrsOf idxLeaf
+    let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
+    htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot
+  else
+    return false
+
+/-- A malformed signature is rejected before any public-hash query is issued. -/
+@[simp] theorem slhVerifyInternalM_of_not_isWellFormed
+    (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
+    (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core)
+    (hsig : ¬ sig.IsWellFormed) :
+    slhVerifyInternalM core msg sig pk = (pure false : m Bool) := by
+  simp [slhVerifyInternalM, hsig]
 
 /-! ### Pure deterministic interpretations -/
 
@@ -154,6 +182,43 @@ def slhVerifyInternal (prims : Primitives p) [DecidableEq prims.Y] (msg : List B
     (sig : SignatureCore p prims.core) (pk : PublicKeyCore prims.core) : Bool :=
   simulateQ (PublicHash.impl prims)
     (slhVerifyInternalM prims.core msg sig pk : OracleComp (publicHashSpec prims.core) Bool)
+
+/-- Pure internal key generation computes the `d = 1` hypertree root and packages the seeds. -/
+theorem slhKeygenInternal_eq (prims : Primitives p)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) :
+    slhKeygenInternal prims skSeed skPrf pkSeed =
+      let pkRoot := htRoot prims skSeed pkSeed Adrs.zero 0
+      (⟨pkSeed, pkRoot⟩, ⟨skSeed, skPrf, pkSeed, pkRoot⟩) := by
+  simp only [slhKeygenInternal, slhKeygenInternalM, simulateQ_bind,
+    simulateQ_pure, simulateQ_htRootM]
+  rfl
+
+/-- Pure deterministic verification rejects malformed signatures. -/
+@[simp] theorem slhVerifyInternal_of_not_isWellFormed
+    (prims : Primitives p) [DecidableEq prims.Y] (msg : List Byte)
+    (sig : SignatureCore p prims.core) (pk : PublicKeyCore prims.core)
+    (hsig : ¬ sig.IsWellFormed) :
+    slhVerifyInternal prims msg sig pk = false := by
+  rw [slhVerifyInternal]
+  rw [slhVerifyInternalM_of_not_isWellFormed prims.core msg sig pk hsig]
+  rfl
+
+/-- On a well-formed signature, pure verification follows Algorithm 20 after the format guard. -/
+theorem slhVerifyInternal_of_isWellFormed
+    (prims : Primitives p) [DecidableEq prims.Y] (msg : List Byte)
+    (sig : SignatureCore p prims.core) (pk : PublicKeyCore prims.core)
+    (hsig : sig.IsWellFormed) :
+    slhVerifyInternal prims msg sig pk =
+      let digest := prims.Hmsg sig.1 pk.pkSeed pk.pkRoot msg
+      let idxLeaf := (splitDigest p digest).2
+      let md := (splitDigest p digest).1
+      let fAdrs := forsAdrsOf idxLeaf
+      let forsPk := forsPkFromSig prims sig.2.1 md pk.pkSeed fAdrs
+      htVerify prims forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot := by
+  simp only [slhVerifyInternal, slhVerifyInternalM, hsig, if_pos, simulateQ_bind,
+    PublicHash.simulateQ_hmsg, simulateQ_forsPkFromSigM,
+    simulateQ_htVerifyM]
+  rfl
 
 /-! ### Naturality -/
 
@@ -202,8 +267,10 @@ theorem slhVerifyInternalM_natural (core : CorePrimitives p)
     (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) :
     F.toMonadHom (slhVerifyInternalM core msg sig pk) =
       slhVerifyInternalM core msg sig pk := by
-  simp [slhVerifyInternalM, queryHom_hmsg core F,
-    forsPkFromSigM_natural core F, htVerifyM_natural core F]
+  by_cases hsig : sig.IsWellFormed
+  · simp [slhVerifyInternalM, hsig, queryHom_hmsg core F,
+      forsPkFromSigM_natural core F, htVerifyM_natural core F]
+  · simp [slhVerifyInternalM, hsig]
 
 /-! ### Structural query bounds -/
 
@@ -226,6 +293,27 @@ def slhVerifyInternalQueryBound (p : Params) (core : CorePrimitives p)
     (sig : SignatureCore p core) : ℕ :=
   1 + ((∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig.2.1[j.val]).2.length) i) + 1) +
     (p.len * (p.w - 1) + 1 + sig.2.2.2.length)
+
+/-- For a well-formed signature, the verification schedule has a parameter-only bound: one
+`H_msg`, `k` FORS leaf/path recoveries and one `T_k`, then WOTS+/XMSS recovery. -/
+theorem slhVerifyInternalQueryBound_eq_of_isWellFormed
+    (p : Params) (core : CorePrimitives p) (sig : SignatureCore p core)
+    (hsig : sig.IsWellFormed) :
+    slhVerifyInternalQueryBound p core sig =
+      1 + (p.k * (p.a + 1) + 1) + (p.len * (p.w - 1) + 1 + p.hp) := by
+  have hsum :
+      (∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig.2.1[j.val]).2.length) i) =
+        p.k * (p.a + 1) := by
+    calc
+      (∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig.2.1[j.val]).2.length) i) =
+          ∑ _ : Fin p.k, (p.a + 1) := by
+            apply Finset.sum_congr rfl
+            intro i _
+            change 1 + (sig.2.1[i.val]).2.length = p.a + 1
+            rw [hsig.1 i]
+            omega
+      _ = p.k * (p.a + 1) := by simp
+  simp [slhVerifyInternalQueryBound, hsum, hsig.2]
 
 private theorem publicHash_hmsg_isTotalQueryBound_one (core : CorePrimitives p)
     (r : core.Y) (pkSeed : core.PkSeed) (pkRoot : core.Y) (msg : List Byte) :
@@ -322,14 +410,27 @@ theorem slhVerifyInternalM_isTotalQueryBound (core : CorePrimitives p) [Decidabl
     IsTotalQueryBound
       (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool)
       (slhVerifyInternalQueryBound p core sig) := by
-  have hbound := isTotalQueryBound_bind
-    (publicHash_hmsg_isTotalQueryBound_one core sig.1 pk.pkSeed pk.pkRoot msg) fun digest =>
-      isTotalQueryBound_bind
-        (forsPkFromSigM_isTotalQueryBound core sig.2.1 (splitDigest p digest).1 pk.pkSeed
-          (forsAdrsOf (splitDigest p digest).2)) fun forsPk =>
-            htVerifyM_isTotalQueryBound_coarse core forsPk sig.2.2 pk.pkSeed Adrs.zero 0
-              (splitDigest p digest).2 pk.pkRoot
-  simpa [slhVerifyInternalM, slhVerifyInternalQueryBound, Nat.add_assoc] using hbound
+  by_cases hsig : sig.IsWellFormed
+  · have hbound := isTotalQueryBound_bind
+      (publicHash_hmsg_isTotalQueryBound_one core sig.1 pk.pkSeed pk.pkRoot msg) fun digest =>
+        isTotalQueryBound_bind
+          (forsPkFromSigM_isTotalQueryBound core sig.2.1 (splitDigest p digest).1 pk.pkSeed
+            (forsAdrsOf (splitDigest p digest).2)) fun forsPk =>
+              htVerifyM_isTotalQueryBound_coarse core forsPk sig.2.2 pk.pkSeed Adrs.zero 0
+                (splitDigest p digest).2 pk.pkRoot
+    simpa [slhVerifyInternalM, hsig, slhVerifyInternalQueryBound, Nat.add_assoc] using hbound
+  · simp [slhVerifyInternalM, hsig, IsTotalQueryBound]
+
+/-- Well-formed verification inherits the parameter-only structural query budget. -/
+theorem slhVerifyInternalM_isTotalQueryBound_of_isWellFormed
+    (core : CorePrimitives p) [DecidableEq core.Y]
+    (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core)
+    (hsig : sig.IsWellFormed) :
+    IsTotalQueryBound
+      (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool)
+      (1 + (p.k * (p.a + 1) + 1) + (p.len * (p.w - 1) + 1 + p.hp)) := by
+  simpa [slhVerifyInternalQueryBound_eq_of_isWellFormed p core sig hsig] using
+    slhVerifyInternalM_isTotalQueryBound core msg sig pk
 
 /-! ### Deterministic interpretations -/
 
@@ -387,6 +488,47 @@ theorem simulateQ_slhVerifyInternalM (prims : Primitives p) [DecidableEq prims.Y
           OracleComp (publicHashSpec prims.core) Bool) =
       slhVerifyInternal prims msg sig pk := rfl
 
+/-- The pure internal signer follows the same literal FIPS schedule as its oracle program. -/
+theorem slhSignInternal_eq (prims : Primitives p)
+    (msg : List Byte) (sk : SecretKeyCore prims.core) (addrnd : prims.Y) :
+    slhSignInternal prims msg sk addrnd =
+      let R := prims.PRFmsg sk.skPrf addrnd msg
+      let digest := prims.Hmsg R sk.pkSeed sk.pkRoot msg
+      let idxLeaf := (splitDigest p digest).2
+      let md := (splitDigest p digest).1
+      let fAdrs := forsAdrsOf idxLeaf
+      let forsSig := forsSign prims md sk.skSeed sk.pkSeed fAdrs
+      let forsPk := forsPkFromSig prims forsSig md sk.pkSeed fAdrs
+      let htSig := htSign prims forsPk sk.skSeed sk.pkSeed Adrs.zero 0 idxLeaf
+      (R, forsSig, htSig) := by
+  simp only [slhSignInternal, slhSignInternalM, simulateQ_bind, simulateQ_pure,
+    PublicHash.simulateQ_hmsg, simulateQ_forsSignM, simulateQ_forsPkFromSigM,
+    simulateQ_htSignM]
+  rfl
+
+/-- Every honestly generated internal signature has the fixed authentication-path shape
+prescribed by the parameters. -/
+theorem slhSignInternal_isWellFormed (prims : Primitives p)
+    (msg : List Byte) (sk : SecretKeyCore prims.core) (addrnd : prims.Y) :
+    (slhSignInternal prims msg sk addrnd).IsWellFormed := by
+  rw [slhSignInternal_eq]
+  simp [SignatureCore.IsWellFormed,
+    htSign_eq_xmssSign, xmssSign_eq_pair,
+    PerfectMerkleTree.authPath_length]
+
+private theorem slhVerifyInternal_slhSignInternal_aux
+    (prims : Primitives p) [DecidableEq prims.Y]
+    (msg : List Byte) (skSeed : prims.SkSeed) (skPrf : prims.SkPrf)
+    (pkSeed : prims.PkSeed) (addrnd : prims.Y) :
+    slhVerifyInternal prims msg
+        (slhSignInternal prims msg (slhKeygenInternal prims skSeed skPrf pkSeed).2 addrnd)
+        (slhKeygenInternal prims skSeed skPrf pkSeed).1 = true := by
+  have hformat := slhSignInternal_isWellFormed prims msg
+    (slhKeygenInternal prims skSeed skPrf pkSeed).2 addrnd
+  rw [slhVerifyInternal_of_isWellFormed prims msg _ _ hformat]
+  rw [slhSignInternal_eq, slhKeygenInternal_eq]
+  exact htVerify_htSign prims _ skSeed pkSeed Adrs.zero 0 _ (splitDigest_snd_lt p _)
+
 /-- Fixed-answer correctness of the canonical internal programs. Key generation, signing, and
 verification use one total deterministic answer function. This theorem does not install or make
 a claim about random-oracle caching. -/
@@ -399,13 +541,17 @@ theorem simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
       let (pk, sk) ← slhKeygenInternalM core skSeed skPrf pkSeed
       let sig ← slhSignInternalM core msg sk addrnd
       slhVerifyInternalM core msg sig pk) = true := by
-  simp only [slhKeygenInternalM, slhSignInternalM, slhVerifyInternalM,
-    simulateQ_bind, simulateQ_pure,
-    simulateQ_htRootM_withPublicHash, simulateQ_forsSignM_withPublicHash,
-    simulateQ_forsPkFromSigM_withPublicHash, simulateQ_htSignM_withPublicHash,
-    simulateQ_htVerifyM_withPublicHash]
-  exact htVerify_htSign (PublicHash.withPublicHash core answer) _ skSeed pkSeed Adrs.zero 0 _
-    (splitDigest_snd_lt p _)
+  simp only [simulateQ_bind, simulateQ_slhKeygenInternalM_withPublicHash,
+    simulateQ_slhSignInternalM_withPublicHash,
+    simulateQ_slhVerifyInternalM_withPublicHash]
+  change slhVerifyInternal (PublicHash.withPublicHash core answer) msg
+      (slhSignInternal (PublicHash.withPublicHash core answer) msg
+        (slhKeygenInternal (PublicHash.withPublicHash core answer)
+          skSeed skPrf pkSeed).2 addrnd)
+      (slhKeygenInternal (PublicHash.withPublicHash core answer)
+        skSeed skPrf pkSeed).1 = true
+  exact slhVerifyInternal_slhSignInternal_aux (PublicHash.withPublicHash core answer)
+    msg skSeed skPrf pkSeed addrnd
 
 /-- **Deterministic correctness core**: an honestly generated signature verifies, for every
 choice of seeds, randomizer, and deterministic public-hash implementation. -/
@@ -415,14 +561,7 @@ theorem slhVerifyInternal_slhSignInternal (prims : Primitives p) [DecidableEq pr
     slhVerifyInternal prims msg
         (slhSignInternal prims msg (slhKeygenInternal prims skSeed skPrf pkSeed).2 addrnd)
         (slhKeygenInternal prims skSeed skPrf pkSeed).1 = true := by
-  have h := simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
-    prims.core (PublicHash.impl prims) msg skSeed skPrf pkSeed addrnd
-  change ((do
-    let (pk, sk) ← slhKeygenInternal prims skSeed skPrf pkSeed
-    let sig ← slhSignInternal prims msg sk addrnd
-    slhVerifyInternal prims msg sig pk) : Id Bool) = true
-  simpa only [simulateQ_bind, simulateQ_slhKeygenInternalM,
-    simulateQ_slhSignInternalM, simulateQ_slhVerifyInternalM] using h
+  exact slhVerifyInternal_slhSignInternal_aux prims msg skSeed skPrf pkSeed addrnd
 
 /-! ### External-message encoding (FIPS 205 §10) -/
 

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -419,6 +419,21 @@ def d1HmsgIndices (p : Params) (digest : Bytes p.m) : List HmsgIndex :=
   let (md, idxLeaf) := splitDigest p digest
   (List.range p.k).map fun i => (idxLeaf, i, forsIdx p md i)
 
+@[simp] theorem d1HmsgIndices_length (p : Params) (digest : Bytes p.m) :
+    (d1HmsgIndices p digest).length = p.k := by
+  simp [d1HmsgIndices]
+
+/-- Every semantic ITSR coordinate lies in the exact single-tree/FORS ranges used by the target
+ledger. -/
+theorem d1HmsgIndices_mem_bounds (p : Params) (digest : Bytes p.m) (idx : HmsgIndex)
+    (hidx : idx ∈ d1HmsgIndices p digest) :
+    idx.1 < 2 ^ p.hp ∧ idx.2.1 < p.k ∧ idx.2.2 < p.t := by
+  unfold d1HmsgIndices at hidx
+  obtain ⟨i, hi, rfl⟩ := List.mem_map.mp hidx
+  simp only [List.mem_range] at hi
+  dsimp only
+  exact ⟨splitDigest_snd_lt p digest, hi, forsIdx_lt p (splitDigest p digest).1 i⟩
+
 /-- The exact message-compression ITSR problem for SLH-DSA public-key/message inputs.  It uses the
 scheme's external-message encoding and maps a digest to exactly the `k` source-game triples
 `(idxLeaf, FORS-tree index, selected leaf index)`.  A top-level reduction must assume `p.IsD1`. -/

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -5,7 +5,7 @@ Authors: Nicolas Consigny
 -/
 
 module
-public import HashSig.SLHDSA.Scheme
+public import HashSig.SLHDSA.RandomOracle
 public import HashSig.SLHDSA.Security.TargetProfile
 public import VCVio.CryptoFoundations.HardnessAssumptions.CollisionResistance
 public import VCVio.CryptoFoundations.HardnessAssumptions.KeyedHash.ITSR
@@ -193,5 +193,65 @@ def hmsgItsrProblem [SampleableType prims.Y] :
       (Bytes p.m) HmsgIndex where
   khf := hmsgHashFamily prims
   indices := d1HmsgIndices p
+
+/-! ### Concrete EUF-CMA endpoint -/
+
+section ConcreteEUF
+
+variable [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+  [SampleableType prims.PkSeed] [SampleableType prims.Y] [DecidableEq prims.Y]
+
+/-- Adversaries against the canonical explicit-query SLH-DSA scheme. -/
+abbrev EufCmaAdversary :=
+  SignatureAlg.unforgeableAdv
+    (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec prims.core)) prims.core)
+
+/-- The executable EUF-CMA program before applying a public-hash runtime.  Factoring the program
+out makes the concrete endpoint auditable: one deterministic simulation surrounds key generation,
+the adversary, every signing query, and final verification. -/
+noncomputable def eufCmaProgram (adv : EufCmaAdversary prims) :
+    OracleComp (unifSpec + publicHashSpec prims.core) Bool :=
+  letI : DecidableEq (List Byte) := Classical.decEq _
+  letI : DecidableEq (SignatureCore p prims.core) := Classical.decEq _
+  let sigAlg := slhdsaAlg
+    (m := OracleComp (unifSpec + publicHashSpec prims.core)) prims.core
+  do
+    let (pk, sk) ← sigAlg.keygen
+    let impl : QueryImpl
+        ((unifSpec + publicHashSpec prims.core) +
+          (List Byte →ₒ SignatureCore p prims.core))
+        (WriterT (QueryLog (List Byte →ₒ SignatureCore p prims.core))
+          (OracleComp (unifSpec + publicHashSpec prims.core))) :=
+      (HasQuery.toQueryImpl
+          (spec := unifSpec + publicHashSpec prims.core)
+          (m := OracleComp (unifSpec + publicHashSpec prims.core))).liftTarget
+        (WriterT (QueryLog (List Byte →ₒ SignatureCore p prims.core))
+          (OracleComp (unifSpec + publicHashSpec prims.core))) +
+        sigAlg.signingOracle pk sk
+    let simAdv : WriterT (QueryLog (List Byte →ₒ SignatureCore p prims.core))
+        (OracleComp (unifSpec + publicHashSpec prims.core))
+        (List Byte × SignatureCore p prims.core) := simulateQ impl (adv.main pk)
+    let ((msg, sig), log) ← simAdv.run
+    let verified ← sigAlg.verify pk msg sig
+    return !log.wasQueried msg && verified
+
+/-- Concrete-function EUF-CMA experiment for the supplied primitive bundle. -/
+noncomputable def concreteEufCmaExperiment (adv : EufCmaAdversary prims) : SPMF Bool :=
+  SignatureAlg.unforgeableExp (PublicHash.concreteRuntime prims) adv
+
+/-- Concrete-function EUF-CMA advantage. -/
+noncomputable def concreteEufCmaAdvantage (adv : EufCmaAdversary prims) : ℝ≥0∞ :=
+  Pr[= true | concreteEufCmaExperiment prims adv]
+
+/-- Endpoint bridge: the generic `SignatureAlg.unforgeableExp` is exactly one simulation of the
+whole EUF-CMA program with `PublicHash.impl prims`.  Thus subsequent THF reductions start from
+the deterministic SLH-DSA scheme rather than the repository's separate ROM runtime. -/
+theorem concreteEufCmaExperiment_eq_simulate (adv : EufCmaAdversary prims) :
+    concreteEufCmaExperiment prims adv =
+      (liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims))
+        (eufCmaProgram prims adv)) : SPMF Bool) := by
+  rfl
+
+end ConcreteEUF
 
 end SLHDSA

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -6,6 +6,9 @@ Authors: Nicolas Consigny
 
 module
 public import HashSig.SLHDSA.Scheme
+public import HashSig.SLHDSA.Security.TargetProfile
+public import VCVio.CryptoFoundations.HardnessAssumptions.CollisionResistance
+public import VCVio.CryptoFoundations.HardnessAssumptions.KeyedHash.ITSR
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
 public import VCVio.CryptoFoundations.PRF
@@ -21,7 +24,8 @@ generic `TweakableHash` and `PRFScheme` interfaces:
 - `Primitives.thashCollection` packages every fixed input arity of `Thash` under one public seed
   and encoded-address space;
 - `Primitives.msgPrfScheme` exposes the message randomizer `PRF_msg`; and
-- `Primitives.skPrfScheme` exposes the secret-value derivation function `PRF` at a public seed.
+- `Primitives.skPrfScheme` exposes the secret-value derivation function `PRF` jointly over its
+  public seed and address inputs.
 
 These packages identify the primitive families to which an SLH-DSA security reduction applies.
 An aggregate EUF-CMA theorem additionally needs the seed-aware collection games under
@@ -41,7 +45,7 @@ bounds. Primitive packaging alone does not supply those ingredients.
 @[expose] public section
 
 
-open OracleComp OracleSpec ENNReal
+open OracleComp OracleSpec ENNReal CollisionResistance
 
 namespace SLHDSA
 
@@ -102,6 +106,44 @@ def Primitives.thashPreProblem [SampleableType prims.PkSeed] (arity numTargets :
   thColl := prims.thashCollection
   numTargets := numTargets
 
+/-! ### Exact `d = 1` assumption instances -/
+
+/-- Collection SM-DT-TCR problem for every arity-two FORS internal node. -/
+def Primitives.d1ForsTreeTcrProblem [SampleableType prims.PkSeed] :
+    TweakableHash.SM_DT_TCR_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y 2) prims.Y :=
+  prims.thashTcrProblem 2 p.d1TargetProfile.forsTree
+
+/-- Collection SM-DT-TCR problem for every arity-`k` FORS-root compression. -/
+def Primitives.d1ForsRootsTcrProblem [SampleableType prims.PkSeed] :
+    TweakableHash.SM_DT_TCR_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y p.k) prims.Y :=
+  prims.thashTcrProblem p.k p.d1TargetProfile.forsRoots
+
+/-- Collection SM-DT-TCR problem for the WOTS arity-one hash member. -/
+def Primitives.d1WotsChainTcrProblem [SampleableType prims.PkSeed] :
+    TweakableHash.SM_DT_TCR_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y 1) prims.Y :=
+  prims.thashTcrProblem 1 p.d1TargetProfile.wotsTcr
+
+/-- Collection SM-DT-PRE problem for the WOTS arity-one hash member. -/
+def Primitives.d1WotsChainPreProblem [SampleableType prims.PkSeed] :
+    TweakableHash.SM_DT_PRE_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y 1) (Vector prims.Y 1) prims.Y :=
+  prims.thashPreProblem 1 p.d1TargetProfile.wotsPre
+
+/-- Collection SM-DT-TCR problem for every arity-`len` WOTS-public-key compression. -/
+def Primitives.d1WotsPkTcrProblem [SampleableType prims.PkSeed] :
+    TweakableHash.SM_DT_TCR_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y p.len) prims.Y :=
+  prims.thashTcrProblem p.len p.d1TargetProfile.wotsPk
+
+/-- Collection SM-DT-TCR problem for every arity-two node of the single XMSS tree. -/
+def Primitives.d1XmssTreeTcrProblem [SampleableType prims.PkSeed] :
+    TweakableHash.SM_DT_TCR_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y 2) prims.Y :=
+  prims.thashTcrProblem 2 p.d1TargetProfile.xmssTree
+
 /-- The message randomizer `PRF_msg` as a `PRFScheme` keyed by `SK.prf`; `eval` is
 `prims.PRFmsg`. -/
 def msgPrfScheme [SampleableType prims.SkPrf] :
@@ -109,11 +151,47 @@ def msgPrfScheme [SampleableType prims.SkPrf] :
   keygen := $ᵗ prims.SkPrf
   eval := fun skPrf rm => prims.PRFmsg skPrf rm.1 rm.2
 
-/-- The secret-value `PRF` at public seed `pkSeed` as a `PRFScheme` keyed by `SK.seed`; `eval` is
-`prims.PRF pkSeed`. -/
-def skPrfScheme [SampleableType prims.SkSeed] (pkSeed : prims.PkSeed) :
+/-- Secret-value generation as one PRF keyed by `SK.seed`, with the *actual* public seed and
+address both in its domain.  This is the source-faithful SKG family used by the top-level hybrid:
+the reduction may sample `PK.seed` exactly once and query this family at that same seed. -/
+def skPrfScheme [SampleableType prims.SkSeed] :
+    PRFScheme prims.SkSeed (prims.PkSeed × Adrs) prims.Y where
+  keygen := $ᵗ prims.SkSeed
+  eval := fun skSeed pa => prims.PRF pa.1 skSeed pa.2
+
+/-- Fixed-public-seed view retained for component lemmas whose public seed is already in scope. -/
+def skPrfSchemeAtSeed [SampleableType prims.SkSeed] (pkSeed : prims.PkSeed) :
     PRFScheme prims.SkSeed Adrs prims.Y where
   keygen := $ᵗ prims.SkSeed
   eval := fun skSeed adrs => prims.PRF pkSeed skSeed adrs
+
+/-- `H_msg` as the keyed hash family used by the ITSR hop after `PRF_msg` has been replaced by a
+random function.  The sampled message key is the randomizer `R`; the input carries the actual
+`PK.seed`, `PK.root`, and external message jointly, so the hardness problem preserves their
+coupling to key generation instead of silently fixing an unrelated public context.  The hash also
+includes the canonical empty-context encoding used by `slhdsaAlg`. -/
+def hmsgHashFamily [SampleableType prims.Y] :
+    KeyedHashFamily prims.Y (prims.PkSeed × prims.Y × List Byte) (Bytes p.m) where
+  keygen := $ᵗ prims.Y
+  hash := fun R input =>
+    prims.Hmsg R input.1 input.2.1 (emptyContextMessage input.2.2)
+
+/-- One semantic FORS leaf selected by message compression: XMSS leaf, FORS tree, and leaf in
+that tree. -/
+abbrev HmsgIndex := ℕ × ℕ × ℕ
+
+/-- Canonical `d = 1` semantic-index map for the M-FORS ITSR game. -/
+def d1HmsgIndices (p : Params) (digest : Bytes p.m) : List HmsgIndex :=
+  let (md, idxLeaf) := splitDigest p digest
+  (List.range p.k).map fun i => (idxLeaf, i, forsIdx p md i)
+
+/-- The exact message-compression ITSR problem for SLH-DSA public-key/message inputs.  It uses the
+scheme's external-message encoding and maps a digest to exactly the `k` source-game triples
+`(idxLeaf, FORS-tree index, selected leaf index)`.  A top-level reduction must assume `p.IsD1`. -/
+def hmsgItsrProblem [SampleableType prims.Y] :
+    KeyedHash.ITSRProblem prims.Y (prims.PkSeed × prims.Y × List Byte)
+      (Bytes p.m) HmsgIndex where
+  khf := hmsgHashFamily prims
+  indices := d1HmsgIndices p
 
 end SLHDSA

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -530,6 +530,24 @@ noncomputable def concreteStrongEufCmaExperiment (adv : StrongEufCmaAdversary pr
 noncomputable def concreteStrongEufCmaAdvantage (adv : StrongEufCmaAdversary prims) : ℝ≥0∞ :=
   Pr[= true | concreteStrongEufCmaExperiment prims adv]
 
+/-- Concrete probability of producing a new valid signature for a message already submitted to
+the signing oracle.  This is the exact extra term needed to upgrade the EUF-CMA endpoint to
+SUF-CMA; it is not silently identified with any of the EUF hash assumptions. -/
+noncomputable def concreteSameMessageStrongAdvantage
+    (adv : StrongEufCmaAdversary prims) : ℝ≥0∞ :=
+  adv.sameMessageAdvantage (PublicHash.concreteRuntime prims)
+
+/-- The concrete SLH-DSA SUF advantage is bounded by the ordinary EUF advantage of the same
+adversary plus its same-message, new-signature probability.  A full SUF theorem therefore needs
+one additional scheme-specific reduction for the second term. -/
+theorem concreteStrongEufCmaAdvantage_le_euf_add_sameMessage
+    (adv : StrongEufCmaAdversary prims) :
+    concreteStrongEufCmaAdvantage prims adv ≤
+      concreteEufCmaAdvantage prims adv.toUnforgeableAdv +
+        concreteSameMessageStrongAdvantage prims adv := by
+  exact adv.advantage_le_euf_add_sameMessage (PublicHash.concreteRuntime prims)
+    (PublicHash.concreteRuntime_evalSPMF_bind_pure prims)
+
 /-- Endpoint bridge for SUF-CMA: as for EUF-CMA, one deterministic public-hash simulation
 surrounds key generation, all signing queries, and final verification. -/
 theorem concreteStrongEufCmaExperiment_eq_simulate (adv : StrongEufCmaAdversary prims) :

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -478,4 +478,66 @@ theorem concreteEufCmaExperiment_eq_simulate (adv : EufCmaAdversary prims) :
 
 end ConcreteEUF
 
+/-! ### Concrete SUF-CMA endpoint
+
+This endpoint is deliberately separate from the EUF reduction above.  Pair freshness admits a
+new valid signature on an already signed message, so no EUF theorem may be reused without an
+additional same-message binding/re-randomization reduction. -/
+
+section ConcreteSUF
+
+variable [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+  [SampleableType prims.PkSeed] [SampleableType prims.Y] [DecidableEq prims.Y]
+
+/-- Strong-unforgeability adversaries against the canonical explicit-query SLH-DSA scheme. -/
+abbrev StrongEufCmaAdversary :=
+  SignatureAlg.strongUnforgeableAdv
+    (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec prims.core)) prims.core)
+
+/-- The executable SUF-CMA program before applying a public-hash runtime.  The final freshness
+test is on the exact returned `(message, signature)` pair rather than on the message alone. -/
+noncomputable def strongEufCmaProgram (adv : StrongEufCmaAdversary prims) :
+    OracleComp (unifSpec + publicHashSpec prims.core) Bool :=
+  letI : DecidableEq (List Byte) := Classical.decEq _
+  letI : DecidableEq (SignatureCore p prims.core) := Classical.decEq _
+  let sigAlg := slhdsaAlg
+    (m := OracleComp (unifSpec + publicHashSpec prims.core)) prims.core
+  do
+    let (pk, sk) ← sigAlg.keygen
+    let impl : QueryImpl
+        ((unifSpec + publicHashSpec prims.core) +
+          (List Byte →ₒ SignatureCore p prims.core))
+        (WriterT (QueryLog (List Byte →ₒ SignatureCore p prims.core))
+          (OracleComp (unifSpec + publicHashSpec prims.core))) :=
+      (HasQuery.toQueryImpl
+          (spec := unifSpec + publicHashSpec prims.core)
+          (m := OracleComp (unifSpec + publicHashSpec prims.core))).liftTarget
+        (WriterT (QueryLog (List Byte →ₒ SignatureCore p prims.core))
+          (OracleComp (unifSpec + publicHashSpec prims.core))) +
+        sigAlg.signingOracle pk sk
+    let simAdv : WriterT (QueryLog (List Byte →ₒ SignatureCore p prims.core))
+        (OracleComp (unifSpec + publicHashSpec prims.core))
+        (List Byte × SignatureCore p prims.core) := simulateQ impl (adv.main pk)
+    let ((msg, sig), log) ← simAdv.run
+    let verified ← sigAlg.verify pk msg sig
+    return !SignatureAlg.signingLogContains log msg sig && verified
+
+/-- Concrete-function SUF-CMA experiment for the supplied primitive bundle. -/
+noncomputable def concreteStrongEufCmaExperiment (adv : StrongEufCmaAdversary prims) : SPMF Bool :=
+  SignatureAlg.strongUnforgeableExp (PublicHash.concreteRuntime prims) adv
+
+/-- Concrete-function SUF-CMA advantage. -/
+noncomputable def concreteStrongEufCmaAdvantage (adv : StrongEufCmaAdversary prims) : ℝ≥0∞ :=
+  Pr[= true | concreteStrongEufCmaExperiment prims adv]
+
+/-- Endpoint bridge for SUF-CMA: as for EUF-CMA, one deterministic public-hash simulation
+surrounds key generation, all signing queries, and final verification. -/
+theorem concreteStrongEufCmaExperiment_eq_simulate (adv : StrongEufCmaAdversary prims) :
+    concreteStrongEufCmaExperiment prims adv =
+      (liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims))
+        (strongEufCmaProgram prims adv)) : SPMF Bool) := by
+  rfl
+
+end ConcreteSUF
+
 end SLHDSA

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -10,6 +10,7 @@ public import HashSig.SLHDSA.Security.Targets
 public import VCVio.CryptoFoundations.HardnessAssumptions.CollisionResistance
 public import VCVio.CryptoFoundations.HardnessAssumptions.KeyedHash.ITSR
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTOpenPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
 public import VCVio.CryptoFoundations.PRF
@@ -116,6 +117,17 @@ def Primitives.thashDsprProblem [SampleableType prims.PkSeed] (arity numTargets 
   thColl := prims.thashCollection
   numTargets := numTargets
 
+/-- The source-final-validity SM-DT-OpenPRE problem for one fixed-arity `Thash` member and the
+exact hidden-input distribution embedded by its reduction. -/
+def Primitives.thashOpenPreProblem [SampleableType prims.PkSeed] (arity numTargets : ℕ)
+    (inputGen : ProbComp (Vector prims.Y arity)) :
+    TweakableHash.SM_DT_OpenPRE_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y arity) prims.Y where
+  th := prims.thashMember arity
+  inputGen := inputGen
+  thColl := prims.thashCollection
+  numTargets := numTargets
+
 /-! ### Exact `d = 1` assumption instances -/
 
 /-- Source-final-validity SM-DT-DSPR problem for all arity-one FORS secret leaves. -/
@@ -123,6 +135,13 @@ def Primitives.d1ForsLeafDsprProblem [SampleableType prims.PkSeed] :
     TweakableHash.SM_DT_DSPR_Problem ℕ prims.PkSeed prims.AdrsKey
       (Vector prims.Y 1) prims.Y :=
   prims.thashDsprProblem 1 p.d1TargetProfile.forsLeaf
+
+/-- Source-final-validity SM-DT-OpenPRE problem for all arity-one FORS secret leaves. -/
+def Primitives.d1ForsLeafOpenPreProblem [SampleableType prims.PkSeed]
+    [SampleableType prims.Y] :
+    TweakableHash.SM_DT_OpenPRE_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y 1) prims.Y :=
+  prims.thashOpenPreProblem 1 p.d1TargetProfile.forsLeaf ($ᵗ Vector prims.Y 1)
 
 /-- Collection SM-DT-TCR problem for every arity-two FORS internal node. -/
 def Primitives.d1ForsTreeTcrProblem [SampleableType prims.PkSeed] :
@@ -161,6 +180,94 @@ def Primitives.d1XmssTreeTcrProblem [SampleableType prims.PkSeed] :
   prims.thashTcrProblem 2 p.d1TargetProfile.xmssTree
 
 /-! ### Deterministic component-reduction witnesses -/
+
+/-- The message-independent honest FORS roots committed by the arity-`k` compression. -/
+def Primitives.forsHonestRoots (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) : Vector prims.Y p.k :=
+  Vector.ofFn fun i => forsRoot prims sk pk adrs i.val
+
+/-- The roots reconstructed from a candidate FORS signature and digest. -/
+def Primitives.forsRecoveredRoots (sig : ForsSigCore p prims.core) (md : List Byte)
+    (pk : prims.PkSeed) (adrs : Adrs) : Vector prims.Y p.k :=
+  Vector.ofFn fun i =>
+    let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+    PerfectMerkleTree.climb (forsNodeHash prims pk adrs) idx
+      (prims.F pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1) (sig[i.val]).2
+
+/-- A changed reconstructed FORS-root vector that still compresses to the honest FORS public key
+is directly an arity-`k` TCR witness at `forsPkAdrs`. -/
+theorem Primitives.forsRootsBinding_to_tcrWitness [SampleableType prims.PkSeed]
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (sig : ForsSigCore p prims.core) (md : List Byte)
+    (hpk : forsPkFromSig prims sig md pk adrs = forsPkGen prims sk pk adrs)
+    (hne : prims.forsHonestRoots sk pk adrs ≠ prims.forsRecoveredRoots sig md pk adrs) :
+    let target := prims.forsHonestRoots sk pk adrs
+    let collision := prims.forsRecoveredRoots sig md pk adrs
+    target ≠ collision ∧
+      (prims.thashMember p.k).eval pk (prims.adrsToKey (forsPkAdrs adrs)) target =
+        (prims.thashMember p.k).eval pk (prims.adrsToKey (forsPkAdrs adrs)) collision := by
+  dsimp
+  refine ⟨hne, ?_⟩
+  simpa [Primitives.forsHonestRoots, Primitives.forsRecoveredRoots,
+    Primitives.thashMember] using hpk.symm
+
+/-- If one well-formed FORS authentication path reconstructs its honest root from a different
+leaf, it yields an arity-two TCR witness at an exact `FORS_TREE` address. -/
+theorem Primitives.forsTreeBinding_to_tcrWitness [SampleableType prims.PkSeed]
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (sig : ForsSigCore p prims.core) (md : List Byte) (i : Fin p.k)
+    (hlen : (sig[i.val]).2.length = p.a)
+    (hroot : (prims.forsRecoveredRoots sig md pk adrs)[i.val] =
+      (prims.forsHonestRoots sk pk adrs)[i.val])
+    (hne :
+      let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+      forsLeaf prims sk pk adrs idx ≠
+        prims.F pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1) :
+    let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+    ∃ (h : ℕ) (c : prims.Y × prims.Y), 0 < h ∧ h ≤ p.a ∧
+      let target : Vector prims.Y 2 :=
+        #v[PerfectMerkleTree.merkleRoot (forsLeaf prims sk pk adrs)
+              (forsNodeHash prims pk adrs) (h - 1) (2 * (idx / 2 ^ h)),
+          PerfectMerkleTree.merkleRoot (forsLeaf prims sk pk adrs)
+              (forsNodeHash prims pk adrs) (h - 1) (2 * (idx / 2 ^ h) + 1)]
+      let collision : Vector prims.Y 2 := #v[c.1, c.2]
+      target ≠ collision ∧
+        (prims.thashMember 2).eval pk
+            (prims.adrsToKey (forsNodeAdrs adrs h (idx / 2 ^ h))) target =
+          (prims.thashMember 2).eval pk
+            (prims.adrsToKey (forsNodeAdrs adrs h (idx / 2 ^ h))) collision := by
+  dsimp only
+  let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+  have ht : idx / 2 ^ p.a = i.val := by
+    dsimp [idx]
+    rw [Nat.add_comm, Nat.add_mul_div_right _ _ (by positivity : 0 < 2 ^ p.a),
+      Nat.div_eq_of_lt (forsIdx_lt p md i.val), Nat.zero_add]
+  have hroot' :
+      PerfectMerkleTree.climb (forsNodeHash prims pk adrs) idx
+          (prims.F pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1) (sig[i.val]).2 =
+        PerfectMerkleTree.merkleRoot (forsLeaf prims sk pk adrs)
+          (forsNodeHash prims pk adrs) p.a (idx / 2 ^ p.a) := by
+    rw [ht]
+    simpa [idx, Primitives.forsRecoveredRoots, Primitives.forsHonestRoots] using hroot
+  obtain ⟨h, c, hpos, hle, hnePairs, heq⟩ :=
+    PerfectMerkleTree.climb_binding (forsLeaf prims sk pk adrs)
+      (forsNodeHash prims pk adrs) p.a idx
+      (prims.F pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1) (sig[i.val]).2
+      hlen hroot' hne
+  refine ⟨h, c, hpos, hle, ?_⟩
+  dsimp
+  constructor
+  · intro hv
+    apply hnePairs
+    have hl := congrArg Vector.toList hv
+    have hpairs :
+        PerfectMerkleTree.merkleRoot (forsLeaf prims sk pk adrs)
+            (forsNodeHash prims pk adrs) (h - 1) (2 * (idx / 2 ^ h)) = c.1 ∧
+          PerfectMerkleTree.merkleRoot (forsLeaf prims sk pk adrs)
+            (forsNodeHash prims pk adrs) (h - 1) (2 * (idx / 2 ^ h) + 1) = c.2 := by
+      simpa using hl
+    exact Prod.ext hpairs.1 hpairs.2
+  · simpa [Primitives.thashMember] using heq
 
 /-- Translate the existing oriented XMSS binding theorem into the exact message/tweak shape of
 the arity-two TCR game.  The first vector is an honest internal-node target and the second is the

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -143,18 +143,24 @@ def Primitives.thashUdProblem [SampleableType prims.PkSeed] (arity numTargets : 
 
 /-! ### Exact `d = 1` assumption instances -/
 
-/-- Source-final-validity SM-DT-DSPR problem for all arity-one FORS secret leaves. -/
+/-- Source-final-validity stand-alone SM-DT-DSPR problem for all arity-one FORS secret leaves.
+The EasyCrypt OpenPRE-to-DSPR/TCR hop does not need collection access during target commitment;
+keeping this member stand-alone avoids strengthening the final theorem unnecessarily. -/
 def Primitives.d1ForsLeafDsprProblem [SampleableType prims.PkSeed] :
-    TweakableHash.SM_DT_DSPR_Problem ℕ prims.PkSeed prims.AdrsKey
+    TweakableHash.SM_DT_DSPR_Problem Empty prims.PkSeed prims.AdrsKey
       (Vector prims.Y 1) prims.Y :=
-  prims.thashDsprProblem 1 p.d1TargetProfile.forsLeaf
+  TweakableHash.SM_DT_DSPR_Problem.standalone
+    (prims.thashMember 1) p.d1TargetProfile.forsLeaf
 
-/-- Source-final-validity SM-DT-OpenPRE problem for all arity-one FORS secret leaves. -/
+/-- Source-final-validity stand-alone SM-DT-OpenPRE problem for all arity-one FORS secret leaves.
+Its executable DSPR and TCR reductions therefore attack the exact stand-alone properties used by
+the source low-level theorem, while the other SLH-DSA hash terms retain collection access. -/
 def Primitives.d1ForsLeafOpenPreProblem [SampleableType prims.PkSeed]
     [SampleableType prims.Y] :
-    TweakableHash.SM_DT_OpenPRE_Problem ℕ prims.PkSeed prims.AdrsKey
+    TweakableHash.SM_DT_OpenPRE_Problem Empty prims.PkSeed prims.AdrsKey
       (Vector prims.Y 1) prims.Y :=
-  prims.thashOpenPreProblem 1 p.d1TargetProfile.forsLeaf ($ᵗ Vector prims.Y 1)
+  TweakableHash.SM_DT_OpenPRE_Problem.standalone
+    (prims.thashMember 1) ($ᵗ Vector prims.Y 1) p.d1TargetProfile.forsLeaf
 
 /-- The concrete FORS OpenPRE problem satisfies the uniform-input hypothesis required by the
 source OpenPRE-to-DSPR/TCR finite-fiber argument. -/

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -160,6 +160,43 @@ def Primitives.d1XmssTreeTcrProblem [SampleableType prims.PkSeed] :
       (Vector prims.Y 2) prims.Y :=
   prims.thashTcrProblem 2 p.d1TargetProfile.xmssTree
 
+/-! ### Deterministic component-reduction witnesses -/
+
+/-- Translate the existing oriented XMSS binding theorem into the exact message/tweak shape of
+the arity-two TCR game.  The first vector is an honest internal-node target and the second is the
+distinct adversarial child pair recovered from the forged authentication path. -/
+theorem Primitives.xmssBinding_to_tcrWitness [SampleableType prims.PkSeed]
+    (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (idx : ℕ) (hidx : idx < 2 ^ p.hp)
+    (sig : XmssSig p prims) (hlen : sig.2.length = p.hp)
+    (hroot : xmssPkFromSig prims idx sig msg pk adrs = xmssRoot prims sk pk adrs)
+    (hne : xmssLeaf prims sk pk adrs idx
+      ≠ wotsPkFromSig prims sig.1 msg pk (wotsLeafAdrs adrs idx)) :
+    ∃ (h : ℕ) (c : prims.Y × prims.Y), 0 < h ∧ h ≤ p.hp ∧
+      let target : Vector prims.Y 2 :=
+        #v[xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h)),
+          xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h) + 1)]
+      let collision : Vector prims.Y 2 := #v[c.1, c.2]
+      target ≠ collision ∧
+        (prims.thashMember 2).eval pk
+            (prims.adrsToKey (xmssNodeAdrs adrs h (idx / 2 ^ h))) target =
+          (prims.thashMember 2).eval pk
+            (prims.adrsToKey (xmssNodeAdrs adrs h (idx / 2 ^ h))) collision := by
+  obtain ⟨h, c, hpos, hle, hnePairs, heq⟩ :=
+    xmssPkFromSig_binding prims msg sk pk adrs idx hidx sig hlen hroot hne
+  refine ⟨h, c, hpos, hle, ?_⟩
+  dsimp
+  constructor
+  · intro hv
+    apply hnePairs
+    have hl := congrArg Vector.toList hv
+    have hpairs :
+        xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h)) = c.1 ∧
+          xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h) + 1) = c.2 := by
+      simpa using hl
+    exact Prod.ext hpairs.1 hpairs.2
+  · exact heq
+
 /-- The message randomizer `PRF_msg` as a `PRFScheme` keyed by `SK.prf`; `eval` is
 `prims.PRFmsg`. -/
 def msgPrfScheme [SampleableType prims.SkPrf] :

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Quang Dao
 -/
 
 module

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -291,6 +291,154 @@ theorem Primitives.wotsPkBinding_to_tcrWitness [SampleableType prims.PkSeed]
   refine ⟨hne, ?_⟩
   simpa [Primitives.thashMember] using hpk.symm
 
+/-- Two distinct values whose equal-length WOTS chains converge yield an arity-one TCR witness
+at the first convergence step.  This is the deterministic collision-extraction kernel used by
+the source `Game3 → Game4` hop. -/
+theorem Primitives.wotsChainsConverge_to_tcrWitness [SampleableType prims.PkSeed]
+    (pk : prims.PkSeed) (adrs : Adrs) (x y : prims.Y) (i s : ℕ)
+    (hne : x ≠ y) (heq : chain prims pk adrs x i s = chain prims pk adrs y i s) :
+    ∃ k, k < s ∧
+      let target : Vector prims.Y 1 := #v[chain prims pk adrs x i k]
+      let collision : Vector prims.Y 1 := #v[chain prims pk adrs y i k]
+      target ≠ collision ∧
+        (prims.thashMember 1).eval pk
+            (prims.adrsToKey (adrs.setHashAddress (i + k))) target =
+          (prims.thashMember 1).eval pk
+            (prims.adrsToKey (adrs.setHashAddress (i + k))) collision := by
+  induction s with
+  | zero => simp only [chain_zero] at heq; exact (hne heq).elim
+  | succ s ih =>
+      by_cases hprev : chain prims pk adrs x i s = chain prims pk adrs y i s
+      · obtain ⟨k, hk, hw⟩ := ih hprev
+        exact ⟨k, Nat.lt_succ_of_lt hk, hw⟩
+      · refine ⟨s, Nat.lt_succ_self s, ?_⟩
+        dsimp
+        constructor
+        · intro hv
+          apply hprev
+          have hl := congrArg Vector.toList hv
+          simpa using hl
+        · simpa [Primitives.thashMember, chain_succ] using heq
+
+/-- A source-faithful pointwise WOTS chain split.  Suppose a forged chain starts at the smaller
+message digit `b`, an honest signature starts at the larger digit `a`, and both continuations
+reach the same public-key chain end.  Either the forged chain reaches the honest signature value,
+giving the exact PRE equation at hash index `a - 1`, or the two continuations contain an
+arity-one TCR witness.
+
+The `(w - 2) * UD` term does not arise from this pointwise split: in the EasyCrypt proof it pays
+for the preceding `Game2 → Game3` distributional hybrid that makes the value before the honest
+signature step uniform. -/
+theorem Primitives.wotsChainPair_to_tcr_or_preWitness [SampleableType prims.PkSeed]
+    (pk : prims.PkSeed) (adrs : Adrs) (honest forged : prims.Y) (a b : ℕ)
+    (hba : b < a) (ha : a < p.w)
+    (hend : chain prims pk adrs honest a (p.w - 1 - a) =
+      chain prims pk adrs forged b (p.w - 1 - b)) :
+    (∃ k, k < p.w - 1 - a ∧
+      let target : Vector prims.Y 1 := #v[chain prims pk adrs honest a k]
+      let collision : Vector prims.Y 1 :=
+        #v[chain prims pk adrs (chain prims pk adrs forged b (a - b)) a k]
+      target ≠ collision ∧
+        (prims.thashMember 1).eval pk
+            (prims.adrsToKey (adrs.setHashAddress (a + k))) target =
+          (prims.thashMember 1).eval pk
+            (prims.adrsToKey (adrs.setHashAddress (a + k))) collision) ∨
+      (let preimage : Vector prims.Y 1 :=
+        #v[chain prims pk adrs forged b (a - b - 1)]
+       (prims.thashMember 1).eval pk
+          (prims.adrsToKey (adrs.setHashAddress (a - 1))) preimage = honest) := by
+  let meeting := chain prims pk adrs forged b (a - b)
+  by_cases hmeeting : meeting = honest
+  · right
+    dsimp
+    have hstep := chain_succ prims pk adrs forged b (a - b - 1)
+    have hsub : a - b - 1 + 1 = a - b := by omega
+    have haddr : b + (a - b - 1) = a - 1 := by omega
+    rw [hsub, haddr] at hstep
+    simpa [Primitives.thashMember, meeting] using hstep.symm.trans hmeeting
+  · left
+    have hremaining : (a - b) + (p.w - 1 - a) = p.w - 1 - b := by omega
+    have hstart : b + (a - b) = a := by omega
+    have hforged : chain prims pk adrs meeting a (p.w - 1 - a) =
+        chain prims pk adrs forged b (p.w - 1 - b) := by
+      simpa [meeting, hremaining, hstart] using
+        chain_compose prims pk adrs forged b (a - b) (p.w - 1 - a)
+    exact prims.wotsChainsConverge_to_tcrWitness pk adrs honest meeting a
+      (p.w - 1 - a) (fun h => hmeeting h.symm) (hend.trans hforged.symm)
+
+private theorem exists_getD_lt_of_not_forall₂_le {xs ys : List ℕ}
+    (hlen : xs.length = ys.length) (hnot : ¬ WotsChecksum.Forall₂ (· ≤ ·) xs ys) :
+    ∃ i, i < xs.length ∧ ys.getD i 0 < xs.getD i 0 := by
+  induction xs generalizing ys with
+  | nil =>
+      cases ys with
+      | nil => exact (hnot .nil).elim
+      | cons => simp at hlen
+  | cons x xs ih =>
+      cases ys with
+      | nil => simp at hlen
+      | cons y ys =>
+          simp only [List.length_cons, Nat.succ.injEq] at hlen
+          by_cases hxy : x ≤ y
+          · have htail : ¬ WotsChecksum.Forall₂ (· ≤ ·) xs ys :=
+              fun h => hnot (.cons hxy h)
+            obtain ⟨i, hi, hlt⟩ := ih hlen htail
+            exact ⟨i + 1, by simp [hi], by simpa using hlt⟩
+          · exact ⟨0, by simp, by simpa using Nat.lt_of_not_ge hxy⟩
+
+/-- Pointwise classification of an accepted fresh WOTS forgery in the source `Game3` shape.
+The honest and forged signatures finish to the same vector of chain ends.  Checksum
+incomparability selects a chain on which the forged message digit is smaller; that chain then
+yields either the exact TCR witness used by `Game3 → Game4` or the exact PRE equation used to
+bound `Game4`.
+
+As in the source proof, the UD term is deliberately absent from this deterministic theorem: its
+coefficient `(w - 2)` belongs to the preceding distributional hybrid, not to a third kind of
+accepted-forgery witness. -/
+theorem Primitives.wotsAcceptedPair_to_tcr_or_preWitness [SampleableType prims.PkSeed]
+    (pk : prims.PkSeed) (adrs : Adrs) (msg msg' : prims.Y)
+    (sig sig' : WotsSig p prims.core) (hlgw : 0 < p.lgw)
+    (henc : prims.core.WotsMessageEncodingInjective) (hfresh : msg ≠ msg')
+    (haccepted : wotsPkFromSigTops prims sig msg pk adrs =
+      wotsPkFromSigTops prims sig' msg' pk adrs) :
+    ∃ i : Fin p.len,
+      let a := chainStepsCore prims.core msg i.val
+      let b := chainStepsCore prims.core msg' i.val
+      b < a ∧
+        ((∃ k, k < p.w - 1 - a ∧
+          let target : Vector prims.Y 1 :=
+            #v[chain prims pk (wotsChainAdrs adrs i.val) sig[i.val] a k]
+          let collision : Vector prims.Y 1 :=
+            #v[chain prims pk (wotsChainAdrs adrs i.val)
+              (chain prims pk (wotsChainAdrs adrs i.val) sig'[i.val] b (a - b)) a k]
+          target ≠ collision ∧
+            (prims.thashMember 1).eval pk
+                (prims.adrsToKey ((wotsChainAdrs adrs i.val).setHashAddress (a + k))) target =
+              (prims.thashMember 1).eval pk
+                (prims.adrsToKey ((wotsChainAdrs adrs i.val).setHashAddress (a + k)))
+                collision) ∨
+          (let preimage : Vector prims.Y 1 :=
+            #v[chain prims pk (wotsChainAdrs adrs i.val) sig'[i.val] b (a - b - 1)]
+           (prims.thashMember 1).eval pk
+              (prims.adrsToKey ((wotsChainAdrs adrs i.val).setHashAddress (a - 1))) preimage =
+            sig[i.val])) := by
+  have hlen (m : prims.Y) : (chainLengthsCore prims.core m).length = p.len := by
+    simpa [chainLengthsCore, Params.len] using
+      WotsChecksum.wotsFullDigits_length (wotsMsgDigitsCore prims.core m)
+        p.w p.len1 p.len2 (wotsMsgDigitsCore_length prims.core m)
+  have hnot := (chainLengthsCore_incomparable prims.core msg msg' hlgw henc hfresh).1
+  obtain ⟨i, hi, hlt⟩ := exists_getD_lt_of_not_forall₂_le
+    ((hlen msg).trans (hlen msg').symm) hnot
+  let fi : Fin p.len := ⟨i, by simpa [hlen msg] using hi⟩
+  have hend := congrArg (fun v : Vector prims.Y p.len => v[fi.val]) haccepted
+  simp only [wotsPkFromSigTops_eq_ofFn, Vector.getElem_ofFn] at hend
+  refine ⟨fi, ?_, ?_⟩
+  · simpa [fi, chainStepsCore] using hlt
+  · exact prims.wotsChainPair_to_tcr_or_preWitness pk (wotsChainAdrs adrs fi.val)
+      sig[fi.val] sig'[fi.val] (chainStepsCore prims.core msg fi.val)
+      (chainStepsCore prims.core msg' fi.val) (by simpa [fi, chainStepsCore] using hlt)
+      (chainStepsCore_lt prims.core msg fi.val) hend
+
 /-- The message-independent honest FORS roots committed by the arity-`k` compression. -/
 def Primitives.forsHonestRoots (sk : prims.SkSeed) (pk : prims.PkSeed)
     (adrs : Adrs) : Vector prims.Y p.k :=

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -206,6 +206,46 @@ def Primitives.d1XmssTreeTcrProblem [SampleableType prims.PkSeed] :
       (Vector prims.Y 2) prims.Y :=
   prims.thashTcrProblem 2 p.d1TargetProfile.xmssTree
 
+/-! The following projection lemmas pin every concrete game to the corresponding entry of the
+audited target ledger.  They are intentionally separate canaries: changing one problem's cap
+cannot silently alter the fully expanded security statement. -/
+
+@[simp] theorem Primitives.d1ForsLeafDsprProblem_numTargets
+    [SampleableType prims.PkSeed] :
+    prims.d1ForsLeafDsprProblem.numTargets = p.d1TargetProfile.forsLeaf := rfl
+
+@[simp] theorem Primitives.d1ForsLeafOpenPreProblem_numTargets
+    [SampleableType prims.PkSeed] [SampleableType prims.Y] :
+    prims.d1ForsLeafOpenPreProblem.numTargets = p.d1TargetProfile.forsLeaf := rfl
+
+@[simp] theorem Primitives.d1ForsTreeTcrProblem_numTargets
+    [SampleableType prims.PkSeed] :
+    prims.d1ForsTreeTcrProblem.numTargets = p.d1TargetProfile.forsTree := rfl
+
+@[simp] theorem Primitives.d1ForsRootsTcrProblem_numTargets
+    [SampleableType prims.PkSeed] :
+    prims.d1ForsRootsTcrProblem.numTargets = p.d1TargetProfile.forsRoots := rfl
+
+@[simp] theorem Primitives.d1WotsChainUdProblem_numTargets
+    [SampleableType prims.PkSeed] [SampleableType prims.Y] :
+    prims.d1WotsChainUdProblem.numTargets = p.d1TargetProfile.wotsUd := rfl
+
+@[simp] theorem Primitives.d1WotsChainTcrProblem_numTargets
+    [SampleableType prims.PkSeed] :
+    prims.d1WotsChainTcrProblem.numTargets = p.d1TargetProfile.wotsTcr := rfl
+
+@[simp] theorem Primitives.d1WotsChainPreProblem_numTargets
+    [SampleableType prims.PkSeed] :
+    prims.d1WotsChainPreProblem.numTargets = p.d1TargetProfile.wotsPre := rfl
+
+@[simp] theorem Primitives.d1WotsPkTcrProblem_numTargets
+    [SampleableType prims.PkSeed] :
+    prims.d1WotsPkTcrProblem.numTargets = p.d1TargetProfile.wotsPk := rfl
+
+@[simp] theorem Primitives.d1XmssTreeTcrProblem_numTargets
+    [SampleableType prims.PkSeed] :
+    prims.d1XmssTreeTcrProblem.numTargets = p.d1TargetProfile.xmssTree := rfl
+
 /-! ### Deterministic component-reduction witnesses -/
 
 /-- A distinct secret value that hashes to an honest FORS leaf is an arity-one TCR witness at the

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -389,6 +389,16 @@ def skPrfSchemeAtSeed [SampleableType prims.SkSeed] (pkSeed : prims.PkSeed) :
   keygen := $ᵗ prims.SkSeed
   eval := fun skSeed adrs => prims.PRF pkSeed skSeed adrs
 
+@[simp] theorem msgPrfScheme_uniformKey [SampleableType prims.SkPrf] :
+    PRFScheme.UniformKey (msgPrfScheme prims) := rfl
+
+@[simp] theorem skPrfScheme_uniformKey [SampleableType prims.SkSeed] :
+    PRFScheme.UniformKey (skPrfScheme prims) := rfl
+
+@[simp] theorem skPrfSchemeAtSeed_uniformKey [SampleableType prims.SkSeed]
+    (pkSeed : prims.PkSeed) :
+    PRFScheme.UniformKey (skPrfSchemeAtSeed prims pkSeed) := rfl
+
 /-- `H_msg` as the keyed hash family used by the ITSR hop after `PRF_msg` has been replaced by a
 random function.  The sampled message key is the randomizer `R`; the input carries the actual
 `PK.seed`, `PK.root`, and external message jointly, so the hardness problem preserves their

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -525,7 +525,7 @@ noncomputable def eufCmaProgram (adv : EufCmaAdversary prims) :
     return !log.wasQueried msg && verified
 
 /-- Concrete-function EUF-CMA experiment for the supplied primitive bundle. -/
-noncomputable def concreteEufCmaExperiment (adv : EufCmaAdversary prims) : SPMF Bool :=
+noncomputable def concreteEufCmaExperiment (adv : EufCmaAdversary prims) :=
   SignatureAlg.unforgeableExp (PublicHash.concreteRuntime prims) adv
 
 /-- Concrete-function EUF-CMA advantage. -/
@@ -537,8 +537,8 @@ whole EUF-CMA program with `PublicHash.impl prims`.  Thus subsequent THF reducti
 the deterministic SLH-DSA scheme rather than the repository's separate ROM runtime. -/
 theorem concreteEufCmaExperiment_eq_simulate (adv : EufCmaAdversary prims) :
     concreteEufCmaExperiment prims adv =
-      (liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims))
-        (eufCmaProgram prims adv)) : SPMF Bool) := by
+      liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims))
+        (eufCmaProgram prims adv)) := by
   rfl
 
 end ConcreteEUF
@@ -588,7 +588,7 @@ noncomputable def strongEufCmaProgram (adv : StrongEufCmaAdversary prims) :
     return !SignatureAlg.signingLogContains log msg sig && verified
 
 /-- Concrete-function SUF-CMA experiment for the supplied primitive bundle. -/
-noncomputable def concreteStrongEufCmaExperiment (adv : StrongEufCmaAdversary prims) : SPMF Bool :=
+noncomputable def concreteStrongEufCmaExperiment (adv : StrongEufCmaAdversary prims) :=
   SignatureAlg.strongUnforgeableExp (PublicHash.concreteRuntime prims) adv
 
 /-- Concrete-function SUF-CMA advantage. -/
@@ -617,8 +617,8 @@ theorem concreteStrongEufCmaAdvantage_le_euf_add_sameMessage
 surrounds key generation, all signing queries, and final verification. -/
 theorem concreteStrongEufCmaExperiment_eq_simulate (adv : StrongEufCmaAdversary prims) :
     concreteStrongEufCmaExperiment prims adv =
-      (liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims))
-        (strongEufCmaProgram prims adv)) : SPMF Bool) := by
+      liftM (simulateQ (unifFwdAnswerImpl (PublicHash.impl prims))
+        (strongEufCmaProgram prims adv)) := by
   rfl
 
 end ConcreteSUF

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -181,6 +181,43 @@ def Primitives.d1XmssTreeTcrProblem [SampleableType prims.PkSeed] :
 
 /-! ### Deterministic component-reduction witnesses -/
 
+/-- A distinct secret value that hashes to an honest FORS leaf is an arity-one TCR witness at the
+exact leaf address. -/
+theorem Primitives.forsLeafCollision_to_tcrWitness [SampleableType prims.PkSeed]
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (idx : ℕ) (candidate : prims.Y)
+    (hne : forsSkGenCore prims.core sk pk adrs idx ≠ candidate)
+    (heq : forsLeaf prims sk pk adrs idx =
+      prims.F pk (forsNodeAdrs adrs 0 idx) candidate) :
+    let target : Vector prims.Y 1 := #v[forsSkGenCore prims.core sk pk adrs idx]
+    let collision : Vector prims.Y 1 := #v[candidate]
+    target ≠ collision ∧
+      (prims.thashMember 1).eval pk (prims.adrsToKey (forsNodeAdrs adrs 0 idx)) target =
+        (prims.thashMember 1).eval pk
+          (prims.adrsToKey (forsNodeAdrs adrs 0 idx)) collision := by
+  dsimp
+  constructor
+  · intro hv
+    apply hne
+    have hl := congrArg Vector.toList hv
+    simpa using hl
+  · simpa [Primitives.thashMember] using heq
+
+/-- A changed vector of WOTS chain ends that still compresses to the honest WOTS public key is an
+arity-`len` TCR witness at the exact `WOTS_PK` address. -/
+theorem Primitives.wotsPkBinding_to_tcrWitness [SampleableType prims.PkSeed]
+    (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (sig : WotsSig p prims.core)
+    (hpk : wotsPkFromSig prims sig msg pk adrs = wotsPkGen prims sk pk adrs)
+    (hne : wotsPkGenTops prims sk pk adrs ≠ wotsPkFromSigTops prims sig msg pk adrs) :
+    let target := wotsPkGenTops prims sk pk adrs
+    let collision := wotsPkFromSigTops prims sig msg pk adrs
+    target ≠ collision ∧
+      (prims.thashMember p.len).eval pk (prims.adrsToKey (wotsPkAdrs adrs)) target =
+        (prims.thashMember p.len).eval pk (prims.adrsToKey (wotsPkAdrs adrs)) collision := by
+  dsimp
+  refine ⟨hne, ?_⟩
+  simpa [Primitives.thashMember] using hpk.symm
+
 /-- The message-independent honest FORS roots committed by the arity-`k` compression. -/
 def Primitives.forsHonestRoots (sk : prims.SkSeed) (pk : prims.PkSeed)
     (adrs : Adrs) : Vector prims.Y p.k :=

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -414,6 +414,55 @@ theorem Primitives.xmssBinding_to_tcrWitness [SampleableType prims.PkSeed]
     exact Prod.ext hpairs.1 hpairs.2
   · exact heq
 
+/-- Exhaustive deterministic split underlying the fixed-length XMSS reduction.  A candidate XMSS
+signature that reconstructs the honest root either reaches exactly the honest vector of WOTS
+chain ends (the residual WOTS event), changes that vector while preserving its `WOTS_PK`
+compression (an arity-`len` TCR witness), or changes the reconstructed XMSS leaf (an arity-two
+tree TCR witness).
+
+This is the pointwise event inclusion needed before the probability-level `xmss` field of
+`D1CompositionCertificate` can be discharged; the remaining work is to construct the two
+source-game adversaries and transport this split through their transcripts. -/
+theorem Primitives.xmssRootForgery_to_wotsConsistency_or_tcrWitness
+    [SampleableType prims.PkSeed]
+    (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (idx : ℕ) (hidx : idx < 2 ^ p.hp)
+    (sig : XmssSig p prims) (hlen : sig.2.length = p.hp)
+    (hroot : xmssPkFromSig prims idx sig msg pk adrs = xmssRoot prims sk pk adrs) :
+    wotsPkGenTops prims sk pk (wotsLeafAdrs adrs idx) =
+        wotsPkFromSigTops prims sig.1 msg pk (wotsLeafAdrs adrs idx) ∨
+      (let target := wotsPkGenTops prims sk pk (wotsLeafAdrs adrs idx)
+       let collision := wotsPkFromSigTops prims sig.1 msg pk (wotsLeafAdrs adrs idx)
+       target ≠ collision ∧
+         (prims.thashMember p.len).eval pk
+              (prims.adrsToKey (wotsPkAdrs (wotsLeafAdrs adrs idx))) target =
+           (prims.thashMember p.len).eval pk
+              (prims.adrsToKey (wotsPkAdrs (wotsLeafAdrs adrs idx))) collision) ∨
+      (∃ (h : ℕ) (c : prims.Y × prims.Y), 0 < h ∧ h ≤ p.hp ∧
+        let target : Vector prims.Y 2 :=
+          #v[xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h)),
+            xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h) + 1)]
+        let collision : Vector prims.Y 2 := #v[c.1, c.2]
+        target ≠ collision ∧
+          (prims.thashMember 2).eval pk
+              (prims.adrsToKey (xmssNodeAdrs adrs h (idx / 2 ^ h))) target =
+            (prims.thashMember 2).eval pk
+              (prims.adrsToKey (xmssNodeAdrs adrs h (idx / 2 ^ h))) collision) := by
+  let leafAdrs := wotsLeafAdrs adrs idx
+  by_cases hleaf : xmssLeaf prims sk pk adrs idx =
+      wotsPkFromSig prims sig.1 msg pk leafAdrs
+  · have hpk : wotsPkFromSig prims sig.1 msg pk leafAdrs =
+        wotsPkGen prims sk pk leafAdrs := by
+      rw [← xmssLeaf_eq_wotsPkGen]
+      exact hleaf.symm
+    by_cases htops : wotsPkGenTops prims sk pk leafAdrs =
+        wotsPkFromSigTops prims sig.1 msg pk leafAdrs
+    · exact Or.inl htops
+    · exact Or.inr <| Or.inl <|
+        prims.wotsPkBinding_to_tcrWitness msg sk pk leafAdrs sig.1 hpk htops
+  · exact Or.inr <| Or.inr <|
+      prims.xmssBinding_to_tcrWitness msg sk pk adrs idx hidx sig hlen hroot hleaf
+
 /-- The message randomizer `PRF_msg` as a `PRFScheme` keyed by `SK.prf`; `eval` is
 `prims.PRFmsg`. -/
 def msgPrfScheme [SampleableType prims.SkPrf] :

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -13,6 +13,7 @@ public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTOpenPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTUDC
 public import VCVio.CryptoFoundations.PRF
 
 /-!
@@ -128,6 +129,18 @@ def Primitives.thashOpenPreProblem [SampleableType prims.PkSeed] (arity numTarge
   thColl := prims.thashCollection
   numTargets := numTargets
 
+/-- The source-final-validity SM-DT-UD-C problem for one fixed-arity `Thash` member, with explicit
+real-input and ideal-output distributions and the whole collection available during selection. -/
+def Primitives.thashUdProblem [SampleableType prims.PkSeed] (arity numTargets : ℕ)
+    (inputGen : ProbComp (Vector prims.Y arity)) (outputGen : ProbComp prims.Y) :
+    TweakableHash.SM_DT_UD_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y arity) prims.Y where
+  th := prims.thashMember arity
+  inputGen := inputGen
+  outputGen := outputGen
+  thColl := prims.thashCollection
+  numTargets := numTargets
+
 /-! ### Exact `d = 1` assumption instances -/
 
 /-- Source-final-validity SM-DT-DSPR problem for all arity-one FORS secret leaves. -/
@@ -160,6 +173,13 @@ def Primitives.d1WotsChainTcrProblem [SampleableType prims.PkSeed] :
     TweakableHash.SM_DT_TCR_Problem ℕ prims.PkSeed prims.AdrsKey
       (Vector prims.Y 1) prims.Y :=
   prims.thashTcrProblem 1 p.d1TargetProfile.wotsTcr
+
+/-- Collection SM-DT-UD-C problem for WOTS chain starts.  The real world hashes a uniformly
+sampled arity-one chain value; the ideal world samples a uniform digest directly. -/
+def Primitives.d1WotsChainUdProblem [SampleableType prims.PkSeed] [SampleableType prims.Y] :
+    TweakableHash.SM_DT_UD_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y 1) prims.Y :=
+  prims.thashUdProblem 1 p.d1TargetProfile.wotsUd ($ᵗ Vector prims.Y 1) ($ᵗ prims.Y)
 
 /-- Collection SM-DT-PRE problem for the WOTS arity-one hash member. -/
 def Primitives.d1WotsChainPreProblem [SampleableType prims.PkSeed] :

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -757,6 +757,43 @@ section ConcreteSUF
 variable [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
   [SampleableType prims.PkSeed] [SampleableType prims.Y] [DecidableEq prims.Y]
 
+/-- Whether the signing trace contains the same signed `(R, M)` pair as the candidate signature.
+For SLH-DSA, `SignatureCore.1` is exactly the message randomizer `R`; the remaining signature
+components are intentionally ignored by this predicate. -/
+abbrev signingLogContainsRMessage
+    (log : QueryLog (List Byte →ₒ SignatureCore p prims.core))
+    (msg : List Byte) (sig : SignatureCore p prims.core) : Bool :=
+  SignatureAlg.signingLogContainsMessageKey (fun σ => σ.1) log msg sig
+
+omit [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+  [SampleableType prims.PkSeed] [SampleableType prims.Y] in
+/-- Exact pointwise refinement of the generic same-message SUF residual.  A new signature on an
+old message either uses a fresh `(R, M)` pair, which remains eligible for the source ITSR hop, or
+reuses `(R, M)` while changing another signature component, which is the genuine binding
+residual. -/
+theorem sameMessageResidual_RMessage_partition
+    (log : QueryLog (List Byte →ₒ SignatureCore p prims.core))
+    (msg : List Byte) (sig : SignatureCore p prims.core) :
+    (log.wasQueried msg && !SignatureAlg.signingLogContains log msg sig) =
+      ((log.wasQueried msg && !signingLogContainsRMessage prims log msg sig) ||
+        (signingLogContainsRMessage prims log msg sig &&
+          !SignatureAlg.signingLogContains log msg sig)) := by
+  exact SignatureAlg.sameMessageResidual_messageKey_partition (fun σ => σ.1) log msg sig
+
+omit [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+  [SampleableType prims.PkSeed] [SampleableType prims.Y] in
+/-- Reusing `(R, M)` in the exact-pair-fresh branch produces a previously returned signature with
+the same randomizer and message but different remaining components. -/
+theorem reusedRMessageFreshSignature_witness
+    (log : QueryLog (List Byte →ₒ SignatureCore p prims.core))
+    (msg : List Byte) (sig : SignatureCore p prims.core)
+    (hreused : signingLogContainsRMessage prims log msg sig = true)
+    (hfresh : SignatureAlg.signingLogContains log msg sig = false) :
+    ∃ sig' : SignatureCore p prims.core,
+      ⟨msg, sig'⟩ ∈ log ∧ sig'.1 = sig.1 ∧ sig' ≠ sig := by
+  exact SignatureAlg.signingLogContainsMessageKey_distinct_witness
+    (fun σ => σ.1) log msg sig hreused hfresh
+
 /-- Strong-unforgeability adversaries against the canonical explicit-query SLH-DSA scheme. -/
 abbrev StrongEufCmaAdversary :=
   SignatureAlg.strongUnforgeableAdv

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -6,9 +6,10 @@ Authors: Nicolas Consigny
 
 module
 public import HashSig.SLHDSA.RandomOracle
-public import HashSig.SLHDSA.Security.TargetProfile
+public import HashSig.SLHDSA.Security.Targets
 public import VCVio.CryptoFoundations.HardnessAssumptions.CollisionResistance
 public import VCVio.CryptoFoundations.HardnessAssumptions.KeyedHash.ITSR
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
 public import VCVio.CryptoFoundations.PRF
@@ -106,7 +107,22 @@ def Primitives.thashPreProblem [SampleableType prims.PkSeed] (arity numTargets :
   thColl := prims.thashCollection
   numTargets := numTargets
 
+/-- The source-final-validity SM-DT-DSPR problem for one fixed-arity `Thash` member, with the
+whole collection available during target selection. -/
+def Primitives.thashDsprProblem [SampleableType prims.PkSeed] (arity numTargets : ℕ) :
+    TweakableHash.SM_DT_DSPR_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y arity) prims.Y where
+  th := prims.thashMember arity
+  thColl := prims.thashCollection
+  numTargets := numTargets
+
 /-! ### Exact `d = 1` assumption instances -/
+
+/-- Source-final-validity SM-DT-DSPR problem for all arity-one FORS secret leaves. -/
+def Primitives.d1ForsLeafDsprProblem [SampleableType prims.PkSeed] :
+    TweakableHash.SM_DT_DSPR_Problem ℕ prims.PkSeed prims.AdrsKey
+      (Vector prims.Y 1) prims.Y :=
+  prims.thashDsprProblem 1 p.d1TargetProfile.forsLeaf
 
 /-- Collection SM-DT-TCR problem for every arity-two FORS internal node. -/
 def Primitives.d1ForsTreeTcrProblem [SampleableType prims.PkSeed] :

--- a/HashSig/SLHDSA/Security.lean
+++ b/HashSig/SLHDSA/Security.lean
@@ -156,6 +156,13 @@ def Primitives.d1ForsLeafOpenPreProblem [SampleableType prims.PkSeed]
       (Vector prims.Y 1) prims.Y :=
   prims.thashOpenPreProblem 1 p.d1TargetProfile.forsLeaf ($ᵗ Vector prims.Y 1)
 
+/-- The concrete FORS OpenPRE problem satisfies the uniform-input hypothesis required by the
+source OpenPRE-to-DSPR/TCR finite-fiber argument. -/
+@[simp] theorem Primitives.d1ForsLeafOpenPreProblem_hasUniformInputs
+    [SampleableType prims.PkSeed] [SampleableType prims.Y] :
+    prims.d1ForsLeafOpenPreProblem.HasUniformInputs := by
+  rfl
+
 /-- Collection SM-DT-TCR problem for every arity-two FORS internal node. -/
 def Primitives.d1ForsTreeTcrProblem [SampleableType prims.PkSeed] :
     TweakableHash.SM_DT_TCR_Problem ℕ prims.PkSeed prims.AdrsKey

--- a/HashSig/SLHDSA/Security/ReductionBound.lean
+++ b/HashSig/SLHDSA/Security/ReductionBound.lean
@@ -322,6 +322,30 @@ theorem concreteStrongEufCmaAdvantage_le_explicitLowLevelBound_add_sameMessage
     (add_le_add (concreteEufCmaAdvantage_le_explicitLowLevelBound prims
       adv.toUnforgeableAdv reds cert) le_rfl)
 
+/-- Quantitative SUF-CMA theorem under an explicit bound `ε` for the sole additional
+same-message/new-signature property. -/
+theorem concreteStrongEufCmaAdvantage_le_explicitLowLevelBound_add
+    (adv : StrongEufCmaAdversary prims) (reds : D1ReductionAdversaries prims)
+    (cert : D1EufCmaReductionCertificate prims adv.toUnforgeableAdv reds)
+    (ε : ℝ≥0∞) (hsame : concreteSameMessageStrongAdvantage prims adv ≤ ε) :
+    concreteStrongEufCmaAdvantage prims adv ≤
+      (PRFScheme.prfAdvantageENNReal (skPrfScheme prims) reds.skPrf +
+        PRFScheme.prfAdvantageENNReal (msgPrfScheme prims) reds.msgPrf) +
+      (KeyedHash.ITSRAdvantage reds.hmsgItsr +
+        (TweakableHash.SM_DT_DSPR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toDSPR reds.forsOpenPre) +
+          3 * TweakableHash.SM_DT_TCR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toTCR reds.forsOpenPre)) +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsTreeTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsRootsTcr) +
+      (((p.w - 2) * TweakableHash.SM_DT_UD_Advantage reds.wotsUd +
+          TweakableHash.SM_DT_TCR_Advantage reds.wotsTcr +
+          TweakableHash.SM_DT_PRE_Advantage reds.wotsPre) +
+        TweakableHash.SM_DT_TCR_Advantage reds.wotsPkTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.xmssTreeTcr) + ε :=
+  (concreteStrongEufCmaAdvantage_le_explicitLowLevelBound_add_sameMessage
+    prims adv reds cert).trans (add_le_add le_rfl hsame)
+
 end ConcreteAdversaries
 
 end SLHDSA

--- a/HashSig/SLHDSA/Security/ReductionBound.lean
+++ b/HashSig/SLHDSA/Security/ReductionBound.lean
@@ -1,0 +1,252 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Security
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.OpenPREFromTCRDSPR
+
+/-!
+# Quantitative `d = 1` SLH-DSA reduction accounting
+
+This module fixes the exact additive shape of the source-faithful security theorem while keeping
+the unfinished program transformations visible as separately reviewable obligations.  It follows
+the EasyCrypt decomposition in `SPHINCS_PLUS.ec`:
+
+* the top-level hop pays the secret-key-generation PRF, message-randomization PRF, M-FORS, and
+  fixed-length XMSS losses;
+* M-FORS pays ITSR, OpenPRE for `F`, TCR for FORS `H`, and TCR for FORS-root compression;
+* fixed-length XMSS pays WOTS, WOTS-public-key-compression TCR, and XMSS-tree TCR; and
+* WOTS pays `(w - 2) * UD + TCR + PRE` for `F`.
+
+The low-level source theorem replaces the OpenPRE term by the concrete reduction adversaries from
+`OpenPREFromTCRDSPR.lean`, yielding `DSPR + 3 * TCR`.  No theorem in this file assumes the desired
+headline inequality as a single opaque premise: `D1CompositionCertificate` exposes the three
+component reductions independently, and `d1_eufCma_le_lowLevelBound` additionally requires only
+the named OpenPRE counting step.
+
+References:
+
+* Barbosa, Dupressoir, Hülsing, Meijers, and Strub, "A Tight Security Proof for SPHINCS+,
+  Formally Verified", Theorem 1 and the accompanying EasyCrypt artifact.
+* Barbosa et al., "Machine-Checked Security for XMSS as in RFC 8391 and SPHINCS+",
+  Security Theorems 1 and 2.
+-/
+
+@[expose] public section
+
+open ENNReal
+
+namespace SLHDSA
+
+/-- Numerical advantages delivered by the high-level component reductions.  A later packaging
+layer instantiates each field with the advantage of a concrete reduction adversary against the
+corresponding game. -/
+structure D1HighLevelTerms where
+  skPrf : ℝ≥0∞
+  msgPrf : ℝ≥0∞
+  hmsgItsr : ℝ≥0∞
+  forsOpenPre : ℝ≥0∞
+  forsTreeTcr : ℝ≥0∞
+  forsRootsTcr : ℝ≥0∞
+  wotsUd : ℝ≥0∞
+  wotsTcr : ℝ≥0∞
+  wotsPre : ℝ≥0∞
+  wotsPkTcr : ℝ≥0∞
+  xmssTreeTcr : ℝ≥0∞
+
+namespace D1HighLevelTerms
+
+/-- The two PRF hybrid losses at the top level. -/
+noncomputable def prfBound (terms : D1HighLevelTerms) : ℝ≥0∞ := terms.skPrf + terms.msgPrf
+
+/-- The exact M-FORS high-level bound. -/
+noncomputable def mForsBound (terms : D1HighLevelTerms) : ℝ≥0∞ :=
+  terms.hmsgItsr + terms.forsOpenPre + terms.forsTreeTcr + terms.forsRootsTcr
+
+/-- The exact WOTS-TW bound, including the source factor `w - 2` on UD. -/
+noncomputable def wotsBound (p : Params) (terms : D1HighLevelTerms) : ℝ≥0∞ :=
+  (p.w - 2) * terms.wotsUd + terms.wotsTcr + terms.wotsPre
+
+/-- The fixed-length XMSS contribution after expanding its WOTS component. -/
+noncomputable def xmssBound (p : Params) (terms : D1HighLevelTerms) : ℝ≥0∞ :=
+  terms.wotsBound p + terms.wotsPkTcr + terms.xmssTreeTcr
+
+/-- The exact high-level `d = 1` EUF-CMA right-hand side. -/
+noncomputable def bound (p : Params) (terms : D1HighLevelTerms) : ℝ≥0∞ :=
+  terms.prfBound + terms.mForsBound + terms.xmssBound p
+
+end D1HighLevelTerms
+
+/-- Independently auditable outputs of the three program-level component reductions.  These are
+the obligations still produced by translating the EasyCrypt game hops to the repository's exact
+SLH-DSA program; separating them prevents an aggregate theorem from laundering that work into one
+field with the headline conclusion itself. -/
+structure D1CompositionCertificate (p : Params) (eufAdv : ℝ≥0∞)
+    (terms : D1HighLevelTerms) where
+  /-- Loss of the M-FORS component before expanding it into hash assumptions. -/
+  mForsLoss : ℝ≥0∞
+  /-- Loss of the non-PRF fixed-length XMSS component. -/
+  xmssLoss : ℝ≥0∞
+  /-- Loss of its WOTS subcomponent. -/
+  wotsLoss : ℝ≥0∞
+  /-- Top-level PRF/M-FORS/XMSS case split. -/
+  topLevel : eufAdv ≤ terms.prfBound + mForsLoss + xmssLoss
+  /-- M-FORS reduction to ITSR, OpenPRE, FORS-tree TCR, and root-compression TCR. -/
+  mFors : mForsLoss ≤ terms.mForsBound
+  /-- Fixed-length XMSS reduction to WOTS and its two binding collisions. -/
+  xmss : xmssLoss ≤ wotsLoss + terms.wotsPkTcr + terms.xmssTreeTcr
+  /-- WOTS reduction to `(w - 2) * UD + TCR + PRE`. -/
+  wots : wotsLoss ≤ terms.wotsBound p
+
+/-- Composition of the three explicit component obligations gives the exact high-level theorem. -/
+theorem D1CompositionCertificate.eufAdv_le_bound {p : Params} {eufAdv : ℝ≥0∞}
+    {terms : D1HighLevelTerms} (cert : D1CompositionCertificate p eufAdv terms) :
+    eufAdv ≤ terms.bound p := by
+  calc
+    eufAdv ≤ terms.prfBound + cert.mForsLoss + cert.xmssLoss := cert.topLevel
+    _ ≤ terms.prfBound + terms.mForsBound + cert.xmssLoss :=
+      add_le_add (add_le_add le_rfl cert.mFors) le_rfl
+    _ ≤ terms.prfBound + terms.mForsBound +
+        (cert.wotsLoss + terms.wotsPkTcr + terms.xmssTreeTcr) :=
+      add_le_add le_rfl cert.xmss
+    _ ≤ terms.bound p := by
+      unfold D1HighLevelTerms.bound D1HighLevelTerms.xmssBound
+      exact add_le_add le_rfl (add_le_add (add_le_add cert.wots le_rfl) le_rfl)
+
+/-- Low-level terms introduced by the concrete OpenPRE-to-DSPR/TCR reductions. -/
+structure D1OpenPreReductionTerms where
+  forsLeafDspr : ℝ≥0∞
+  forsLeafTcr : ℝ≥0∞
+
+namespace D1OpenPreReductionTerms
+
+/-- The exact low-level replacement for OpenPRE. -/
+noncomputable def bound (terms : D1OpenPreReductionTerms) : ℝ≥0∞ :=
+  terms.forsLeafDspr + 3 * terms.forsLeafTcr
+
+end D1OpenPreReductionTerms
+
+/-- Replace only the M-FORS OpenPRE term, leaving every other source term unchanged. -/
+noncomputable def D1HighLevelTerms.withOpenPreReduction (terms : D1HighLevelTerms)
+    (openPre : D1OpenPreReductionTerms) : D1HighLevelTerms :=
+  { terms with forsOpenPre := openPre.bound }
+
+/-- Monotonicity of the full accounting theorem in its OpenPRE term. -/
+theorem D1HighLevelTerms.bound_le_withOpenPreReduction {p : Params}
+    {terms : D1HighLevelTerms} {openPre : D1OpenPreReductionTerms}
+    (hopen : terms.forsOpenPre ≤ openPre.bound) :
+    terms.bound p ≤ (terms.withOpenPreReduction openPre).bound p := by
+  unfold D1HighLevelTerms.bound D1HighLevelTerms.prfBound D1HighLevelTerms.mForsBound
+    D1HighLevelTerms.xmssBound D1HighLevelTerms.wotsBound withOpenPreReduction
+  dsimp only
+  gcongr
+
+/-- Source-faithful low-level conclusion: the concrete EUF-CMA advantage is bounded by the exact
+PRF/ITSR/UD/TCR/PRE/DSPR expression once the three program-level component reductions and the
+OpenPRE counting lemma have been supplied. -/
+theorem d1_eufCma_le_lowLevelBound {p : Params} {eufAdv : ℝ≥0∞}
+    {terms : D1HighLevelTerms} {openPre : D1OpenPreReductionTerms}
+    (cert : D1CompositionCertificate p eufAdv terms)
+    (hopen : terms.forsOpenPre ≤ openPre.bound) :
+    eufAdv ≤ (terms.withOpenPreReduction openPre).bound p :=
+  cert.eufAdv_le_bound.trans (terms.bound_le_withOpenPreReduction hopen)
+
+/-! ## Concrete adversary packaging
+
+The declarations below connect every numerical field above to an adversary against a specific
+game instance with the exact target cap from `Params.d1TargetProfile`. -/
+
+section ConcreteAdversaries
+
+variable {p : Params} (prims : Primitives p)
+  [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+  [SampleableType prims.PkSeed] [SampleableType prims.Y] [Inhabited prims.Y]
+
+/-- One concrete reduction adversary for every term of the high-level source theorem. -/
+structure D1ReductionAdversaries where
+  skPrf : PRFScheme.PRFAdversary (prims.PkSeed × Adrs) prims.Y
+  msgPrf : PRFScheme.PRFAdversary (prims.Y × List Byte) prims.Y
+  hmsgItsr : KeyedHash.ITSRAdversary (hmsgItsrProblem prims)
+  forsOpenPre :
+    TweakableHash.SM_DT_OpenPRE_Adversary (prims.d1ForsLeafOpenPreProblem)
+  forsTreeTcr : TweakableHash.SM_DT_TCR_Adversary (prims.d1ForsTreeTcrProblem)
+  forsRootsTcr : TweakableHash.SM_DT_TCR_Adversary (prims.d1ForsRootsTcrProblem)
+  wotsUd : TweakableHash.SM_DT_UD_Adversary (prims.d1WotsChainUdProblem)
+  wotsTcr : TweakableHash.SM_DT_TCR_Adversary (prims.d1WotsChainTcrProblem)
+  wotsPre : TweakableHash.SM_DT_PRE_Adversary (prims.d1WotsChainPreProblem)
+  wotsPkTcr : TweakableHash.SM_DT_TCR_Adversary (prims.d1WotsPkTcrProblem)
+  xmssTreeTcr : TweakableHash.SM_DT_TCR_Adversary (prims.d1XmssTreeTcrProblem)
+
+namespace D1ReductionAdversaries
+
+variable [DecidableEq prims.PkSeed] [DecidableEq prims.AdrsKey] [DecidableEq prims.Y]
+
+/-- Evaluate the exact high-level RHS on the concrete reduction adversaries. -/
+noncomputable def advantages (reds : D1ReductionAdversaries prims) : D1HighLevelTerms where
+  skPrf := PRFScheme.prfAdvantageENNReal (skPrfScheme prims) reds.skPrf
+  msgPrf := PRFScheme.prfAdvantageENNReal (msgPrfScheme prims) reds.msgPrf
+  hmsgItsr := KeyedHash.ITSRAdvantage reds.hmsgItsr
+  forsOpenPre := TweakableHash.SM_DT_OpenPRE_Advantage reds.forsOpenPre
+  forsTreeTcr := TweakableHash.SM_DT_TCR_Advantage reds.forsTreeTcr
+  forsRootsTcr := TweakableHash.SM_DT_TCR_Advantage reds.forsRootsTcr
+  wotsUd := TweakableHash.SM_DT_UD_Advantage reds.wotsUd
+  wotsTcr := TweakableHash.SM_DT_TCR_Advantage reds.wotsTcr
+  wotsPre := TweakableHash.SM_DT_PRE_Advantage reds.wotsPre
+  wotsPkTcr := TweakableHash.SM_DT_TCR_Advantage reds.wotsPkTcr
+  xmssTreeTcr := TweakableHash.SM_DT_TCR_Advantage reds.xmssTreeTcr
+
+variable [Fintype prims.Y]
+
+/-- Evaluate the low-level OpenPRE replacement on the executable DSPR and TCR reductions. -/
+noncomputable def openPreReductionTerms (reds : D1ReductionAdversaries prims) :
+    D1OpenPreReductionTerms where
+  forsLeafDspr := TweakableHash.SM_DT_DSPR_Advantage
+    (TweakableHash.SM_DT_OpenPRE_toDSPR reds.forsOpenPre)
+  forsLeafTcr := TweakableHash.SM_DT_TCR_Advantage
+    (TweakableHash.SM_DT_OpenPRE_toTCR reds.forsOpenPre)
+
+/-- The one mathematical lemma still needed to justify replacing OpenPRE by the executable
+DSPR/TCR reductions: the finite-preimage counting step from the source proof. -/
+def OpenPreCountingStatement (reds : D1ReductionAdversaries prims) : Prop :=
+  TweakableHash.SM_DT_OpenPRE_Advantage reds.forsOpenPre ≤
+    TweakableHash.SM_DT_OpenPRE_TCR_DSPR_Bound reds.forsOpenPre
+
+omit [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+  [DecidableEq prims.PkSeed] in
+@[simp] theorem openPreReductionTerms_bound (reds : D1ReductionAdversaries prims) :
+    reds.openPreReductionTerms.bound =
+      TweakableHash.SM_DT_OpenPRE_TCR_DSPR_Bound reds.forsOpenPre := by
+  rfl
+
+end D1ReductionAdversaries
+
+variable [DecidableEq prims.PkSeed] [DecidableEq prims.AdrsKey] [DecidableEq prims.Y]
+  [Fintype prims.Y]
+
+/-- Reviewable boundary for the complete `d = 1` EUF-CMA reduction.  Besides the concrete game
+adversaries, it requires the parameter profile, reachable encoded-target separation, the three
+program-level component reductions, and the isolated OpenPRE counting lemma. -/
+structure D1EufCmaReductionCertificate (adv : EufCmaAdversary prims)
+    (reds : D1ReductionAdversaries prims) where
+  profile : p.D1SecurityProfile
+  targetSeparation : Primitives.D1TargetTweakSeparation prims
+  composition : D1CompositionCertificate p (concreteEufCmaAdvantage prims adv) reds.advantages
+  openPreCounting : reds.OpenPreCountingStatement
+
+/-- The concrete, quantitative, low-level EUF-CMA statement obtained from a checked reduction
+certificate.  Every term is the advantage of the concrete adversary stored in `reds`; the FORS
+leaf DSPR/TCR adversaries are executable transformations of its OpenPRE adversary. -/
+theorem concreteEufCmaAdvantage_le_lowLevelBound (adv : EufCmaAdversary prims)
+    (reds : D1ReductionAdversaries prims) (cert : D1EufCmaReductionCertificate prims adv reds) :
+    concreteEufCmaAdvantage prims adv ≤
+      (reds.advantages.withOpenPreReduction reds.openPreReductionTerms).bound p := by
+  apply d1_eufCma_le_lowLevelBound cert.composition
+  simpa [D1ReductionAdversaries.OpenPreCountingStatement,
+    D1ReductionAdversaries.advantages] using cert.openPreCounting
+
+end ConcreteAdversaries
+
+end SLHDSA

--- a/HashSig/SLHDSA/Security/ReductionBound.lean
+++ b/HashSig/SLHDSA/Security/ReductionBound.lean
@@ -208,11 +208,12 @@ noncomputable def openPreReductionTerms (reds : D1ReductionAdversaries prims) :
   forsLeafTcr := TweakableHash.SM_DT_TCR_Advantage
     (TweakableHash.SM_DT_OpenPRE_toTCR reds.forsOpenPre)
 
-/-- The one mathematical lemma still needed to justify replacing OpenPRE by the executable
-DSPR/TCR reductions: the finite-preimage counting step from the source proof. -/
-def OpenPreCountingStatement (reds : D1ReductionAdversaries prims) : Prop :=
-  TweakableHash.SM_DT_OpenPRE_Advantage reds.forsOpenPre ≤
-    TweakableHash.SM_DT_OpenPRE_TCR_DSPR_Bound reds.forsOpenPre
+/-- The three concrete probability-decomposition/coupling obligations needed to justify replacing
+OpenPRE by the executable DSPR/TCR reductions.  This is strictly finer than assuming the target
+inequality: it exposes singleton and larger-fiber masses, the exact DSPR truncated subtraction,
+and the collision-weighted TCR lower bound. -/
+abbrev OpenPreCountingStatement (reds : D1ReductionAdversaries prims) :=
+  TweakableHash.SM_DT_OpenPRE_CountingLemma reds.forsOpenPre
 
 omit [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
   [DecidableEq prims.PkSeed] in
@@ -244,8 +245,8 @@ theorem concreteEufCmaAdvantage_le_lowLevelBound (adv : EufCmaAdversary prims)
     concreteEufCmaAdvantage prims adv ≤
       (reds.advantages.withOpenPreReduction reds.openPreReductionTerms).bound p := by
   apply d1_eufCma_le_lowLevelBound cert.composition
-  simpa [D1ReductionAdversaries.OpenPreCountingStatement,
-    D1ReductionAdversaries.advantages] using cert.openPreCounting
+  simpa [D1ReductionAdversaries.advantages] using
+    TweakableHash.SM_DT_OpenPRE_le_TCR_DSPR reds.forsOpenPre cert.openPreCounting
 
 end ConcreteAdversaries
 

--- a/HashSig/SLHDSA/Security/ReductionBound.lean
+++ b/HashSig/SLHDSA/Security/ReductionBound.lean
@@ -233,6 +233,8 @@ program-level component reductions, and the isolated OpenPRE counting lemma. -/
 structure D1EufCmaReductionCertificate (adv : EufCmaAdversary prims)
     (reds : D1ReductionAdversaries prims) where
   profile : p.D1SecurityProfile
+  /-- Distinct XMSS/WOTS node messages have distinct full-width message-digit encodings. -/
+  wotsEncodingInjective : prims.core.WotsMessageEncodingInjective
   targetSeparation : Primitives.D1TargetTweakSeparation prims
   composition : D1CompositionCertificate p (concreteEufCmaAdvantage prims adv) reds.advantages
   openPreCounting : reds.OpenPreCountingStatement

--- a/HashSig/SLHDSA/Security/ReductionBound.lean
+++ b/HashSig/SLHDSA/Security/ReductionBound.lean
@@ -80,7 +80,8 @@ noncomputable def bound (p : Params) (terms : D1HighLevelTerms) : ℝ≥0∞ :=
 
 end D1HighLevelTerms
 
-/-- Independently auditable outputs of the three program-level component reductions.  These are
+/-- Independently auditable outputs of the top-level split and three program-level component
+reductions.  These are
 the obligations still produced by translating the EasyCrypt game hops to the repository's exact
 SLH-DSA program; separating them prevents an aggregate theorem from laundering that work into one
 field with the headline conclusion itself. -/
@@ -101,7 +102,8 @@ structure D1CompositionCertificate (p : Params) (eufAdv : ℝ≥0∞)
   /-- WOTS reduction to `(w - 2) * UD + TCR + PRE`. -/
   wots : wotsLoss ≤ terms.wotsBound p
 
-/-- Composition of the three explicit component obligations gives the exact high-level theorem. -/
+/-- Composition of the top-level split and three component obligations gives the exact high-level
+theorem. -/
 theorem D1CompositionCertificate.eufAdv_le_bound {p : Params} {eufAdv : ℝ≥0∞}
     {terms : D1HighLevelTerms} (cert : D1CompositionCertificate p eufAdv terms) :
     eufAdv ≤ terms.bound p := by
@@ -145,8 +147,8 @@ theorem D1HighLevelTerms.bound_le_withOpenPreReduction {p : Params}
   gcongr
 
 /-- Source-faithful low-level conclusion: the concrete EUF-CMA advantage is bounded by the exact
-PRF/ITSR/UD/TCR/PRE/DSPR expression once the three program-level component reductions and the
-OpenPRE counting lemma have been supplied. -/
+PRF/ITSR/UD/TCR/PRE/DSPR expression once the top-level split, three program-level component
+reductions, and the OpenPRE counting lemma have been supplied. -/
 theorem d1_eufCma_le_lowLevelBound {p : Params} {eufAdv : ℝ≥0∞}
     {terms : D1HighLevelTerms} {openPre : D1OpenPreReductionTerms}
     (cert : D1CompositionCertificate p eufAdv terms)

--- a/HashSig/SLHDSA/Security/ReductionBound.lean
+++ b/HashSig/SLHDSA/Security/ReductionBound.lean
@@ -248,6 +248,34 @@ theorem concreteEufCmaAdvantage_le_lowLevelBound (adv : EufCmaAdversary prims)
   simpa [D1ReductionAdversaries.advantages] using
     TweakableHash.SM_DT_OpenPRE_le_TCR_DSPR reds.forsOpenPre cert.openPreCounting
 
+/-- Fully expanded version of the concrete low-level theorem.  This is the reviewer-facing
+statement of the exact primitive properties and coefficients: two PRFs, H_msg ITSR, FORS-leaf
+DSPR and TCR (with coefficient three), FORS tree/root TCR, WOTS UD/TCR/PRE (with coefficient
+`w - 2` on UD), WOTS-public-key TCR, and XMSS-tree TCR. -/
+theorem concreteEufCmaAdvantage_le_explicitLowLevelBound (adv : EufCmaAdversary prims)
+    (reds : D1ReductionAdversaries prims) (cert : D1EufCmaReductionCertificate prims adv reds) :
+    concreteEufCmaAdvantage prims adv ≤
+      (PRFScheme.prfAdvantageENNReal (skPrfScheme prims) reds.skPrf +
+        PRFScheme.prfAdvantageENNReal (msgPrfScheme prims) reds.msgPrf) +
+      (KeyedHash.ITSRAdvantage reds.hmsgItsr +
+        (TweakableHash.SM_DT_DSPR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toDSPR reds.forsOpenPre) +
+          3 * TweakableHash.SM_DT_TCR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toTCR reds.forsOpenPre)) +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsTreeTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsRootsTcr) +
+      (((p.w - 2) * TweakableHash.SM_DT_UD_Advantage reds.wotsUd +
+          TweakableHash.SM_DT_TCR_Advantage reds.wotsTcr +
+          TweakableHash.SM_DT_PRE_Advantage reds.wotsPre) +
+        TweakableHash.SM_DT_TCR_Advantage reds.wotsPkTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.xmssTreeTcr) := by
+  simpa [D1ReductionAdversaries.advantages, D1ReductionAdversaries.openPreReductionTerms,
+    D1HighLevelTerms.withOpenPreReduction, D1HighLevelTerms.bound,
+    D1HighLevelTerms.prfBound, D1HighLevelTerms.mForsBound,
+    D1HighLevelTerms.xmssBound, D1HighLevelTerms.wotsBound,
+    D1OpenPreReductionTerms.bound] using
+    concreteEufCmaAdvantage_le_lowLevelBound prims adv reds cert
+
 /-! ## Strong-unforgeability corollary -/
 
 /-- Most-general concrete SUF-CMA statement currently justified by the source reduction.  The
@@ -264,6 +292,32 @@ theorem concreteStrongEufCmaAdvantage_le_lowLevelBound_add_sameMessage
         concreteSameMessageStrongAdvantage prims adv := by
   exact (concreteStrongEufCmaAdvantage_le_euf_add_sameMessage prims adv).trans
     (add_le_add (concreteEufCmaAdvantage_le_lowLevelBound prims
+      adv.toUnforgeableAdv reds cert) le_rfl)
+
+/-- Fully expanded SUF-CMA corollary.  It has exactly the EUF hash/PRF terms above plus the
+scheme-specific same-message/new-signature probability, making the additional property needed
+for a genuine SUF theorem syntactically visible. -/
+theorem concreteStrongEufCmaAdvantage_le_explicitLowLevelBound_add_sameMessage
+    (adv : StrongEufCmaAdversary prims) (reds : D1ReductionAdversaries prims)
+    (cert : D1EufCmaReductionCertificate prims adv.toUnforgeableAdv reds) :
+    concreteStrongEufCmaAdvantage prims adv ≤
+      (PRFScheme.prfAdvantageENNReal (skPrfScheme prims) reds.skPrf +
+        PRFScheme.prfAdvantageENNReal (msgPrfScheme prims) reds.msgPrf) +
+      (KeyedHash.ITSRAdvantage reds.hmsgItsr +
+        (TweakableHash.SM_DT_DSPR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toDSPR reds.forsOpenPre) +
+          3 * TweakableHash.SM_DT_TCR_Advantage
+            (TweakableHash.SM_DT_OpenPRE_toTCR reds.forsOpenPre)) +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsTreeTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.forsRootsTcr) +
+      (((p.w - 2) * TweakableHash.SM_DT_UD_Advantage reds.wotsUd +
+          TweakableHash.SM_DT_TCR_Advantage reds.wotsTcr +
+          TweakableHash.SM_DT_PRE_Advantage reds.wotsPre) +
+        TweakableHash.SM_DT_TCR_Advantage reds.wotsPkTcr +
+        TweakableHash.SM_DT_TCR_Advantage reds.xmssTreeTcr) +
+      concreteSameMessageStrongAdvantage prims adv := by
+  exact (concreteStrongEufCmaAdvantage_le_euf_add_sameMessage prims adv).trans
+    (add_le_add (concreteEufCmaAdvantage_le_explicitLowLevelBound prims
       adv.toUnforgeableAdv reds cert) le_rfl)
 
 end ConcreteAdversaries

--- a/HashSig/SLHDSA/Security/ReductionBound.lean
+++ b/HashSig/SLHDSA/Security/ReductionBound.lean
@@ -248,6 +248,24 @@ theorem concreteEufCmaAdvantage_le_lowLevelBound (adv : EufCmaAdversary prims)
   simpa [D1ReductionAdversaries.advantages] using
     TweakableHash.SM_DT_OpenPRE_le_TCR_DSPR reds.forsOpenPre cert.openPreCounting
 
+/-! ## Strong-unforgeability corollary -/
+
+/-- Most-general concrete SUF-CMA statement currently justified by the source reduction.  The
+ordinary forgery branch receives the complete low-level EUF bound above; the only additional term
+is the exact probability of returning a new valid signature for an already queried message.
+
+This theorem deliberately does not call that residual term negligible.  Closing it requires a
+new SLH-DSA-specific binding reduction beyond the cited EUF-CMA proof. -/
+theorem concreteStrongEufCmaAdvantage_le_lowLevelBound_add_sameMessage
+    (adv : StrongEufCmaAdversary prims) (reds : D1ReductionAdversaries prims)
+    (cert : D1EufCmaReductionCertificate prims adv.toUnforgeableAdv reds) :
+    concreteStrongEufCmaAdvantage prims adv ≤
+      (reds.advantages.withOpenPreReduction reds.openPreReductionTerms).bound p +
+        concreteSameMessageStrongAdvantage prims adv := by
+  exact (concreteStrongEufCmaAdvantage_le_euf_add_sameMessage prims adv).trans
+    (add_le_add (concreteEufCmaAdvantage_le_lowLevelBound prims
+      adv.toUnforgeableAdv reds cert) le_rfl)
+
 end ConcreteAdversaries
 
 end SLHDSA

--- a/HashSig/SLHDSA/Security/ReductionBound.lean
+++ b/HashSig/SLHDSA/Security/ReductionBound.lean
@@ -229,9 +229,12 @@ end D1ReductionAdversaries
 variable [DecidableEq prims.PkSeed] [DecidableEq prims.AdrsKey] [DecidableEq prims.Y]
   [Fintype prims.Y]
 
-/-- Reviewable boundary for the complete `d = 1` EUF-CMA reduction.  Besides the concrete game
-adversaries, it requires the parameter profile, reachable encoded-target separation, the three
-program-level component reductions, and the isolated OpenPRE counting lemma. -/
+/-- Reviewable boundary for the still-conditional `d = 1` EUF-CMA reduction.  Besides the concrete
+game adversaries, it records the parameter profile, reachable encoded-target separation, the four
+program-level composition inequalities, and the isolated OpenPRE counting lemma.
+
+The representation fields are gates for the future constructors of those program reductions;
+the algebraic theorem below currently projects only `composition` and `openPreCounting`. -/
 structure D1EufCmaReductionCertificate (adv : EufCmaAdversary prims)
     (reds : D1ReductionAdversaries prims) where
   profile : p.D1SecurityProfile
@@ -241,9 +244,9 @@ structure D1EufCmaReductionCertificate (adv : EufCmaAdversary prims)
   composition : D1CompositionCertificate p (concreteEufCmaAdvantage prims adv) reds.advantages
   openPreCounting : reds.OpenPreCountingStatement
 
-/-- The concrete, quantitative, low-level EUF-CMA statement obtained from a checked reduction
-certificate.  Every term is the advantage of the concrete adversary stored in `reds`; the FORS
-leaf DSPR/TCR adversaries are executable transformations of its OpenPRE adversary. -/
+/-- The concrete, quantitative, low-level EUF-CMA statement obtained from the explicit conditional
+certificate above.  Every term is the advantage of the concrete adversary stored in `reds`; the
+FORS-leaf DSPR/TCR adversaries are executable transformations of its OpenPRE adversary. -/
 theorem concreteEufCmaAdvantage_le_lowLevelBound (adv : EufCmaAdversary prims)
     (reds : D1ReductionAdversaries prims) (cert : D1EufCmaReductionCertificate prims adv reds) :
     concreteEufCmaAdvantage prims adv ≤
@@ -282,9 +285,10 @@ theorem concreteEufCmaAdvantage_le_explicitLowLevelBound (adv : EufCmaAdversary 
 
 /-! ## Strong-unforgeability corollary -/
 
-/-- Most-general concrete SUF-CMA statement currently justified by the source reduction.  The
-ordinary forgery branch receives the complete low-level EUF bound above; the only additional term
-is the exact probability of returning a new valid signature for an already queried message.
+/-- Most-general concrete SUF-CMA statement currently justified by the conditional source
+accounting.  The ordinary forgery branch receives the conditional low-level EUF expression above;
+the only additional term is the exact probability of returning a new valid signature for an
+already queried message.
 
 This theorem deliberately does not call that residual term negligible.  Closing it requires a
 new SLH-DSA-specific binding reduction beyond the cited EUF-CMA proof. -/

--- a/HashSig/SLHDSA/Security/TargetProfile.lean
+++ b/HashSig/SLHDSA/Security/TargetProfile.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Params
+
+/-!
+# Exact target counts for the current `d = 1` SLH-DSA construction
+
+The concrete reductions for SPHINCS+/SLH-DSA do not assume an unquantified “multi-target”
+property.  Each reduction commits to every relevant target in the stateless key structure before
+the public seed is revealed.  This file records those target caps for the repository's current
+single-XMSS-tree (`d = 1`) construction.
+
+Write `L = 2^h'` for the number of XMSS leaves and `t = 2^a` for the number of leaves in one
+FORS tree.  There is one FORS instance per XMSS leaf.  Consequently the source proof uses
+
+* `L * k * t` arity-one FORS-leaf targets;
+* `L * k * (t - 1)` arity-two FORS-tree targets;
+* `L` arity-`k` FORS-root-compression targets;
+* `L * len` arity-one WOTS-chain targets for UD-C and PRE-C;
+* `L * len * w` arity-one WOTS-chain targets for TCR-C;
+* `L` arity-`len` WOTS-public-key-compression targets; and
+* `L - 1` arity-two XMSS-tree targets.
+
+These are construction counts, not adversary query bounds.  The message-compression/ITSR target
+cap is instead determined by the signing-oracle query bound and belongs to that game.
+
+## References
+
+* Barbosa, Dupressoir, Hülsing, Meijers, and Strub, “A Tight Security Proof for SPHINCS+,
+  Formally Verified”, Figure 12 and the reductions in `FORS_ES.ec` and
+  `FL_SL_XMSS_MT_ES.ec`.
+* Hülsing and Kudinov, “Recovering the Tight Security Proof of SPHINCS+”.
+-/
+
+@[expose] public section
+
+namespace SLHDSA
+
+/-- Exact multi-target caps used by the concrete reductions for the current `d = 1` scheme. -/
+structure D1TargetProfile where
+  /-- Arity-one `F` targets covering all FORS secret leaves. -/
+  forsLeaf : ℕ
+  /-- Arity-two `H` targets covering all non-leaf FORS nodes. -/
+  forsTree : ℕ
+  /-- Arity-`k` `Tℓ` targets covering every FORS-root compression. -/
+  forsRoots : ℕ
+  /-- Arity-one `F` targets for the WOTS UD-C game. -/
+  wotsUd : ℕ
+  /-- Arity-one `F` targets for the WOTS TCR-C game, including every chain position. -/
+  wotsTcr : ℕ
+  /-- Arity-one `F` targets for the WOTS PRE-C game. -/
+  wotsPre : ℕ
+  /-- Arity-`len` `Tℓ` targets covering every WOTS public-key compression. -/
+  wotsPk : ℕ
+  /-- Arity-two `H` targets covering every non-leaf node of the single XMSS tree. -/
+  xmssTree : ℕ
+deriving Repr, DecidableEq
+
+namespace Params
+
+/-- The structural parameter condition under which the target ledger and the repository's
+single-tree signing algorithm describe a `d = 1` SLH-DSA construction.  Consumers of the ledger
+must carry this hypothesis; the formulas below are total as Lean functions but are only claimed as
+security-reduction counts under `IsD1`. -/
+def IsD1 (p : Params) : Prop := p.d = 1 ∧ p.h = p.hp
+
+instance (p : Params) : Decidable p.IsD1 := by
+  unfold IsD1
+  infer_instance
+
+/-- Arithmetic side conditions needed before a generic parameter record may be used in a
+`d = 1` concrete security theorem.  The word-size clauses are the first-order obligations behind
+reachable-address separation for the 32-bit ADRS fields; the final separation theorem must still
+reason about the actual reachable address families, because the concrete address encoding is not
+globally injective. -/
+def D1SecurityProfile (p : Params) : Prop :=
+  p.IsD1 ∧ 0 < p.n ∧ 0 < p.hp ∧ 0 < p.a ∧ 0 < p.k ∧ 0 < p.lgw ∧
+    p.hp ≤ 32 ∧ p.k * p.t ≤ 2 ^ 32 ∧ p.len ≤ 2 ^ 32 ∧ p.w ≤ 2 ^ 32
+
+instance (p : Params) : Decidable p.D1SecurityProfile := by
+  unfold D1SecurityProfile
+  infer_instance
+
+/-- The SP 800-230 Initial Public Draft usage cap for the reduced parameter sets.  This is a
+draft-profile bound, not an FIPS 205 approval claim. -/
+def sp800230IpdSignatureLimit : ℕ := 2 ^ 24
+
+/-- Number `L = 2^h'` of leaves in the current single XMSS tree. -/
+def d1LeafCount (p : Params) : ℕ := 2 ^ p.hp
+
+/-- Exact target profile for the repository's current `d = 1` SLH-DSA construction.  Reduction
+theorems using it must assume `p.IsD1`. -/
+def d1TargetProfile (p : Params) : D1TargetProfile where
+  forsLeaf := p.d1LeafCount * p.k * p.t
+  forsTree := p.d1LeafCount * p.k * (p.t - 1)
+  forsRoots := p.d1LeafCount
+  wotsUd := p.d1LeafCount * p.len
+  wotsTcr := p.d1LeafCount * p.len * p.w
+  wotsPre := p.d1LeafCount * p.len
+  wotsPk := p.d1LeafCount
+  xmssTree := p.d1LeafCount - 1
+
+@[simp] theorem d1TargetProfile_forsLeaf (p : Params) :
+    p.d1TargetProfile.forsLeaf = 2 ^ p.hp * p.k * 2 ^ p.a := rfl
+
+@[simp] theorem d1TargetProfile_forsTree (p : Params) :
+    p.d1TargetProfile.forsTree = 2 ^ p.hp * p.k * (2 ^ p.a - 1) := rfl
+
+@[simp] theorem d1TargetProfile_forsRoots (p : Params) :
+    p.d1TargetProfile.forsRoots = 2 ^ p.hp := rfl
+
+@[simp] theorem d1TargetProfile_wotsUd (p : Params) :
+    p.d1TargetProfile.wotsUd = 2 ^ p.hp * p.len := rfl
+
+@[simp] theorem d1TargetProfile_wotsTcr (p : Params) :
+    p.d1TargetProfile.wotsTcr = 2 ^ p.hp * p.len * p.w := rfl
+
+@[simp] theorem d1TargetProfile_wotsPre (p : Params) :
+    p.d1TargetProfile.wotsPre = 2 ^ p.hp * p.len := rfl
+
+@[simp] theorem d1TargetProfile_wotsPk (p : Params) :
+    p.d1TargetProfile.wotsPk = 2 ^ p.hp := rfl
+
+@[simp] theorem d1TargetProfile_xmssTree (p : Params) :
+    p.d1TargetProfile.xmssTree = 2 ^ p.hp - 1 := rfl
+
+end Params
+
+end SLHDSA

--- a/HashSig/SLHDSA/Security/TargetProfile.lean
+++ b/HashSig/SLHDSA/Security/TargetProfile.lean
@@ -86,6 +86,14 @@ instance (p : Params) : Decidable p.D1SecurityProfile := by
   unfold D1SecurityProfile
   infer_instance
 
+/-- The repository's supported SHA2-128-24 parameter record satisfies every arithmetic side
+condition of the single-tree security profile. -/
+theorem slhdsaSha2_128_24_d1SecurityProfile :
+    slhdsaSha2_128_24.D1SecurityProfile := by
+  have hlog : Nat.log 4 192 = 3 := by decide
+  norm_num [D1SecurityProfile, IsD1, slhdsaSha2_128_24, ParameterSet.params,
+    Params.len, Params.len1, Params.len2, Params.w, Params.t, hlog]
+
 /-- The SP 800-230 Initial Public Draft usage cap for the reduced parameter sets.  This is a
 draft-profile bound, not an FIPS 205 approval claim. -/
 def sp800230IpdSignatureLimit : ℕ := 2 ^ 24
@@ -104,6 +112,22 @@ def d1TargetProfile (p : Params) : D1TargetProfile where
   wotsPre := p.d1LeafCount * p.len
   wotsPk := p.d1LeafCount
   xmssTree := p.d1LeafCount - 1
+
+/-- Concrete target ledger for the only parameter set presently implemented by the repository.
+The WOTS-TCR entry is the source proof's loose `L * len * w` cap. -/
+theorem slhdsaSha2_128_24_d1TargetProfile :
+    slhdsaSha2_128_24.d1TargetProfile =
+      { forsLeaf := 422212465065984
+        forsTree := 422212439900160
+        forsRoots := 4194304
+        wotsUd := 285212672
+        wotsTcr := 1140850688
+        wotsPre := 285212672
+        wotsPk := 4194304
+        xmssTree := 4194303 } := by
+  have hlog : Nat.log 4 192 = 3 := by decide
+  norm_num [slhdsaSha2_128_24, ParameterSet.params, d1TargetProfile, d1LeafCount,
+    Params.len, Params.len1, Params.len2, Params.w, Params.t, hlog]
 
 @[simp] theorem d1TargetProfile_forsLeaf (p : Params) :
     p.d1TargetProfile.forsLeaf = 2 ^ p.hp * p.k * 2 ^ p.a := rfl

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -179,6 +179,23 @@ variable {p : Params}
 def encodeTargets (prims : Primitives p) (addresses : List Adrs) : List prims.AdrsKey :=
   addresses.map prims.adrsToKey
 
+/-- Exact proof interface for compressed-address separation: once an unencoded address list is
+known to be duplicate-free, its encoded image is duplicate-free iff `adrsToKey` is injective on
+that reachable list.  This avoids asking for the false global injectivity property of SHA ADRSc. -/
+theorem encodeTargets_nodup_iff_injOn (prims : Primitives p) (addresses : List Adrs)
+    (haddresses : addresses.Nodup) :
+    (prims.encodeTargets addresses).Nodup ↔
+      ∀ a ∈ addresses, ∀ b ∈ addresses, prims.adrsToKey a = prims.adrsToKey b → a = b := by
+  simpa [encodeTargets] using List.nodup_map_iff_inj_on (f := prims.adrsToKey) haddresses
+
+/-- Forward constructor form of `encodeTargets_nodup_iff_injOn`. -/
+theorem encodeTargets_nodup_of_injOn (prims : Primitives p) (addresses : List Adrs)
+    (haddresses : addresses.Nodup)
+    (hinj : ∀ a ∈ addresses, ∀ b ∈ addresses,
+      prims.adrsToKey a = prims.adrsToKey b → a = b) :
+    (prims.encodeTargets addresses).Nodup :=
+  (prims.encodeTargets_nodup_iff_injOn addresses haddresses).2 hinj
+
 def d1ForsLeafTweaks (prims : Primitives p) : List prims.AdrsKey :=
   prims.encodeTargets p.d1ForsLeafAddresses
 

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -102,6 +102,16 @@ def d1XmssTreeAddresses (p : Params) : List Adrs :=
     p.d1ForsRootsAddresses.length = p.d1TargetProfile.forsRoots := by
   simp [d1ForsRootsAddresses, d1TargetProfile, d1LeafCount]
 
+/-- FORS-root-compression addresses are structurally distinct before concrete encoding: their
+key-pair word is exactly the XMSS leaf index. -/
+theorem d1ForsRootsAddresses_nodup (p : Params) :
+    p.d1ForsRootsAddresses.Nodup := by
+  apply List.Nodup.map_on (d := List.nodup_range)
+  intro i _ j _ hij
+  have hword := congrArg Adrs.word1 hij
+  simpa [forsPkAdrs, forsAdrsOf, Adrs.getKeyPairAddress, Adrs.setKeyPairAddress,
+    Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero] using hword
+
 theorem d1WotsPreAddresses_length_le (p : Params) (core : CorePrimitives p)
     (messageAt : ℕ → core.Y) :
     (p.d1WotsPreAddresses core messageAt).length ≤ p.d1TargetProfile.wotsPre := by
@@ -145,6 +155,15 @@ theorem d1WotsTcrAddressSpace_length_le (p : Params) :
 @[simp] theorem d1WotsPkAddresses_length (p : Params) :
     p.d1WotsPkAddresses.length = p.d1TargetProfile.wotsPk := by
   simp [d1WotsPkAddresses, d1TargetProfile, d1LeafCount]
+
+/-- WOTS public-key-compression addresses are structurally distinct before concrete encoding. -/
+theorem d1WotsPkAddresses_nodup (p : Params) :
+    p.d1WotsPkAddresses.Nodup := by
+  apply List.Nodup.map_on (d := List.nodup_range)
+  intro i _ j _ hij
+  have hword := congrArg Adrs.word1 hij
+  simpa [wotsPkAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress, Adrs.setKeyPairAddress,
+    Adrs.setTypeAndClear, Adrs.zero] using hword
 
 @[simp] theorem d1XmssTreeAddresses_length (p : Params) :
     p.d1XmssTreeAddresses.length = p.d1TargetProfile.xmssTree := by

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Scheme
+public import HashSig.SLHDSA.Security.TargetProfile
+
+/-!
+# Concrete `d = 1` SLH-DSA target enumerations
+
+The quantitative target profile is useful only if each number is tied to the actual ADRS values
+queried by the construction.  This module enumerates those reachable target coordinates and maps
+them through a primitive bundle's concrete address encoding.  The length theorems recover the
+caps in `Params.d1TargetProfile`.
+
+These theorems count issued targets.  They deliberately do not claim that `adrsToKey` is globally
+injective: a concrete instantiation must prove `Nodup`/cross-disjointness on these reachable lists.
+-/
+
+@[expose] public section
+
+namespace SLHDSA
+
+/-- Internal nodes of a perfect binary tree, listed bottom-up as `(height, index)` pairs. -/
+def perfectInternalCoords : ℕ → List (ℕ × ℕ)
+  | 0 => []
+  | h + 1 =>
+      (List.range (2 ^ h)).map (fun i => (1, i)) ++
+        (perfectInternalCoords h).map (fun zi => (zi.1 + 1, zi.2))
+
+@[simp] theorem perfectInternalCoords_length (h : ℕ) :
+    (perfectInternalCoords h).length = 2 ^ h - 1 := by
+  induction h with
+  | zero => simp [perfectInternalCoords]
+  | succ h ih =>
+      simp [perfectInternalCoords, ih, pow_succ]
+      omega
+
+namespace Params
+
+/-- Every FORS secret-leaf target address, before concrete address encoding. -/
+def d1ForsLeafAddresses (p : Params) : List Adrs :=
+  (List.range p.d1LeafCount).flatMap fun idxLeaf =>
+    (List.range p.k).flatMap fun tree =>
+      (List.range p.t).map fun leaf =>
+        forsNodeAdrs (forsAdrsOf idxLeaf) 0 (tree * p.t + leaf)
+
+/-- Every FORS internal-node target address, before concrete address encoding. -/
+def d1ForsTreeAddresses (p : Params) : List Adrs :=
+  (List.range p.d1LeafCount).flatMap fun idxLeaf =>
+    (List.range p.k).flatMap fun tree =>
+      (perfectInternalCoords p.a).map fun zi =>
+        forsNodeAdrs (forsAdrsOf idxLeaf) zi.1
+          (tree * 2 ^ (p.a - zi.1) + zi.2)
+
+/-- Every FORS-root-compression target address. -/
+def d1ForsRootsAddresses (p : Params) : List Adrs :=
+  (List.range p.d1LeafCount).map fun idxLeaf => forsPkAdrs (forsAdrsOf idxLeaf)
+
+/-- The WOTS arity-one target addresses used by UD-C and PRE-C. -/
+def d1WotsChainAddresses (p : Params) : List Adrs :=
+  (List.range p.d1LeafCount).flatMap fun idxLeaf =>
+    (List.range p.len).map fun chain => wotsChainAdrs (wotsLeafAdrs Adrs.zero idxLeaf) chain
+
+/-- The WOTS arity-one target addresses used by TCR-C, including every chain position. -/
+def d1WotsTcrAddresses (p : Params) : List Adrs :=
+  (List.range p.d1LeafCount).flatMap fun idxLeaf =>
+    (List.range p.len).flatMap fun chain =>
+      (List.range p.w).map fun step =>
+        (wotsChainAdrs (wotsLeafAdrs Adrs.zero idxLeaf) chain).setHashAddress step
+
+/-- Every WOTS public-key-compression target address. -/
+def d1WotsPkAddresses (p : Params) : List Adrs :=
+  (List.range p.d1LeafCount).map fun idxLeaf => wotsPkAdrs (wotsLeafAdrs Adrs.zero idxLeaf)
+
+/-- Every internal node of the single XMSS tree. -/
+def d1XmssTreeAddresses (p : Params) : List Adrs :=
+  (perfectInternalCoords p.hp).map fun zi => xmssNodeAdrs Adrs.zero zi.1 zi.2
+
+@[simp] theorem d1ForsLeafAddresses_length (p : Params) :
+    p.d1ForsLeafAddresses.length = p.d1TargetProfile.forsLeaf := by
+  simp [d1ForsLeafAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
+
+@[simp] theorem d1ForsTreeAddresses_length (p : Params) :
+    p.d1ForsTreeAddresses.length = p.d1TargetProfile.forsTree := by
+  simp [d1ForsTreeAddresses, d1TargetProfile, d1LeafCount, t, Nat.mul_assoc]
+
+@[simp] theorem d1ForsRootsAddresses_length (p : Params) :
+    p.d1ForsRootsAddresses.length = p.d1TargetProfile.forsRoots := by
+  simp [d1ForsRootsAddresses, d1TargetProfile, d1LeafCount]
+
+@[simp] theorem d1WotsChainAddresses_length (p : Params) :
+    p.d1WotsChainAddresses.length = p.d1TargetProfile.wotsUd := by
+  simp [d1WotsChainAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
+
+@[simp] theorem d1WotsChainAddresses_length_pre (p : Params) :
+    p.d1WotsChainAddresses.length = p.d1TargetProfile.wotsPre := by
+  simp [d1WotsChainAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
+
+@[simp] theorem d1WotsTcrAddresses_length (p : Params) :
+    p.d1WotsTcrAddresses.length = p.d1TargetProfile.wotsTcr := by
+  simp [d1WotsTcrAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
+
+@[simp] theorem d1WotsPkAddresses_length (p : Params) :
+    p.d1WotsPkAddresses.length = p.d1TargetProfile.wotsPk := by
+  simp [d1WotsPkAddresses, d1TargetProfile, d1LeafCount]
+
+@[simp] theorem d1XmssTreeAddresses_length (p : Params) :
+    p.d1XmssTreeAddresses.length = p.d1TargetProfile.xmssTree := by
+  simp [d1XmssTreeAddresses, d1TargetProfile, d1LeafCount]
+
+end Params
+
+namespace Primitives
+
+variable {p : Params}
+
+/-- Encode a reachable address list with the primitive bundle's actual tweak function. -/
+def encodeTargets (prims : Primitives p) (addresses : List Adrs) : List prims.AdrsKey :=
+  addresses.map prims.adrsToKey
+
+def d1ForsLeafTweaks (prims : Primitives p) : List prims.AdrsKey :=
+  prims.encodeTargets p.d1ForsLeafAddresses
+
+def d1ForsTreeTweaks (prims : Primitives p) : List prims.AdrsKey :=
+  prims.encodeTargets p.d1ForsTreeAddresses
+
+def d1ForsRootsTweaks (prims : Primitives p) : List prims.AdrsKey :=
+  prims.encodeTargets p.d1ForsRootsAddresses
+
+def d1WotsChainTweaks (prims : Primitives p) : List prims.AdrsKey :=
+  prims.encodeTargets p.d1WotsChainAddresses
+
+def d1WotsTcrTweaks (prims : Primitives p) : List prims.AdrsKey :=
+  prims.encodeTargets p.d1WotsTcrAddresses
+
+def d1WotsPkTweaks (prims : Primitives p) : List prims.AdrsKey :=
+  prims.encodeTargets p.d1WotsPkAddresses
+
+def d1XmssTreeTweaks (prims : Primitives p) : List prims.AdrsKey :=
+  prims.encodeTargets p.d1XmssTreeAddresses
+
+@[simp] theorem d1ForsLeafTweaks_length (prims : Primitives p) :
+    prims.d1ForsLeafTweaks.length = p.d1TargetProfile.forsLeaf := by
+  simp [d1ForsLeafTweaks, encodeTargets]
+
+@[simp] theorem d1ForsTreeTweaks_length (prims : Primitives p) :
+    prims.d1ForsTreeTweaks.length = p.d1TargetProfile.forsTree := by
+  simp [d1ForsTreeTweaks, encodeTargets]
+
+@[simp] theorem d1WotsTcrTweaks_length (prims : Primitives p) :
+    prims.d1WotsTcrTweaks.length = p.d1TargetProfile.wotsTcr := by
+  simp [d1WotsTcrTweaks, encodeTargets]
+
+@[simp] theorem d1ForsRootsTweaks_length (prims : Primitives p) :
+    prims.d1ForsRootsTweaks.length = p.d1TargetProfile.forsRoots := by
+  simp [d1ForsRootsTweaks, encodeTargets]
+
+@[simp] theorem d1WotsChainTweaks_length (prims : Primitives p) :
+    prims.d1WotsChainTweaks.length = p.d1TargetProfile.wotsUd := by
+  simp [d1WotsChainTweaks, encodeTargets]
+
+@[simp] theorem d1WotsChainTweaks_length_pre (prims : Primitives p) :
+    prims.d1WotsChainTweaks.length = p.d1TargetProfile.wotsPre := by
+  simp [d1WotsChainTweaks, encodeTargets]
+
+@[simp] theorem d1WotsPkTweaks_length (prims : Primitives p) :
+    prims.d1WotsPkTweaks.length = p.d1TargetProfile.wotsPk := by
+  simp [d1WotsPkTweaks, encodeTargets]
+
+@[simp] theorem d1XmssTreeTweaks_length (prims : Primitives p) :
+    prims.d1XmssTreeTweaks.length = p.d1TargetProfile.xmssTree := by
+  simp [d1XmssTreeTweaks, encodeTargets]
+
+end Primitives
+
+end SLHDSA

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -34,6 +34,7 @@ def perfectInternalCoords : ℕ → List (ℕ × ℕ)
       (List.range (2 ^ h)).map (fun i => (1, i)) ++
         (perfectInternalCoords h).map (fun zi => (zi.1 + 1, zi.2))
 
+/-- A perfect binary tree of height `h` has exactly `2^h - 1` internal coordinates. -/
 @[simp] theorem perfectInternalCoords_length (h : ℕ) :
     (perfectInternalCoords h).length = 2 ^ h - 1 := by
   induction h with
@@ -143,6 +144,7 @@ def d1WotsPkAddresses (p : Params) : List Adrs :=
 def d1XmssTreeAddresses (p : Params) : List Adrs :=
   (perfectInternalCoords p.hp).map fun zi => xmssNodeAdrs Adrs.zero zi.1 zi.2
 
+/-- The FORS-leaf address enumeration realizes the exact target-profile count. -/
 @[simp] theorem d1ForsLeafAddresses_length (p : Params) :
     p.d1ForsLeafAddresses.length = p.d1TargetProfile.forsLeaf := by
   simp [d1ForsLeafAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
@@ -188,6 +190,7 @@ theorem d1ForsLeafAddresses_nodup (p : Params) :
   simpa [coords, List.product, d1ForsLeafAddresses, List.map_flatMap,
     List.flatMap_map, List.flatMap_assoc, List.map_map, Function.comp_def] using hmapped
 
+/-- The FORS-tree address enumeration realizes the exact target-profile count. -/
 @[simp] theorem d1ForsTreeAddresses_length (p : Params) :
     p.d1ForsTreeAddresses.length = p.d1TargetProfile.forsTree := by
   simp [d1ForsTreeAddresses, d1TargetProfile, d1LeafCount, t, Nat.mul_assoc]
@@ -246,6 +249,7 @@ theorem d1ForsTreeAddresses_nodup (p : Params) :
   simpa [coords, List.product, d1ForsTreeAddresses, List.map_flatMap,
     List.flatMap_map, List.flatMap_assoc, List.map_map, Function.comp_def] using hmapped
 
+/-- The FORS-root-compression enumeration realizes the exact target-profile count. -/
 @[simp] theorem d1ForsRootsAddresses_length (p : Params) :
     p.d1ForsRootsAddresses.length = p.d1TargetProfile.forsRoots := by
   simp [d1ForsRootsAddresses, d1TargetProfile, d1LeafCount]
@@ -260,6 +264,7 @@ theorem d1ForsRootsAddresses_nodup (p : Params) :
   simpa [forsPkAdrs, forsAdrsOf, Adrs.getKeyPairAddress, Adrs.setKeyPairAddress,
     Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero] using hword
 
+/-- A message-dependent WOTS PRE transcript never exceeds its target-profile cap. -/
 theorem d1WotsPreAddresses_length_le (p : Params) (core : CorePrimitives p)
     (messageAt : ℕ → core.Y) :
     (p.d1WotsPreAddresses core messageAt).length ≤ p.d1TargetProfile.wotsPre := by
@@ -326,6 +331,7 @@ theorem d1WotsPreAddresses_nodup (p : Params) (core : CorePrimitives p)
   simpa [coords, encode, List.product, d1WotsPreAddresses, List.flatMap_map,
     List.flatMap_assoc, Function.comp_def] using hencoded
 
+/-- The reachable WOTS chain-step space stays within the source proof's loose TCR cap. -/
 theorem d1WotsTcrAddressSpace_length_le (p : Params) :
     p.d1WotsTcrAddressSpace.length ≤ p.d1TargetProfile.wotsTcr := by
   simp only [d1WotsTcrAddressSpace, List.length_flatMap, List.length_map,
@@ -367,6 +373,7 @@ theorem d1WotsTcrAddressSpace_nodup (p : Params) :
   simpa [coords, List.product, d1WotsTcrAddressSpace, List.map_flatMap,
     List.flatMap_map, List.flatMap_assoc, List.map_map, Function.comp_def] using hmapped
 
+/-- The WOTS public-key-compression enumeration realizes the exact target-profile count. -/
 @[simp] theorem d1WotsPkAddresses_length (p : Params) :
     p.d1WotsPkAddresses.length = p.d1TargetProfile.wotsPk := by
   simp [d1WotsPkAddresses, d1TargetProfile, d1LeafCount]
@@ -380,6 +387,7 @@ theorem d1WotsPkAddresses_nodup (p : Params) :
   simpa [wotsPkAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress, Adrs.setKeyPairAddress,
     Adrs.setTypeAndClear, Adrs.zero] using hword
 
+/-- The XMSS-tree address enumeration realizes the exact target-profile count. -/
 @[simp] theorem d1XmssTreeAddresses_length (p : Params) :
     p.d1XmssTreeAddresses.length = p.d1TargetProfile.xmssTree := by
   simp [d1XmssTreeAddresses, d1TargetProfile, d1LeafCount]

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -94,6 +94,47 @@ def d1XmssTreeAddresses (p : Params) : List Adrs :=
     p.d1ForsLeafAddresses.length = p.d1TargetProfile.forsLeaf := by
   simp [d1ForsLeafAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
 
+/-- FORS leaf addresses are structurally duplicate-free before concrete compression.  The
+key-pair word identifies the XMSS leaf, while quotient and remainder of the global FORS leaf
+index recover the tree and local leaf. -/
+theorem d1ForsLeafAddresses_nodup (p : Params) :
+    p.d1ForsLeafAddresses.Nodup := by
+  let coords :=
+    ((List.range p.d1LeafCount).product (List.range p.k)).product (List.range p.t)
+  have hcoords : coords.Nodup :=
+    (List.nodup_range.product List.nodup_range).product List.nodup_range
+  have hmapped := hcoords.map_on (f := fun c : (ℕ × ℕ) × ℕ =>
+      forsNodeAdrs (forsAdrsOf c.1.1) 0 (c.1.2 * p.t + c.2)) (by
+    intro c hc d hd hadrs
+    obtain ⟨ci, hci, cj, hcj, cl, hcl, rfl⟩ :
+        ∃ ci < p.d1LeafCount, ∃ cj < p.k, ∃ cl < p.t, ((ci, cj), cl) = c := by
+      simpa [coords, List.product] using hc
+    obtain ⟨di, hdi, dj, hdj, dl, hdl, rfl⟩ :
+        ∃ di < p.d1LeafCount, ∃ dj < p.k, ∃ dl < p.t, ((di, dj), dl) = d := by
+      simpa [coords, List.product] using hd
+    have houter : ci = di := by
+      simpa [forsNodeAdrs, forsAdrsOf, Adrs.getKeyPairAddress,
+        Adrs.setTreeHeight, Adrs.setTreeIndex, Adrs.setKeyPairAddress,
+        Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero] using
+          congrArg Adrs.word1 hadrs
+    have hglobal : cj * p.t + cl = dj * p.t + dl := by
+      simpa [forsNodeAdrs, forsAdrsOf, Adrs.getKeyPairAddress,
+        Adrs.setTreeHeight, Adrs.setTreeIndex, Adrs.setKeyPairAddress,
+        Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero] using
+          congrArg Adrs.word3 hadrs
+    have htpos : 0 < p.t := by unfold Params.t; positivity
+    have htree : cj = dj := by
+      have hdiv := congrArg (fun x => x / p.t) hglobal
+      simpa [Nat.add_comm, Nat.add_mul_div_right, Nat.div_eq_of_lt,
+        hcl, hdl, htpos] using hdiv
+    have hleaf : cl = dl := by
+      have hmod := congrArg (fun x => x % p.t) hglobal
+      simpa [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt,
+        hcl, hdl] using hmod
+    exact Prod.ext (Prod.ext houter htree) hleaf)
+  simpa [coords, List.product, d1ForsLeafAddresses, List.map_flatMap,
+    List.flatMap_map, List.flatMap_assoc, List.map_map, Function.comp_def] using hmapped
+
 @[simp] theorem d1ForsTreeAddresses_length (p : Params) :
     p.d1ForsTreeAddresses.length = p.d1TargetProfile.forsTree := by
   simp [d1ForsTreeAddresses, d1TargetProfile, d1LeafCount, t, Nat.mul_assoc]

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -42,6 +42,37 @@ def perfectInternalCoords : ℕ → List (ℕ × ℕ)
       simp [perfectInternalCoords, ih, pow_succ]
       omega
 
+theorem perfectInternalCoords_height_pos {h : ℕ} {zi : ℕ × ℕ}
+    (hmem : zi ∈ perfectInternalCoords h) : 0 < zi.1 := by
+  induction h with
+  | zero => simp [perfectInternalCoords] at hmem
+  | succ h ih =>
+      simp only [perfectInternalCoords, List.mem_append, List.mem_map] at hmem
+      rcases hmem with ⟨i, _, rfl⟩ | ⟨zi, hzi, rfl⟩
+      · simp
+      · exact Nat.succ_pos zi.1
+
+/-- Internal perfect-tree coordinates are never repeated. -/
+theorem perfectInternalCoords_nodup (h : ℕ) :
+    (perfectInternalCoords h).Nodup := by
+  induction h with
+  | zero => simp [perfectInternalCoords]
+  | succ h ih =>
+      rw [perfectInternalCoords, List.nodup_append]
+      refine ⟨?_, ?_, ?_⟩
+      · exact List.nodup_range.map (fun _ _ hpair => Prod.mk.inj hpair |>.2)
+      · exact ih.map (fun _ _ hpair => by
+          have hfst := congrArg Prod.fst hpair
+          have hsnd := congrArg Prod.snd hpair
+          exact Prod.ext (Nat.succ.inj hfst) hsnd)
+      · intro x hxLeft y hxRight hxy
+        obtain ⟨i, _, rfl⟩ := List.mem_map.mp hxLeft
+        obtain ⟨zi, hzi, rfl⟩ := List.mem_map.mp hxRight
+        have hheight := congrArg Prod.fst hxy
+        have hpos := perfectInternalCoords_height_pos hzi
+        simp only at hheight
+        omega
+
 namespace Params
 
 /-- Every FORS secret-leaf target address, before concrete address encoding. -/
@@ -276,6 +307,17 @@ theorem d1WotsPkAddresses_nodup (p : Params) :
 @[simp] theorem d1XmssTreeAddresses_length (p : Params) :
     p.d1XmssTreeAddresses.length = p.d1TargetProfile.xmssTree := by
   simp [d1XmssTreeAddresses, d1TargetProfile, d1LeafCount]
+
+/-- XMSS internal-node addresses are structurally duplicate-free before concrete compression. -/
+theorem d1XmssTreeAddresses_nodup (p : Params) :
+    p.d1XmssTreeAddresses.Nodup := by
+  apply List.Nodup.map_on (d := perfectInternalCoords_nodup p.hp)
+  intro zi _ zj _ hadrs
+  apply Prod.ext
+  · simpa [xmssNodeAdrs, Adrs.setTreeHeight, Adrs.setTreeIndex,
+      Adrs.setTypeAndClear, Adrs.zero] using congrArg Adrs.word2 hadrs
+  · simpa [xmssNodeAdrs, Adrs.setTreeHeight, Adrs.setTreeIndex,
+      Adrs.setTypeAndClear, Adrs.zero] using congrArg Adrs.word3 hadrs
 
 end Params
 

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -451,6 +451,37 @@ structure D1TargetTweakSeparation (prims : Primitives p) : Prop where
   wotsPk : prims.d1WotsPkTweaks.Nodup
   xmssTree : prims.d1XmssTreeTweaks.Nodup
 
+/-- Build the exact game-facing separation certificate from injectivity of the concrete address
+encoding on each reachable target family.  The structural `Nodup` facts are unconditional and
+proved above; consequently a concrete SHA instantiation need only reason about the information
+retained by `ADRSc` on these seven restricted domains. -/
+theorem D1TargetTweakSeparation.ofInjOn (prims : Primitives p)
+    (hForsLeaf : ∀ a ∈ p.d1ForsLeafAddresses, ∀ b ∈ p.d1ForsLeafAddresses,
+      prims.adrsToKey a = prims.adrsToKey b → a = b)
+    (hForsTree : ∀ a ∈ p.d1ForsTreeAddresses, ∀ b ∈ p.d1ForsTreeAddresses,
+      prims.adrsToKey a = prims.adrsToKey b → a = b)
+    (hForsRoots : ∀ a ∈ p.d1ForsRootsAddresses, ∀ b ∈ p.d1ForsRootsAddresses,
+      prims.adrsToKey a = prims.adrsToKey b → a = b)
+    (hWotsPre : ∀ messageAt : ℕ → prims.Y,
+      ∀ a ∈ p.d1WotsPreAddresses prims.core messageAt,
+        ∀ b ∈ p.d1WotsPreAddresses prims.core messageAt,
+          prims.adrsToKey a = prims.adrsToKey b → a = b)
+    (hWotsTcr : ∀ a ∈ p.d1WotsTcrAddressSpace, ∀ b ∈ p.d1WotsTcrAddressSpace,
+      prims.adrsToKey a = prims.adrsToKey b → a = b)
+    (hWotsPk : ∀ a ∈ p.d1WotsPkAddresses, ∀ b ∈ p.d1WotsPkAddresses,
+      prims.adrsToKey a = prims.adrsToKey b → a = b)
+    (hXmssTree : ∀ a ∈ p.d1XmssTreeAddresses, ∀ b ∈ p.d1XmssTreeAddresses,
+      prims.adrsToKey a = prims.adrsToKey b → a = b) :
+    D1TargetTweakSeparation prims where
+  forsLeaf := prims.encodeTargets_nodup_of_injOn _ p.d1ForsLeafAddresses_nodup hForsLeaf
+  forsTree := prims.encodeTargets_nodup_of_injOn _ p.d1ForsTreeAddresses_nodup hForsTree
+  forsRoots := prims.encodeTargets_nodup_of_injOn _ p.d1ForsRootsAddresses_nodup hForsRoots
+  wotsPre messageAt := prims.encodeTargets_nodup_of_injOn _
+    (p.d1WotsPreAddresses_nodup prims.core messageAt) (hWotsPre messageAt)
+  wotsTcr := prims.encodeTargets_nodup_of_injOn _ p.d1WotsTcrAddressSpace_nodup hWotsTcr
+  wotsPk := prims.encodeTargets_nodup_of_injOn _ p.d1WotsPkAddresses_nodup hWotsPk
+  xmssTree := prims.encodeTargets_nodup_of_injOn _ p.d1XmssTreeAddresses_nodup hXmssTree
+
 @[simp] theorem d1ForsLeafTweaks_length (prims : Primitives p) :
     prims.d1ForsLeafTweaks.length = p.d1TargetProfile.forsLeaf := by
   simp [d1ForsLeafTweaks, encodeTargets]

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -52,6 +52,17 @@ theorem perfectInternalCoords_height_pos {h : ℕ} {zi : ℕ × ℕ}
       · simp
       · exact Nat.succ_pos zi.1
 
+/-- An internal coordinate's height never exceeds the height of its perfect tree. -/
+theorem perfectInternalCoords_height_le {h : ℕ} {zi : ℕ × ℕ}
+    (hmem : zi ∈ perfectInternalCoords h) : zi.1 ≤ h := by
+  induction h generalizing zi with
+  | zero => simp [perfectInternalCoords] at hmem
+  | succ h ih =>
+      simp only [perfectInternalCoords, List.mem_append, List.mem_map] at hmem
+      rcases hmem with ⟨i, _, rfl⟩ | ⟨zi, hzi, rfl⟩
+      · exact Nat.succ_le_succ (Nat.zero_le h)
+      · exact Nat.succ_le_succ (ih hzi)
+
 /-- At height `z`, a perfect tree of height `h` has exactly `2^(h-z)` node positions. -/
 theorem perfectInternalCoords_index_lt {h : ℕ} {zi : ℕ × ℕ}
     (hmem : zi ∈ perfectInternalCoords h) : zi.2 < 2 ^ (h - zi.1) := by

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -52,6 +52,17 @@ theorem perfectInternalCoords_height_pos {h : ℕ} {zi : ℕ × ℕ}
       · simp
       · exact Nat.succ_pos zi.1
 
+/-- At height `z`, a perfect tree of height `h` has exactly `2^(h-z)` node positions. -/
+theorem perfectInternalCoords_index_lt {h : ℕ} {zi : ℕ × ℕ}
+    (hmem : zi ∈ perfectInternalCoords h) : zi.2 < 2 ^ (h - zi.1) := by
+  induction h generalizing zi with
+  | zero => simp [perfectInternalCoords] at hmem
+  | succ h ih =>
+      simp only [perfectInternalCoords, List.mem_append, List.mem_map] at hmem
+      rcases hmem with ⟨i, hi, rfl⟩ | ⟨zi, hzi, rfl⟩
+      · simpa using hi
+      · simpa only [Nat.succ_sub_succ_eq_sub] using ih hzi
+
 /-- Internal perfect-tree coordinates are never repeated. -/
 theorem perfectInternalCoords_nodup (h : ℕ) :
     (perfectInternalCoords h).Nodup := by
@@ -169,6 +180,60 @@ theorem d1ForsLeafAddresses_nodup (p : Params) :
 @[simp] theorem d1ForsTreeAddresses_length (p : Params) :
     p.d1ForsTreeAddresses.length = p.d1TargetProfile.forsTree := by
   simp [d1ForsTreeAddresses, d1TargetProfile, d1LeafCount, t, Nat.mul_assoc]
+
+/-- FORS internal-node addresses are structurally duplicate-free before concrete compression. -/
+theorem d1ForsTreeAddresses_nodup (p : Params) :
+    p.d1ForsTreeAddresses.Nodup := by
+  let coords :=
+    ((List.range p.d1LeafCount).product (List.range p.k)).product
+      (perfectInternalCoords p.a)
+  have hcoords : coords.Nodup :=
+    (List.nodup_range.product List.nodup_range).product
+      (perfectInternalCoords_nodup p.a)
+  have hmapped := hcoords.map_on (f := fun c : (ℕ × ℕ) × (ℕ × ℕ) =>
+      forsNodeAdrs (forsAdrsOf c.1.1) c.2.1
+        (c.1.2 * 2 ^ (p.a - c.2.1) + c.2.2)) (by
+    intro c hc d hd hadrs
+    obtain ⟨ci, hci, cj, hcj, cz, hcz, rfl⟩ :
+        ∃ ci < p.d1LeafCount, ∃ cj < p.k, ∃ cz ∈ perfectInternalCoords p.a,
+          ((ci, cj), cz) = c := by
+      simpa [coords, List.product] using hc
+    obtain ⟨di, hdi, dj, hdj, dz, hdz, rfl⟩ :
+        ∃ di < p.d1LeafCount, ∃ dj < p.k, ∃ dz ∈ perfectInternalCoords p.a,
+          ((di, dj), dz) = d := by
+      simpa [coords, List.product] using hd
+    have houter : ci = di := by
+      simpa [forsNodeAdrs, forsAdrsOf, Adrs.getKeyPairAddress,
+        Adrs.setTreeHeight, Adrs.setTreeIndex, Adrs.setKeyPairAddress,
+        Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero] using
+          congrArg Adrs.word1 hadrs
+    have hheight : cz.1 = dz.1 := by
+      simpa [forsNodeAdrs, forsAdrsOf, Adrs.getKeyPairAddress,
+        Adrs.setTreeHeight, Adrs.setTreeIndex, Adrs.setKeyPairAddress,
+        Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero] using
+          congrArg Adrs.word2 hadrs
+    have hglobal : cj * 2 ^ (p.a - cz.1) + cz.2 =
+        dj * 2 ^ (p.a - dz.1) + dz.2 := by
+      simpa [forsNodeAdrs, forsAdrsOf, Adrs.getKeyPairAddress,
+        Adrs.setTreeHeight, Adrs.setTreeIndex, Adrs.setKeyPairAddress,
+        Adrs.setTypeAndClear, Adrs.setTreeAddress, Adrs.zero] using
+          congrArg Adrs.word3 hadrs
+    rw [hheight] at hglobal
+    have hczBound := perfectInternalCoords_index_lt hcz
+    have hdzBound := perfectInternalCoords_index_lt hdz
+    have hczBound' : cz.2 < 2 ^ (p.a - dz.1) := by simpa [hheight] using hczBound
+    have hpow : 0 < 2 ^ (p.a - dz.1) := by positivity
+    have htree : cj = dj := by
+      have hdiv := congrArg (fun x => x / 2 ^ (p.a - dz.1)) hglobal
+      simpa [Nat.add_comm, Nat.add_mul_div_right, Nat.div_eq_of_lt,
+        hczBound', hdzBound, hpow] using hdiv
+    have hnode : cz.2 = dz.2 := by
+      have hmod := congrArg (fun x => x % 2 ^ (p.a - dz.1)) hglobal
+      simpa [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt,
+        hczBound', hdzBound] using hmod
+    exact Prod.ext (Prod.ext houter htree) (Prod.ext hheight hnode))
+  simpa [coords, List.product, d1ForsTreeAddresses, List.map_flatMap,
+    List.flatMap_map, List.flatMap_assoc, List.map_map, Function.comp_def] using hmapped
 
 @[simp] theorem d1ForsRootsAddresses_length (p : Params) :
     p.d1ForsRootsAddresses.length = p.d1TargetProfile.forsRoots := by

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -9,12 +9,15 @@ public import HashSig.SLHDSA.Scheme
 public import HashSig.SLHDSA.Security.TargetProfile
 
 /-!
-# Concrete `d = 1` SLH-DSA target enumerations
+# Concrete `d = 1` SLH-DSA target coordinates
 
 The quantitative target profile is useful only if each number is tied to the actual ADRS values
-queried by the construction.  This module enumerates those reachable target coordinates and maps
-them through a primitive bundle's concrete address encoding.  The length theorems recover the
-caps in `Params.d1TargetProfile`.
+queried by the construction.  This module enumerates the message-independent FORS/XMSS targets
+and maps them through a primitive bundle's concrete address encoding.  WOTS target selection is
+message/hybrid dependent: its PRE transcript constructor is therefore parameterized by the honest
+message at each leaf, while its TCR declaration is only the reachable address space from which a
+reduction selects targets.  The length theorems recover, or upper-bound by, the caps in
+`Params.d1TargetProfile`.
 
 These theorems count issued targets.  They deliberately do not claim that `adrsToKey` is globally
 injective: a concrete instantiation must prove `Nodup`/cross-disjointness on these reachable lists.
@@ -60,16 +63,23 @@ def d1ForsTreeAddresses (p : Params) : List Adrs :=
 def d1ForsRootsAddresses (p : Params) : List Adrs :=
   (List.range p.d1LeafCount).map fun idxLeaf => forsPkAdrs (forsAdrsOf idxLeaf)
 
-/-- The WOTS arity-one target addresses used by UD-C and PRE-C. -/
-def d1WotsChainAddresses (p : Params) : List Adrs :=
-  (List.range p.d1LeafCount).flatMap fun idxLeaf =>
-    (List.range p.len).map fun chain => wotsChainAdrs (wotsLeafAdrs Adrs.zero idxLeaf) chain
-
-/-- The WOTS arity-one target addresses used by TCR-C, including every chain position. -/
-def d1WotsTcrAddresses (p : Params) : List Adrs :=
+/-- The actual WOTS PRE-C target transcript for one honest WOTS message at each XMSS leaf.  Chain
+`i` contributes a target at hash address `digit - 1` exactly when its honest digit is nonzero. -/
+def d1WotsPreAddresses (p : Params) (core : CorePrimitives p)
+    (messageAt : ℕ → core.Y) : List Adrs :=
   (List.range p.d1LeafCount).flatMap fun idxLeaf =>
     (List.range p.len).flatMap fun chain =>
-      (List.range p.w).map fun step =>
+      let digit := chainStepsCore core (messageAt idxLeaf) chain
+      if digit = 0 then [] else
+        [(wotsChainAdrs (wotsLeafAdrs Adrs.zero idxLeaf) chain).setHashAddress (digit - 1)]
+
+/-- Reachable WOTS chain-step address space.  Actual TCR-C targets form a message-dependent
+subsequence of this list.  There are only `w - 1` executed hash positions per chain; the source
+reduction deliberately uses the looser `len * w` target cap. -/
+def d1WotsTcrAddressSpace (p : Params) : List Adrs :=
+  (List.range p.d1LeafCount).flatMap fun idxLeaf =>
+    (List.range p.len).flatMap fun chain =>
+      (List.range (p.w - 1)).map fun step =>
         (wotsChainAdrs (wotsLeafAdrs Adrs.zero idxLeaf) chain).setHashAddress step
 
 /-- Every WOTS public-key-compression target address. -/
@@ -92,17 +102,45 @@ def d1XmssTreeAddresses (p : Params) : List Adrs :=
     p.d1ForsRootsAddresses.length = p.d1TargetProfile.forsRoots := by
   simp [d1ForsRootsAddresses, d1TargetProfile, d1LeafCount]
 
-@[simp] theorem d1WotsChainAddresses_length (p : Params) :
-    p.d1WotsChainAddresses.length = p.d1TargetProfile.wotsUd := by
-  simp [d1WotsChainAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
+theorem d1WotsPreAddresses_length_le (p : Params) (core : CorePrimitives p)
+    (messageAt : ℕ → core.Y) :
+    (p.d1WotsPreAddresses core messageAt).length ≤ p.d1TargetProfile.wotsPre := by
+  simp only [d1WotsPreAddresses, List.length_flatMap]
+  calc
+    (List.map
+        (fun idxLeaf =>
+          (List.map
+            (fun chain =>
+              (if chainStepsCore core (messageAt idxLeaf) chain = 0 then [] else
+                [(wotsChainAdrs (wotsLeafAdrs Adrs.zero idxLeaf) chain).setHashAddress
+                  (chainStepsCore core (messageAt idxLeaf) chain - 1)]).length)
+            (List.range p.len)).sum)
+        (List.range p.d1LeafCount)).sum ≤
+        (List.map (fun _ => p.len) (List.range p.d1LeafCount)).sum := by
+      apply List.sum_le_sum
+      intro idxLeaf _
+      calc
+        _ ≤ (List.map (fun _ => 1) (List.range p.len)).sum := by
+          apply List.sum_le_sum
+          intro chain _
+          split <;> simp
+        _ = p.len := by simp
+    _ = p.d1TargetProfile.wotsPre := by
+      simp [d1TargetProfile, d1LeafCount]
 
-@[simp] theorem d1WotsChainAddresses_length_pre (p : Params) :
-    p.d1WotsChainAddresses.length = p.d1TargetProfile.wotsPre := by
-  simp [d1WotsChainAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
-
-@[simp] theorem d1WotsTcrAddresses_length (p : Params) :
-    p.d1WotsTcrAddresses.length = p.d1TargetProfile.wotsTcr := by
-  simp [d1WotsTcrAddresses, d1TargetProfile, d1LeafCount, Nat.mul_assoc]
+theorem d1WotsTcrAddressSpace_length_le (p : Params) :
+    p.d1WotsTcrAddressSpace.length ≤ p.d1TargetProfile.wotsTcr := by
+  simp only [d1WotsTcrAddressSpace, List.length_flatMap, List.length_map,
+    List.length_range]
+  simp only [List.sum_replicate, List.map_const', nsmul_eq_mul]
+  simp only [List.length_range]
+  unfold d1TargetProfile
+  calc
+    p.d1LeafCount * (p.len * (p.w - 1)) =
+        (p.d1LeafCount * p.len) * (p.w - 1) :=
+      (Nat.mul_assoc _ _ _).symm
+    _ ≤ (p.d1LeafCount * p.len) * p.w :=
+      Nat.mul_le_mul_left _ (Nat.sub_le p.w 1)
 
 @[simp] theorem d1WotsPkAddresses_length (p : Params) :
     p.d1WotsPkAddresses.length = p.d1TargetProfile.wotsPk := by
@@ -131,11 +169,11 @@ def d1ForsTreeTweaks (prims : Primitives p) : List prims.AdrsKey :=
 def d1ForsRootsTweaks (prims : Primitives p) : List prims.AdrsKey :=
   prims.encodeTargets p.d1ForsRootsAddresses
 
-def d1WotsChainTweaks (prims : Primitives p) : List prims.AdrsKey :=
-  prims.encodeTargets p.d1WotsChainAddresses
+def d1WotsPreTweaks (prims : Primitives p) (messageAt : ℕ → prims.Y) : List prims.AdrsKey :=
+  prims.encodeTargets (p.d1WotsPreAddresses prims.core messageAt)
 
-def d1WotsTcrTweaks (prims : Primitives p) : List prims.AdrsKey :=
-  prims.encodeTargets p.d1WotsTcrAddresses
+def d1WotsTcrTweakSpace (prims : Primitives p) : List prims.AdrsKey :=
+  prims.encodeTargets p.d1WotsTcrAddressSpace
 
 def d1WotsPkTweaks (prims : Primitives p) : List prims.AdrsKey :=
   prims.encodeTargets p.d1WotsPkAddresses
@@ -151,21 +189,17 @@ def d1XmssTreeTweaks (prims : Primitives p) : List prims.AdrsKey :=
     prims.d1ForsTreeTweaks.length = p.d1TargetProfile.forsTree := by
   simp [d1ForsTreeTweaks, encodeTargets]
 
-@[simp] theorem d1WotsTcrTweaks_length (prims : Primitives p) :
-    prims.d1WotsTcrTweaks.length = p.d1TargetProfile.wotsTcr := by
-  simp [d1WotsTcrTweaks, encodeTargets]
+theorem d1WotsTcrTweakSpace_length_le (prims : Primitives p) :
+    prims.d1WotsTcrTweakSpace.length ≤ p.d1TargetProfile.wotsTcr := by
+  simpa [d1WotsTcrTweakSpace, encodeTargets] using p.d1WotsTcrAddressSpace_length_le
 
 @[simp] theorem d1ForsRootsTweaks_length (prims : Primitives p) :
     prims.d1ForsRootsTweaks.length = p.d1TargetProfile.forsRoots := by
   simp [d1ForsRootsTweaks, encodeTargets]
 
-@[simp] theorem d1WotsChainTweaks_length (prims : Primitives p) :
-    prims.d1WotsChainTweaks.length = p.d1TargetProfile.wotsUd := by
-  simp [d1WotsChainTweaks, encodeTargets]
-
-@[simp] theorem d1WotsChainTweaks_length_pre (prims : Primitives p) :
-    prims.d1WotsChainTweaks.length = p.d1TargetProfile.wotsPre := by
-  simp [d1WotsChainTweaks, encodeTargets]
+theorem d1WotsPreTweaks_length_le (prims : Primitives p) (messageAt : ℕ → prims.Y) :
+    (prims.d1WotsPreTweaks messageAt).length ≤ p.d1TargetProfile.wotsPre := by
+  simpa [d1WotsPreTweaks, encodeTargets] using p.d1WotsPreAddresses_length_le prims.core messageAt
 
 @[simp] theorem d1WotsPkTweaks_length (prims : Primitives p) :
     prims.d1WotsPkTweaks.length = p.d1TargetProfile.wotsPk := by

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -138,6 +138,46 @@ theorem d1WotsPreAddresses_length_le (p : Params) (core : CorePrimitives p)
     _ = p.d1TargetProfile.wotsPre := by
       simp [d1TargetProfile, d1LeafCount]
 
+/-- Every message-dependent WOTS PRE transcript is structurally duplicate-free before concrete
+address compression.  Even though the selected hash step depends on the message, the leaf and
+chain words already identify each possible entry. -/
+theorem d1WotsPreAddresses_nodup (p : Params) (core : CorePrimitives p)
+    (messageAt : ℕ → core.Y) :
+    (p.d1WotsPreAddresses core messageAt).Nodup := by
+  let coords := (List.range p.d1LeafCount).product (List.range p.len)
+  let encode : ℕ × ℕ → Option Adrs := fun c =>
+    let digit := chainStepsCore core (messageAt c.1) c.2
+    if digit = 0 then none else
+      some ((wotsChainAdrs (wotsLeafAdrs Adrs.zero c.1) c.2).setHashAddress (digit - 1))
+  have hcoords : coords.Nodup := List.nodup_range.product List.nodup_range
+  have hunique : ∀ a a' b, b ∈ encode a → b ∈ encode a' → a = a' := by
+    intro a a' b hb hb'
+    simp only [encode] at hb hb'
+    split at hb <;> simp_all only [Option.not_mem_none, Option.mem_some_iff]
+    split at hb' <;> simp_all only [Option.not_mem_none, Option.mem_some_iff]
+    subst hb
+    have hadrs := hb'
+    apply Prod.ext
+    · simpa [wotsChainAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress,
+        Adrs.setHashAddress, Adrs.setChainAddress, Adrs.setKeyPairAddress,
+        Adrs.setTypeAndClear, Adrs.zero] using (congrArg Adrs.word1 hadrs).symm
+    · simpa [wotsChainAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress,
+        Adrs.setHashAddress, Adrs.setChainAddress, Adrs.setKeyPairAddress,
+        Adrs.setTypeAndClear, Adrs.zero] using (congrArg Adrs.word2 hadrs).symm
+  have hencoded := hcoords.filterMap hunique
+  rw [List.filterMap_eq_flatMap_toList] at hencoded
+  have hencode_toList : ∀ c : ℕ × ℕ,
+      (encode c).toList =
+        (let digit := chainStepsCore core (messageAt c.1) c.2
+         if digit = 0 then [] else
+           [(wotsChainAdrs (wotsLeafAdrs Adrs.zero c.1) c.2).setHashAddress (digit - 1)]) := by
+    intro c
+    simp only [encode]
+    split <;> simp_all
+  simp_rw [hencode_toList] at hencoded
+  simpa [coords, encode, List.product, d1WotsPreAddresses, List.flatMap_map,
+    List.flatMap_assoc, Function.comp_def] using hencoded
+
 theorem d1WotsTcrAddressSpace_length_le (p : Params) :
     p.d1WotsTcrAddressSpace.length ≤ p.d1TargetProfile.wotsTcr := by
   simp only [d1WotsTcrAddressSpace, List.length_flatMap, List.length_map,
@@ -151,6 +191,33 @@ theorem d1WotsTcrAddressSpace_length_le (p : Params) :
       (Nat.mul_assoc _ _ _).symm
     _ ≤ (p.d1LeafCount * p.len) * p.w :=
       Nat.mul_le_mul_left _ (Nat.sub_le p.w 1)
+
+/-- The complete reachable WOTS chain-step space is structurally duplicate-free before address
+compression.  Its three varying words recover `(leaf, chain, step)` exactly. -/
+theorem d1WotsTcrAddressSpace_nodup (p : Params) :
+    p.d1WotsTcrAddressSpace.Nodup := by
+  let coords :=
+    ((List.range p.d1LeafCount).product (List.range p.len)).product
+      (List.range (p.w - 1))
+  have hcoords : coords.Nodup :=
+    (List.nodup_range.product List.nodup_range).product List.nodup_range
+  have hinj : Function.Injective (fun c : (ℕ × ℕ) × ℕ =>
+      (wotsChainAdrs (wotsLeafAdrs Adrs.zero c.1.1) c.1.2).setHashAddress c.2) := by
+    intro c d h
+    apply Prod.ext
+    · apply Prod.ext
+      · simpa [wotsChainAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress,
+          Adrs.setHashAddress, Adrs.setChainAddress, Adrs.setKeyPairAddress,
+          Adrs.setTypeAndClear, Adrs.zero] using congrArg Adrs.word1 h
+      · simpa [wotsChainAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress,
+          Adrs.setHashAddress, Adrs.setChainAddress, Adrs.setKeyPairAddress,
+          Adrs.setTypeAndClear, Adrs.zero] using congrArg Adrs.word2 h
+    · simpa [wotsChainAdrs, wotsLeafAdrs, Adrs.getKeyPairAddress,
+        Adrs.setHashAddress, Adrs.setChainAddress, Adrs.setKeyPairAddress,
+        Adrs.setTypeAndClear, Adrs.zero] using congrArg Adrs.word3 h
+  have hmapped := hcoords.map hinj
+  simpa [coords, List.product, d1WotsTcrAddressSpace, List.map_flatMap,
+    List.flatMap_map, List.flatMap_assoc, List.map_map, Function.comp_def] using hmapped
 
 @[simp] theorem d1WotsPkAddresses_length (p : Params) :
     p.d1WotsPkAddresses.length = p.d1TargetProfile.wotsPk := by

--- a/HashSig/SLHDSA/Security/Targets.lean
+++ b/HashSig/SLHDSA/Security/Targets.lean
@@ -181,6 +181,25 @@ def d1WotsPkTweaks (prims : Primitives p) : List prims.AdrsKey :=
 def d1XmssTreeTweaks (prims : Primitives p) : List prims.AdrsKey :=
   prims.encodeTargets p.d1XmssTreeAddresses
 
+/-- Concrete address-encoding side condition for the target-selection phases of the `d = 1`
+reductions.  The tweakable-hash games require distinct target tweaks, while `adrsToKey` need not
+be globally injective (the SHA instantiation deliberately truncates ADRS).  Consequently the
+right condition is `Nodup` on each reachable target family, including every message-dependent
+WOTS PRE transcript, rather than a false global injectivity assumption.
+
+The WOTS TCR field is stated for the whole reachable chain-step space, so it also covers every
+message-dependent subsequence selected by the reduction.  Cross-disjointness from collection
+queries remains a property of each concrete reduction transcript and is checked by the games'
+final-validity monitor. -/
+structure D1TargetTweakSeparation (prims : Primitives p) : Prop where
+  forsLeaf : prims.d1ForsLeafTweaks.Nodup
+  forsTree : prims.d1ForsTreeTweaks.Nodup
+  forsRoots : prims.d1ForsRootsTweaks.Nodup
+  wotsPre : ∀ messageAt : ℕ → prims.Y, (prims.d1WotsPreTweaks messageAt).Nodup
+  wotsTcr : prims.d1WotsTcrTweakSpace.Nodup
+  wotsPk : prims.d1WotsPkTweaks.Nodup
+  xmssTree : prims.d1XmssTreeTweaks.Nodup
+
 @[simp] theorem d1ForsLeafTweaks_length (prims : Primitives p) :
     prims.d1ForsLeafTweaks.length = p.d1TargetProfile.forsLeaf := by
   simp [d1ForsLeafTweaks, encodeTargets]

--- a/HashSig/SLHDSA/Wots.lean
+++ b/HashSig/SLHDSA/Wots.lean
@@ -46,6 +46,19 @@ variable {p : Params}
 theorem Params.w_pos (p : Params) : 0 < p.w := by
   unfold Params.w; positivity
 
+/-- A positive Winternitz bit width gives the nondegenerate base required by the checksum
+incomparability theorem. -/
+theorem Params.one_lt_w (p : Params) (hlgw : 0 < p.lgw) : 1 < p.w := by
+  unfold Params.w
+  exact Nat.one_lt_pow (Nat.ne_of_gt hlgw) Nat.one_lt_two
+
+/-- The FIPS definition `len2 = log_w (len1 * (w - 1)) + 1` has enough digits to encode the
+largest checksum. -/
+theorem Params.checksum_lt_w_pow_len2 (p : Params) (hlgw : 0 < p.lgw) :
+    p.len1 * (p.w - 1) < p.w ^ p.len2 := by
+  simpa [Params.len2, Nat.succ_eq_add_one] using
+    Nat.lt_pow_succ_log_self (p.one_lt_w hlgw) (p.len1 * (p.w - 1))
+
 /-! ### The hash chain (FIPS 205 Algorithm 5) -/
 
 /-- Low-level callback-parametric implementation of the WOTS+ chain. -/
@@ -141,10 +154,35 @@ implementation-independent context. -/
 def wotsMsgDigitsCore (core : CorePrimitives p) (msg : core.Y) : List ℕ :=
   base2b (core.yToBytes msg).toList p.lgw p.len1
 
+@[simp] theorem wotsMsgDigitsCore_length (core : CorePrimitives p) (msg : core.Y) :
+    (wotsMsgDigitsCore core msg).length = p.len1 := by
+  simp [wotsMsgDigitsCore]
+
+/-- Each message digit is in the Winternitz range. -/
+theorem wotsMsgDigitsCore_mem_lt (core : CorePrimitives p) (msg : core.Y) :
+    ∀ d ∈ wotsMsgDigitsCore core msg, d < p.w := by
+  simpa [wotsMsgDigitsCore, Params.w] using
+    base2b_lt (core.yToBytes msg).toList p.lgw p.len1
+
 /-- The full step-count list: message digits followed by the base-`w` checksum digits; length
 `len`, computed from the implementation-independent context. -/
 def chainLengthsCore (core : CorePrimitives p) (msg : core.Y) : List ℕ :=
   wotsFullDigits (wotsMsgDigitsCore core msg) p.w p.len1 p.len2
+
+/-- Scheme-level checksum incomparability.  Distinct WOTS message-digit encodings cannot be
+advanced componentwise in either direction.  This instantiates the abstract checksum theorem
+with the exact `Params.len1`/`Params.len2` formulas used by the executable WOTS code. -/
+theorem chainLengthsCore_incomparable_of_msgDigits_ne (core : CorePrimitives p)
+    (msg₁ msg₂ : core.Y) (hlgw : 0 < p.lgw)
+    (hne : wotsMsgDigitsCore core msg₁ ≠ wotsMsgDigitsCore core msg₂) :
+    ¬ WotsChecksum.Forall₂ (· ≤ ·) (chainLengthsCore core msg₁)
+        (chainLengthsCore core msg₂) ∧
+      ¬ WotsChecksum.Forall₂ (· ≤ ·) (chainLengthsCore core msg₂)
+        (chainLengthsCore core msg₁) := by
+  exact WotsChecksum.wots_fullDigits_incomparable p.w_pos
+    (wotsMsgDigitsCore_length core msg₁) (wotsMsgDigitsCore_length core msg₂)
+    (wotsMsgDigitsCore_mem_lt core msg₁) (wotsMsgDigitsCore_mem_lt core msg₂)
+    (p.checksum_lt_w_pow_len2 hlgw) hne
 
 /-- Every entry of `chainLengthsCore` is a genuine base-`w` digit (`< w`). -/
 theorem chainLengthsCore_mem_lt (core : CorePrimitives p) (msg : core.Y) :

--- a/HashSig/SLHDSA/Wots.lean
+++ b/HashSig/SLHDSA/Wots.lean
@@ -154,6 +154,13 @@ implementation-independent context. -/
 def wotsMsgDigitsCore (core : CorePrimitives p) (msg : core.Y) : List ℕ :=
   base2b (core.yToBytes msg).toList p.lgw p.len1
 
+/-- Structural encoding condition needed by the WOTS EUF reduction: distinct node messages must
+produce distinct message-digit vectors.  This is automatic for the supported byte-vector
+instantiation with its full-width base-`w` encoding, but it is not a consequence of the bare
+`CorePrimitives` carrier and therefore must be stated explicitly in generic security theorems. -/
+def CorePrimitives.WotsMessageEncodingInjective (core : CorePrimitives p) : Prop :=
+  Function.Injective (wotsMsgDigitsCore core)
+
 @[simp] theorem wotsMsgDigitsCore_length (core : CorePrimitives p) (msg : core.Y) :
     (wotsMsgDigitsCore core msg).length = p.len1 := by
   simp [wotsMsgDigitsCore]
@@ -183,6 +190,16 @@ theorem chainLengthsCore_incomparable_of_msgDigits_ne (core : CorePrimitives p)
     (wotsMsgDigitsCore_length core msg₁) (wotsMsgDigitsCore_length core msg₂)
     (wotsMsgDigitsCore_mem_lt core msg₁) (wotsMsgDigitsCore_mem_lt core msg₂)
     (p.checksum_lt_w_pow_len2 hlgw) hne
+
+/-- Message-level form consumed by a WOTS reduction.  The encoding side condition turns distinct
+node values into the digit inequality needed by checksum incomparability. -/
+theorem chainLengthsCore_incomparable (core : CorePrimitives p) (msg₁ msg₂ : core.Y)
+    (hlgw : 0 < p.lgw) (henc : core.WotsMessageEncodingInjective) (hne : msg₁ ≠ msg₂) :
+    ¬ WotsChecksum.Forall₂ (· ≤ ·) (chainLengthsCore core msg₁)
+        (chainLengthsCore core msg₂) ∧
+      ¬ WotsChecksum.Forall₂ (· ≤ ·) (chainLengthsCore core msg₂)
+        (chainLengthsCore core msg₁) :=
+  chainLengthsCore_incomparable_of_msgDigits_ne core msg₁ msg₂ hlgw (henc.ne hne)
 
 /-- Every entry of `chainLengthsCore` is a genuine base-`w` digit (`< w`). -/
 theorem chainLengthsCore_mem_lt (core : CorePrimitives p) (msg : core.Y) :

--- a/HashSigTest/SLHDSA/Scheme.lean
+++ b/HashSigTest/SLHDSA/Scheme.lean
@@ -40,16 +40,69 @@ example (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
         return (R, forsSig, htSig)) := by
   rfl
 
-/-- Verification performs `H_msg`, FORS recovery, and hypertree recovery/comparison in order. -/
+/-- Verification first rejects malformed authentication-path lengths, then performs `H_msg`,
+FORS recovery, and hypertree recovery/comparison in order. -/
 example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
     (pk : PublicKeyCore core) :
-    (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool) = (do
-      let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
-      let idxLeaf := (splitDigest p digest).2
-      let md := (splitDigest p digest).1
-      let fAdrs := forsAdrsOf idxLeaf
-      let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
-      htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot) := by
+    (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool) =
+      if sig.IsWellFormed then do
+        let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
+        let idxLeaf := (splitDigest p digest).2
+        let md := (splitDigest p digest).1
+        let fAdrs := forsAdrsOf idxLeaf
+        let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
+        htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot
+      else
+        pure false := by
   rfl
+
+/-- Replace the `d = 1` XMSS authentication path by the empty list. -/
+def withEmptyXmssAuthPath (sig : SignatureCore p core) : SignatureCore p core :=
+  (sig.1, sig.2.1, (sig.2.2.1, []))
+
+/-- Emptying a positive-height XMSS path violates the fixed signature format. -/
+theorem withEmptyXmssAuthPath_not_isWellFormed (sig : SignatureCore p core)
+    (hhp : p.hp ≠ 0) : ¬ (withEmptyXmssAuthPath core sig).IsWellFormed := by
+  intro hformat
+  apply hhp
+  simpa [withEmptyXmssAuthPath] using hformat.2.symm
+
+/-- Replace one FORS authentication path by the empty list. -/
+def withEmptyForsAuthPath (sig : SignatureCore p core) (target : Fin p.k) :
+    SignatureCore p core :=
+  let forsSig := Vector.ofFn fun i : Fin p.k =>
+    if i = target then ((sig.2.1[i.val]).1, []) else sig.2.1[i.val]
+  (sig.1, forsSig, sig.2.2)
+
+/-- Emptying one positive-height FORS path violates the fixed signature format. -/
+theorem withEmptyForsAuthPath_not_isWellFormed (sig : SignatureCore p core)
+    (target : Fin p.k) (ha : p.a ≠ 0) :
+    ¬ (withEmptyForsAuthPath core sig target).IsWellFormed := by
+  intro hformat
+  apply ha
+  have htarget := hformat.1 target
+  simpa [withEmptyForsAuthPath] using htarget.symm
+
+/-- The format guard rejects a malformed XMSS path without reaching `H_msg`. -/
+example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
+    (pk : PublicKeyCore core) (hhp : p.hp ≠ 0) :
+    slhVerifyInternalM core msg (withEmptyXmssAuthPath core sig) pk =
+      (pure false : OracleComp (publicHashSpec core) Bool) := by
+  exact slhVerifyInternalM_of_not_isWellFormed core msg _ pk
+    (withEmptyXmssAuthPath_not_isWellFormed core sig hhp)
+
+/-- The same format guard rejects a malformed FORS path before reaching `H_msg`. -/
+example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
+    (pk : PublicKeyCore core) (target : Fin p.k) (ha : p.a ≠ 0) :
+    slhVerifyInternalM core msg (withEmptyForsAuthPath core sig target) pk =
+      (pure false : OracleComp (publicHashSpec core) Bool) := by
+  exact slhVerifyInternalM_of_not_isWellFormed core msg _ pk
+    (withEmptyForsAuthPath_not_isWellFormed core sig target ha)
+
+/-- Honest signing always produces the fixed authentication-path lengths. -/
+example (prims : Primitives p) (msg : List Byte) (sk : SecretKeyCore prims.core)
+    (addrnd : prims.Y) :
+    (slhSignInternal prims msg sk addrnd).IsWellFormed :=
+  slhSignInternal_isWellFormed prims msg sk addrnd
 
 end SLHDSA.SchemeTest

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -54,6 +54,7 @@ public import VCVio.CryptoFoundations.HardnessAssumptions.NoisyLearning
 public import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.OpenPREFromTCRDSPR
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTOpenPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -59,6 +59,7 @@ public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTOpenPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTUDC
 public import VCVio.CryptoFoundations.HashCommitment
 public import VCVio.CryptoFoundations.IdenSchemeWithAbort
 public import VCVio.CryptoFoundations.KEMDEM

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -55,6 +55,7 @@ public import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTOpenPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
 public import VCVio.CryptoFoundations.HashCommitment

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -46,10 +46,10 @@ public import VCVio.CryptoFoundations.FujisakiOkamoto.TTransform
 public import VCVio.CryptoFoundations.FujisakiOkamoto.UTransform
 public import VCVio.CryptoFoundations.GPVHashAndSign
 public import VCVio.CryptoFoundations.HardnessAssumptions.CollisionResistance
-public import VCVio.CryptoFoundations.HardnessAssumptions.KeyedHash.ITSR
 public import VCVio.CryptoFoundations.HardnessAssumptions.DiffieHellman
 public import VCVio.CryptoFoundations.HardnessAssumptions.EntropySmoothing
 public import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
+public import VCVio.CryptoFoundations.HardnessAssumptions.KeyedHash.ITSR
 public import VCVio.CryptoFoundations.HardnessAssumptions.NoisyLearning
 public import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -53,6 +53,8 @@ public import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
 public import VCVio.CryptoFoundations.HardnessAssumptions.NoisyLearning
 public import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
 public import VCVio.CryptoFoundations.HashCommitment

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -46,6 +46,7 @@ public import VCVio.CryptoFoundations.FujisakiOkamoto.TTransform
 public import VCVio.CryptoFoundations.FujisakiOkamoto.UTransform
 public import VCVio.CryptoFoundations.GPVHashAndSign
 public import VCVio.CryptoFoundations.HardnessAssumptions.CollisionResistance
+public import VCVio.CryptoFoundations.HardnessAssumptions.KeyedHash.ITSR
 public import VCVio.CryptoFoundations.HardnessAssumptions.DiffieHellman
 public import VCVio.CryptoFoundations.HardnessAssumptions.EntropySmoothing
 public import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation

--- a/VCVio/CryptoFoundations/HardnessAssumptions/KeyedHash/ITSR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/KeyedHash/ITSR.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.CollisionResistance
+
+/-!
+# Interleaved target subset resilience
+
+Interleaved target subset resilience (ITSR) is the exact keyed-hash property used for the
+SPHINCS+/SLH-DSA message-compression hop.  The adversary may interleave its own computation with
+target queries.  A target query on `x` samples a fresh key `k`, records `(k, x)`, and returns `k`.
+The adversary wins with a fresh pair `(k⋆, x⋆)` when every semantic index selected by its hash
+output already occurs among the indices selected by the recorded targets.
+
+Freshness is pair freshness: reusing an input with a newly supplied key or reusing a key with a new
+input is not automatically excluded.  This matches the source game and is important for the
+SLH-DSA reduction, where the sampled key is the per-message randomizer produced by the idealized
+`PRF_msg`.
+
+## References
+
+* Barbosa, Dupressoir, Hülsing, Meijers, and Strub, “A Tight Security Proof for SPHINCS+,
+  Formally Verified”, `KeyedHashFunctions.eca`, ITSR.
+* Hülsing and Kudinov, “Recovering the Tight Security Proof of SPHINCS+”.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec ENNReal
+open CollisionResistance
+
+namespace KeyedHash
+
+variable {K X Y Index : Type}
+
+/-- A keyed hash family together with the semantic-index map used by the subset relation. -/
+structure ITSRProblem (K X Y Index : Type) where
+  khf : KeyedHashFamily K X Y
+  indices : Y → List Index
+
+/-- Target oracle: an input is answered with a freshly sampled key. -/
+abbrev ITSRTargetSpec (X K : Type) : OracleSpec X := X →ₒ K
+
+/-- Target transcript in issue order. -/
+abbrev ITSRTranscript (K X : Type) := List (K × X)
+
+/-- An ITSR adversary interleaves private uniform randomness and target queries before returning
+its candidate pair. -/
+structure ITSRAdversary (prob : ITSRProblem K X Y Index) where
+  main : OracleComp (unifSpec + ITSRTargetSpec X K) (K × X)
+
+/-- The semantic indices selected by one keyed-hash input. -/
+def ITSRProblem.indexSet (prob : ITSRProblem K X Y Index) (kx : K × X) : List Index :=
+  prob.indices (prob.khf.hash kx.1 kx.2)
+
+/-- The combined semantic indices selected by all recorded targets. -/
+def ITSRProblem.targetIndexSet (prob : ITSRProblem K X Y Index)
+    (targets : ITSRTranscript K X) : List Index :=
+  targets.flatMap prob.indexSet
+
+/-- Source-game winning relation: the candidate pair is fresh and its selected indices form a
+subset of the indices selected by the target transcript. -/
+def ITSRProblem.Wins [DecidableEq K] [DecidableEq X] [DecidableEq Index]
+    (prob : ITSRProblem K X Y Index) (targets : ITSRTranscript K X) (candidate : K × X) : Prop :=
+  candidate ∉ targets ∧ ∀ i ∈ prob.indexSet candidate, i ∈ prob.targetIndexSet targets
+
+instance [DecidableEq K] [DecidableEq X] [DecidableEq Index]
+    (prob : ITSRProblem K X Y Index) (targets : ITSRTranscript K X) (candidate : K × X) :
+    Decidable (prob.Wins targets candidate) := by
+  unfold ITSRProblem.Wins ITSRProblem.indexSet ITSRProblem.targetIndexSet
+  infer_instance
+
+/-- Target-oracle implementation.  Every query samples and records a fresh key; targets are not
+deduplicated, since the final relation—not the oracle—determines success. -/
+def ITSRTargetOracle (prob : ITSRProblem K X Y Index) :
+    QueryImpl (ITSRTargetSpec X K) (StateT (ITSRTranscript K X) ProbComp) :=
+  fun x => do
+    let k ← (monadLift prob.khf.keygen : StateT (ITSRTranscript K X) ProbComp K)
+    modify fun targets => targets ++ [(k, x)]
+    return k
+
+/-- Combined private-randomness and target handler. -/
+def ITSROracles (prob : ITSRProblem K X Y Index) :
+    QueryImpl (unifSpec + ITSRTargetSpec X K) (StateT (ITSRTranscript K X) ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT (ITSRTranscript K X) ProbComp) +
+    ITSRTargetOracle prob
+
+/-- ITSR experiment. -/
+noncomputable def ITSRExperiment [DecidableEq K] [DecidableEq X] [DecidableEq Index]
+    {prob : ITSRProblem K X Y Index} (adv : ITSRAdversary prob) : ProbComp Bool := do
+  let (candidate, targets) ← (simulateQ (ITSROracles prob) adv.main).run []
+  return decide (prob.Wins targets candidate)
+
+/-- ITSR success probability. -/
+noncomputable def ITSRAdvantage [DecidableEq K] [DecidableEq X] [DecidableEq Index]
+    {prob : ITSRProblem K X Y Index} (adv : ITSRAdversary prob) : ℝ≥0∞ :=
+  Pr[= true | ITSRExperiment adv]
+
+@[simp] theorem ITSRTargetOracle_run (prob : ITSRProblem K X Y Index)
+    (x : X) (targets : ITSRTranscript K X) :
+    (ITSRTargetOracle prob x).run targets =
+      prob.khf.keygen >>= fun k => pure (k, targets ++ [(k, x)]) := by
+  simp [ITSRTargetOracle]
+
+end KeyedHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
@@ -113,7 +113,6 @@ theorem finalValidityInvariant_initial (numTargets : ℕ) (tweakOf : Q → Tweak
     FinalValidityInvariant numTargets tweakOf (.initial : FinalValidityState Q Tweak) := by
   simp [FinalValidityInvariant, FinalValidityState.initial, FinalValidBool]
 
-set_option linter.flexible false in
 /-- Recording a target query preserves exact correspondence between the poison bit and the source
 final predicate. -/
 theorem FinalValidityInvariant.recordTarget (numTargets : ℕ) (tweakOf : Q → Tweak)
@@ -124,23 +123,32 @@ theorem FinalValidityInvariant.recordTarget (numTargets : ℕ) (tweakOf : Q → 
   simp only [FinalValidityInvariant, FinalValidityState.recordTarget] at hinv ⊢
   rw [hinv]
   apply Bool.eq_iff_iff.mpr
-  simp [FinalValidBool, TweakFresh, TweakReserved, List.nodup_append]
-  constructor
-  · rintro ⟨⟨⟨⟨hlen, hnodup⟩, hdisjoint⟩, hlt⟩, hfresh, hnotColl⟩
-    refine ⟨⟨hlt, hnodup, hfresh⟩, ?_⟩
-    intro a ha b hb
-    rcases ha with ⟨x, hx, rfl⟩ | rfl
-    · exact hdisjoint x hx b hb
-    · intro heq
-      exact hnotColl (heq ▸ hb)
-  · rintro ⟨⟨hlt, hnodup, hfresh⟩, hdisjoint⟩
-    refine ⟨⟨⟨⟨Nat.le_of_lt hlt, hnodup⟩, ?_⟩, hlt⟩, hfresh, ?_⟩
-    · intro x hx b hb
-      exact hdisjoint (tweakOf x) (Or.inl ⟨x, hx, rfl⟩) b hb
-    · intro hmem
-      exact hdisjoint (tweakOf q) (Or.inr rfl) (tweakOf q) hmem rfl
+  have hcore :
+      ((((challenges.length ≤ numTargets ∧ (challenges.map tweakOf).Nodup) ∧
+          ∀ a ∈ challenges, ∀ b ∈ collectionTweaks, tweakOf a ≠ b) ∧
+          challenges.length < numTargets) ∧
+        (∀ x ∈ challenges, tweakOf x ≠ tweakOf q) ∧
+          tweakOf q ∉ collectionTweaks) ↔
+        ((challenges.length < numTargets ∧ (challenges.map tweakOf).Nodup ∧
+            ∀ x ∈ challenges, tweakOf x ≠ tweakOf q) ∧
+          ∀ a : Tweak, (∃ x ∈ challenges, tweakOf x = a) ∨ a = tweakOf q →
+            ∀ b ∈ collectionTweaks, a ≠ b) := by
+    constructor
+    · rintro ⟨⟨⟨⟨hlen, hnodup⟩, hdisjoint⟩, hlt⟩, hfresh, hnotColl⟩
+      refine ⟨⟨hlt, hnodup, hfresh⟩, ?_⟩
+      intro a ha b hb
+      rcases ha with ⟨x, hx, rfl⟩ | rfl
+      · exact hdisjoint x hx b hb
+      · intro heq
+        exact hnotColl (heq ▸ hb)
+    · rintro ⟨⟨hlt, hnodup, hfresh⟩, hdisjoint⟩
+      refine ⟨⟨⟨⟨Nat.le_of_lt hlt, hnodup⟩, ?_⟩, hlt⟩, hfresh, ?_⟩
+      · intro x hx b hb
+        exact hdisjoint (tweakOf x) (Or.inl ⟨x, hx, rfl⟩) b hb
+      · intro hmem
+        exact hdisjoint (tweakOf q) (Or.inr rfl) (tweakOf q) hmem rfl
+  simpa [FinalValidBool, TweakFresh, TweakReserved, List.nodup_append] using hcore
 
-set_option linter.flexible false in
 /-- Recording a collection query preserves exact correspondence between the poison bit and the
 source final predicate. -/
 theorem FinalValidityInvariant.recordCollection (numTargets : ℕ) (tweakOf : Q → Tweak)
@@ -151,20 +159,27 @@ theorem FinalValidityInvariant.recordCollection (numTargets : ℕ) (tweakOf : Q 
   simp only [FinalValidityInvariant, FinalValidityState.recordCollection] at hinv ⊢
   rw [hinv]
   apply Bool.eq_iff_iff.mpr
-  simp [FinalValidBool, TweakReserved]
-  constructor
-  · rintro ⟨⟨⟨hlen, hnodup⟩, hdisjoint⟩, hunreserved⟩
-    refine ⟨⟨hlen, hnodup⟩, ?_⟩
-    intro x hx b hb
-    rcases hb with hb | rfl
-    · exact hdisjoint x hx b hb
-    · exact hunreserved x hx
-  · rintro ⟨⟨hlen, hnodup⟩, hdisjoint⟩
-    refine ⟨⟨⟨hlen, hnodup⟩, ?_⟩, ?_⟩
-    · intro x hx b hb
-      exact hdisjoint x hx b (Or.inl hb)
-    · intro x hx
-      exact hdisjoint x hx t (Or.inr rfl)
+  have hcore :
+      (((challenges.length ≤ numTargets ∧ (challenges.map tweakOf).Nodup) ∧
+          ∀ a ∈ challenges, ∀ b ∈ collectionTweaks, tweakOf a ≠ b) ∧
+        ∀ x ∈ challenges, tweakOf x ≠ t) ↔
+        ((challenges.length ≤ numTargets ∧ (challenges.map tweakOf).Nodup) ∧
+          ∀ a ∈ challenges, ∀ b : Tweak, (b ∈ collectionTweaks ∨ b = t) →
+            tweakOf a ≠ b) := by
+    constructor
+    · rintro ⟨⟨⟨hlen, hnodup⟩, hdisjoint⟩, hunreserved⟩
+      refine ⟨⟨hlen, hnodup⟩, ?_⟩
+      intro x hx b hb
+      rcases hb with hb | rfl
+      · exact hdisjoint x hx b hb
+      · exact hunreserved x hx
+    · rintro ⟨⟨hlen, hnodup⟩, hdisjoint⟩
+      refine ⟨⟨⟨hlen, hnodup⟩, ?_⟩, ?_⟩
+      · intro x hx b hb
+        exact hdisjoint x hx b (Or.inl hb)
+      · intro x hx
+        exact hdisjoint x hx t (Or.inr rfl)
+  simpa [FinalValidBool, TweakReserved] using hcore
 
 end Correspondence
 

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
@@ -40,6 +40,35 @@ structure FinalValidityState (Q Tweak : Type) where
 /-- The initially valid empty final-validity state. -/
 def FinalValidityState.initial : FinalValidityState Q Tweak := ⟨[], [], true⟩
 
+/-- The explicit final predicate used by the EasyCrypt/BDHMS games: no more than `numTargets`
+targets, pairwise-distinct target tweaks, and no target tweak used by the collection oracle. -/
+def FinalValid (numTargets : ℕ) (tweakOf : Q → Tweak) (st : FinalValidityState Q Tweak) : Prop :=
+  st.challenges.length ≤ numTargets ∧
+    (st.challenges.map tweakOf).Nodup ∧
+    (st.challenges.map tweakOf).Disjoint st.collectionTweaks
+
+instance [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) : Decidable (FinalValid numTargets tweakOf st) :=
+  decidable_of_iff
+    (st.challenges.length ≤ numTargets ∧
+      (st.challenges.map tweakOf).Nodup ∧
+      ∀ a ∈ st.challenges.map tweakOf, ∀ b ∈ st.collectionTweaks, a ≠ b)
+    (and_congr Iff.rfl (and_congr Iff.rfl List.disjoint_iff_ne.symm))
+
+/-- Executable form of `FinalValid`. The disjointness conjunct is expanded elementwise so the
+decision procedure is explicit and stable. -/
+def FinalValidBool [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) : Bool :=
+  decide (st.challenges.length ≤ numTargets) &&
+    decide (st.challenges.map tweakOf).Nodup &&
+    decide (∀ a ∈ st.challenges.map tweakOf, ∀ b ∈ st.collectionTweaks, a ≠ b)
+
+/-- The monitor invariant: the sticky bit is exactly the decision procedure for the source final
+predicate, rather than merely a one-way soundness flag. -/
+def FinalValidityInvariant [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) : Prop :=
+  st.valid = FinalValidBool numTargets tweakOf st
+
 /-- Record a target query and poison the state if the target cap or tweak discipline is violated.
 The query is always recorded; hashing and returning its answer is the caller's responsibility. -/
 def FinalValidityState.recordTarget [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
@@ -57,6 +86,87 @@ def FinalValidityState.recordCollection [DecidableEq Tweak] (tweakOf : Q → Twe
   challenges := st.challenges
   collectionTweaks := st.collectionTweaks ++ [t]
   valid := st.valid && decide (¬TweakReserved tweakOf st.challenges t)
+
+/-! ## Correspondence to the source final predicate -/
+
+section Correspondence
+
+variable [DecidableEq Tweak]
+
+/-- The executable check recognizes exactly the source final predicate. -/
+theorem finalValidBool_eq_true_iff (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) :
+    FinalValidBool numTargets tweakOf st = true ↔ FinalValid numTargets tweakOf st := by
+  simp [FinalValidBool, FinalValid, List.disjoint_iff_ne]
+  tauto
+
+/-- Consequently, the invariant also has the literal `decide (FinalValid …)` form. -/
+theorem FinalValidityInvariant.eq_decide (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) (hinv : FinalValidityInvariant numTargets tweakOf st) :
+    st.valid = decide (FinalValid numTargets tweakOf st) := by
+  rw [hinv]
+  apply Bool.eq_iff_iff.mpr
+  simp [finalValidBool_eq_true_iff]
+
+/-- The initial monitor satisfies the exact source predicate. -/
+theorem finalValidityInvariant_initial (numTargets : ℕ) (tweakOf : Q → Tweak) :
+    FinalValidityInvariant numTargets tweakOf (.initial : FinalValidityState Q Tweak) := by
+  simp [FinalValidityInvariant, FinalValidityState.initial, FinalValidBool]
+
+set_option linter.flexible false in
+/-- Recording a target query preserves exact correspondence between the poison bit and the source
+final predicate. -/
+theorem FinalValidityInvariant.recordTarget (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) (q : Q)
+    (hinv : FinalValidityInvariant numTargets tweakOf st) :
+    FinalValidityInvariant numTargets tweakOf (st.recordTarget numTargets tweakOf q) := by
+  rcases st with ⟨challenges, collectionTweaks, valid⟩
+  simp only [FinalValidityInvariant, FinalValidityState.recordTarget] at hinv ⊢
+  rw [hinv]
+  apply Bool.eq_iff_iff.mpr
+  simp [FinalValidBool, TweakFresh, TweakReserved, List.nodup_append]
+  constructor
+  · rintro ⟨⟨⟨⟨hlen, hnodup⟩, hdisjoint⟩, hlt⟩, hfresh, hnotColl⟩
+    refine ⟨⟨hlt, hnodup, hfresh⟩, ?_⟩
+    intro a ha b hb
+    rcases ha with ⟨x, hx, rfl⟩ | rfl
+    · exact hdisjoint x hx b hb
+    · intro heq
+      exact hnotColl (heq ▸ hb)
+  · rintro ⟨⟨hlt, hnodup, hfresh⟩, hdisjoint⟩
+    refine ⟨⟨⟨⟨Nat.le_of_lt hlt, hnodup⟩, ?_⟩, hlt⟩, hfresh, ?_⟩
+    · intro x hx b hb
+      exact hdisjoint (tweakOf x) (Or.inl ⟨x, hx, rfl⟩) b hb
+    · intro hmem
+      exact hdisjoint (tweakOf q) (Or.inr rfl) (tweakOf q) hmem rfl
+
+set_option linter.flexible false in
+/-- Recording a collection query preserves exact correspondence between the poison bit and the
+source final predicate. -/
+theorem FinalValidityInvariant.recordCollection (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) (t : Tweak)
+    (hinv : FinalValidityInvariant numTargets tweakOf st) :
+    FinalValidityInvariant numTargets tweakOf (st.recordCollection tweakOf t) := by
+  rcases st with ⟨challenges, collectionTweaks, valid⟩
+  simp only [FinalValidityInvariant, FinalValidityState.recordCollection] at hinv ⊢
+  rw [hinv]
+  apply Bool.eq_iff_iff.mpr
+  simp [FinalValidBool, TweakReserved]
+  constructor
+  · rintro ⟨⟨⟨hlen, hnodup⟩, hdisjoint⟩, hunreserved⟩
+    refine ⟨⟨hlen, hnodup⟩, ?_⟩
+    intro x hx b hb
+    rcases hb with hb | rfl
+    · exact hdisjoint x hx b hb
+    · exact hunreserved x hx
+  · rintro ⟨⟨hlen, hnodup⟩, hdisjoint⟩
+    refine ⟨⟨⟨hlen, hnodup⟩, ?_⟩, ?_⟩
+    · intro x hx b hb
+      exact hdisjoint x hx b (Or.inl hb)
+    · intro x hx
+      exact hdisjoint x hx t (Or.inr rfl)
+
+end Correspondence
 
 /-- Final-validity collection queries return the member's digest directly: invalid queries poison
 the monitor but are never rejected. -/

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
+
+/-!
+# Final-validity monitoring for multi-target tweakable-hash games
+
+The EasyCrypt/BDHMS games answer and record every target and collection query, then require at the
+end that the target cap, distinct-target-tweak condition, and target/collection disjointness all
+hold. This file packages an equivalent sticky **poison bit** presentation: every query is still
+answered and recorded, while the first validity violation changes `valid` permanently to `false`.
+
+This is intentionally separate from `collectionOracle`, whose rejection-on-arrival semantics are a
+different adaptive experiment. A reduction may use the declarations below only when it is proving
+the source final-validity game or has a separate equivalence theorem.
+-/
+
+@[expose] public section
+
+namespace TweakableHash
+
+open OracleComp OracleSpec
+
+variable {ι PkSeed Tweak Y Q : Type}
+
+/-- Histories and sticky validity bit shared by a target oracle and a collection oracle. -/
+structure FinalValidityState (Q Tweak : Type) where
+  /-- Every target query, including queries issued after the game became invalid. -/
+  challenges : List Q
+  /-- Every collection tweak, including queries issued after the game became invalid. -/
+  collectionTweaks : List Tweak
+  /-- Sticky validity bit for the target cap and tweak-separation conditions. -/
+  valid : Bool
+
+/-- The initially valid empty final-validity state. -/
+def FinalValidityState.initial : FinalValidityState Q Tweak := ⟨[], [], true⟩
+
+/-- Record a target query and poison the state if the target cap or tweak discipline is violated.
+The query is always recorded; hashing and returning its answer is the caller's responsibility. -/
+def FinalValidityState.recordTarget [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) (q : Q) : FinalValidityState Q Tweak where
+  challenges := st.challenges ++ [q]
+  collectionTweaks := st.collectionTweaks
+  valid := st.valid && st.challenges.length < numTargets &&
+    decide (TweakFresh tweakOf st.challenges st.collectionTweaks (tweakOf q))
+
+/-- Record a collection tweak and poison the state if it was already reserved by a target query.
+Repeated collection tweaks are valid and remain recorded, exactly as in the source collection
+game. -/
+def FinalValidityState.recordCollection [DecidableEq Tweak] (tweakOf : Q → Tweak)
+    (st : FinalValidityState Q Tweak) (t : Tweak) : FinalValidityState Q Tweak where
+  challenges := st.challenges
+  collectionTweaks := st.collectionTweaks ++ [t]
+  valid := st.valid && decide (¬TweakReserved tweakOf st.challenges t)
+
+/-- Final-validity collection queries return the member's digest directly: invalid queries poison
+the monitor but are never rejected. -/
+abbrev finalValidityCollectionSpec (thColl : TweakableHashCollection ι PkSeed Tweak Y) :
+    OracleSpec ((i : ι) × Tweak × thColl.Msg i) :=
+  _ →ₒ Y
+
+/-- The always-answering collection oracle for final-validity games. -/
+def finalValidityCollectionOracle [DecidableEq Tweak] (tweakOf : Q → Tweak)
+    (thColl : TweakableHashCollection ι PkSeed Tweak Y) (pk : PkSeed) :
+    QueryImpl (finalValidityCollectionSpec thColl) (StateT (FinalValidityState Q Tweak) ProbComp) :=
+  fun q => do
+    let st ← get
+    set (st.recordCollection tweakOf q.2.1)
+    return thColl.eval q.1 pk q.2.1 q.2.2
+
+/-! ## Mutation-resistant semantic pins -/
+
+variable [DecidableEq Tweak] (tweakOf : Q → Tweak)
+  {st : FinalValidityState Q Tweak} {q : Q} {t : Tweak}
+
+/-- Target queries are still recorded after violating the cap; the validity bit is poisoned. -/
+theorem recordTarget_at_cap :
+    (st.recordTarget 0 tweakOf q).challenges = st.challenges ++ [q] ∧
+      (st.recordTarget 0 tweakOf q).valid = false := by
+  simp [FinalValidityState.recordTarget]
+
+/-- Repeating a collection tweak does not poison an otherwise valid state when no target reserved
+it. This would fail if collection tweaks were incorrectly required to be distinct. -/
+theorem recordCollection_repeated_of_unreserved (hvalid : st.valid = true)
+    (hunreserved : ¬TweakReserved tweakOf st.challenges t) :
+    ((st.recordCollection tweakOf t).recordCollection tweakOf t).valid = true := by
+  simp [FinalValidityState.recordCollection, hvalid, hunreserved]
+
+end TweakableHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/OpenPREFromTCRDSPR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/OpenPREFromTCRDSPR.lean
@@ -32,7 +32,7 @@ asserted here without that proof.
 
 namespace TweakableHash
 
-open OracleComp OracleSpec
+open OracleComp OracleSpec ENNReal
 
 variable {ι PkSeed Tweak M Y : Type}
 
@@ -121,5 +121,16 @@ noncomputable def SM_DT_OpenPRE_toDSPR [Inhabited M] [DecidableEq M]
       (simulateQ (SM_DT_OpenPRE_findOracles targets) (adv.find privateState pk ys)).run []
     let sampled := (targets[j]?.map Prod.snd).getD default
     return (j, decide (sampled ≠ m ∨ j ∈ opened))
+
+/-! ## Quantitative reduction target -/
+
+/-- The exact right-hand side of the source reduction, instantiated with the concrete adversaries
+above. `SM_DT_DSPR_Advantage` already contains the truncated `DSPR success - SPprob` subtraction.
+This definition fixes the theorem statement without pretending the counting proof is complete. -/
+noncomputable def SM_DT_OpenPRE_TCR_DSPR_Bound [Fintype M] [Inhabited M] [DecidableEq Tweak]
+    [DecidableEq M] [DecidableEq Y] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_OpenPRE_Adversary prob) : ℝ≥0∞ :=
+  SM_DT_DSPR_Advantage (SM_DT_OpenPRE_toDSPR adv) +
+    3 * SM_DT_TCR_Advantage (SM_DT_OpenPRE_toTCR adv)
 
 end TweakableHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/OpenPREFromTCRDSPR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/OpenPREFromTCRDSPR.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTOpenPRE
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
+
+/-!
+# Reduction adversaries from SM-DT-OpenPRE to DSPR and TCR
+
+This file formalizes the two concrete adversaries used by the EasyCrypt reduction
+`OpenPRE_From_TCR_DSPR_THF.eca`. Both run the OpenPRE adversary's commitment phase, keep precisely
+the bounded prefix of committed tweaks, sample the source problem's input distribution, and route
+the resulting targets through the assumption game's challenge oracle.
+
+The TCR reduction forwards the OpenPRE adversary's final index and candidate. The DSPR reduction
+guesses that a second preimage exists exactly when that candidate differs from the sampled target
+or when the selected target was opened. These are executable reductions, not just existential
+adversary placeholders. The quantitative inequality
+
+`OpenPRE ≤ (DSPR success - SPprob) + 3 · TCR`
+
+still requires the source proof's finite-preimage counting argument and is intentionally not
+asserted here without that proof.
+-/
+
+@[expose] public section
+
+namespace TweakableHash
+
+open OracleComp OracleSpec
+
+variable {ι PkSeed Tweak M Y : Type}
+
+/-- Route commitment-phase randomness and collection queries into an assumption game's larger
+selection interface, leaving its challenge oracle unavailable to the wrapped OpenPRE adversary. -/
+def SM_DT_OpenPRE_liftPick
+    (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) :
+    QueryImpl (unifSpec + finalValidityCollectionSpec prob.thColl)
+      (OracleComp (unifSpec + (SM_DT_TCR_challengeSpec Tweak M Y +
+        finalValidityCollectionSpec prob.thColl)))
+  | .inl q => liftM ((unifSpec + (SM_DT_TCR_challengeSpec Tweak M Y +
+      finalValidityCollectionSpec prob.thColl)).query (.inl q))
+  | .inr q => liftM ((unifSpec + (SM_DT_TCR_challengeSpec Tweak M Y +
+      finalValidityCollectionSpec prob.thColl)).query (.inr (.inr q)))
+
+/-! ## Assumption problems induced by an OpenPRE problem -/
+
+/-- The TCR problem attacked by the OpenPRE-to-TCR reduction. -/
+def SM_DT_OpenPRE_Problem.toTCR (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) :
+    SM_DT_TCR_Problem ι PkSeed Tweak M Y where
+  th := prob.th
+  thColl := prob.thColl
+  numTargets := prob.numTargets
+
+/-- The DSPR problem attacked by the OpenPRE-to-DSPR reduction. -/
+def SM_DT_OpenPRE_Problem.toDSPR (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) :
+    SM_DT_DSPR_Problem ι PkSeed Tweak M Y where
+  th := prob.th
+  thColl := prob.thColl
+  numTargets := prob.numTargets
+
+/-! ## Shared target setup -/
+
+/-- In an assumption game's selection phase, sample OpenPRE target inputs and submit them to that
+game's challenge oracle. The input list is already the bounded prefix. Returned data contains the
+sampled `(tweak, input)` targets needed to implement `open`, and the images shown to OpenPRE. -/
+noncomputable def SM_DT_OpenPRE_reductionInitialize
+    (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) :
+    List Tweak → OracleComp
+      (unifSpec + (SM_DT_TCR_challengeSpec Tweak M Y +
+        finalValidityCollectionSpec prob.thColl)) (List (Tweak × M) × List Y)
+  | [] => pure ([], [])
+  | t :: ts => do
+      let x ← liftM prob.inputGen
+      let y ← liftM ((unifSpec + (SM_DT_TCR_challengeSpec Tweak M Y +
+        finalValidityCollectionSpec prob.thColl)).query (.inr (.inl (t, x))))
+      let (targets, ys) ← SM_DT_OpenPRE_reductionInitialize prob ts
+      return ((t, x) :: targets, y :: ys)
+
+/-! ## Concrete TCR reduction -/
+
+/-- Concrete reduction from an OpenPRE adversary to a TCR adversary. Opening queries are simulated
+from the sampled target inputs; the reduction then forwards the selected index and candidate. -/
+noncomputable def SM_DT_OpenPRE_toTCR [Inhabited M]
+    {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_OpenPRE_Adversary prob) : SM_DT_TCR_Adversary prob.toTCR where
+  State := adv.State × List (Tweak × M) × List Y
+  choose := do
+    let (privateState, tweaks) ← simulateQ (SM_DT_OpenPRE_liftPick prob) adv.pick
+    let (targets, ys) ←
+      SM_DT_OpenPRE_reductionInitialize prob (tweaks.take prob.numTargets)
+    return (privateState, targets, ys)
+  forge state pk := do
+    let (privateState, targets, ys) := state
+    let ((j, m), _) ←
+      (simulateQ (SM_DT_OpenPRE_findOracles targets) (adv.find privateState pk ys)).run []
+    return (j, m)
+
+/-! ## Concrete DSPR reduction -/
+
+/-- Concrete reduction from an OpenPRE adversary to a DSPR adversary. It predicts that the selected
+target has a second preimage iff the candidate differs from the sampled input or the selected target
+was opened. An invalid index uses the fixed witness, matching the source oracle's `nth witness`. -/
+noncomputable def SM_DT_OpenPRE_toDSPR [Inhabited M] [DecidableEq M]
+    {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_OpenPRE_Adversary prob) : SM_DT_DSPR_Adversary prob.toDSPR where
+  State := adv.State × List (Tweak × M) × List Y
+  choose := do
+    let (privateState, tweaks) ← simulateQ (SM_DT_OpenPRE_liftPick prob) adv.pick
+    let (targets, ys) ←
+      SM_DT_OpenPRE_reductionInitialize prob (tweaks.take prob.numTargets)
+    return (privateState, targets, ys)
+  guess state pk := do
+    let (privateState, targets, ys) := state
+    let ((j, m), opened) ←
+      (simulateQ (SM_DT_OpenPRE_findOracles targets) (adv.find privateState pk ys)).run []
+    let sampled := (targets[j]?.map Prod.snd).getD default
+    return (j, decide (sampled ≠ m ∨ j ∈ opened))
+
+end TweakableHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/OpenPREFromTCRDSPR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/OpenPREFromTCRDSPR.lean
@@ -234,9 +234,12 @@ successful OpenPRE mass on fibers of size one. `multipleMass k` is the mass on f
 `k + 2`, aggregating over all selected target indices. The three fields are exactly the substantive
 probabilistic/coupling obligations remaining from the EasyCrypt proof; none is the desired final
 inequality in disguise. -/
-structure SM_DT_OpenPRE_CountingLemma [Fintype M] [Inhabited M] [DecidableEq Tweak]
-    [DecidableEq M] [DecidableEq Y] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+structure SM_DT_OpenPRE_CountingLemma [Fintype M] [Inhabited M] [SampleableType M]
+    [DecidableEq Tweak] [DecidableEq M] [DecidableEq Y]
+    {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
     (adv : SM_DT_OpenPRE_Adversary prob) where
+  /-- The source counting argument uses full uniform sampling of the finite input space. -/
+  uniformInputs : prob.HasUniformInputs
   /-- Successful mass whose selected image has exactly one preimage. -/
   singleMass : ℝ≥0∞
   /-- Successful masses for fiber cardinalities `2, …, Fintype.card M`. -/
@@ -256,8 +259,9 @@ structure SM_DT_OpenPRE_CountingLemma [Fintype M] [Inhabited M] [DecidableEq Twe
 
 /-- Once the named fiber-counting/coupling lemma is supplied, the full quantitative reduction is
 pure ENNReal algebra. This is the exact `OpenPRE ≤ DSPR + 3·TCR` theorem interface. -/
-theorem SM_DT_OpenPRE_le_TCR_DSPR [Fintype M] [Inhabited M] [DecidableEq Tweak]
-    [DecidableEq M] [DecidableEq Y] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+theorem SM_DT_OpenPRE_le_TCR_DSPR [Fintype M] [Inhabited M] [SampleableType M]
+    [DecidableEq Tweak] [DecidableEq M] [DecidableEq Y]
+    {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
     (adv : SM_DT_OpenPRE_Adversary prob) (hcount : SM_DT_OpenPRE_CountingLemma adv) :
     SM_DT_OpenPRE_Advantage adv ≤ SM_DT_OpenPRE_TCR_DSPR_Bound adv := by
   let reciprocal := SM_DT_OpenPRE_reciprocalMass

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/OpenPREFromTCRDSPR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/OpenPREFromTCRDSPR.lean
@@ -25,7 +25,9 @@ adversary placeholders. The quantitative inequality
 `OpenPRE ≤ (DSPR success - SPprob) + 3 · TCR`
 
 still requires the source proof's finite-preimage counting argument and is intentionally not
-asserted here without that proof.
+asserted here without that proof. In particular, that theorem must assume a finite input space and
+`SM_DT_OpenPRE_Problem.HasUniformInputs`; the exact OpenPRE game itself permits any input
+distribution.
 -/
 
 @[expose] public section
@@ -122,6 +124,100 @@ noncomputable def SM_DT_OpenPRE_toDSPR [Inhabited M] [DecidableEq M]
     let sampled := (targets[j]?.map Prod.snd).getD default
     return (j, decide (sampled ≠ m ∨ j ∈ opened))
 
+/-! ## Finite preimage counting -/
+
+/-- Cardinality of the fiber of `y` under the hash fixed at `pk` and `t`. -/
+def PreimageCount [Fintype M] [DecidableEq Y] (th : TweakableHash PkSeed Tweak M Y)
+    (pk : PkSeed) (t : Tweak) (y : Y) : ℕ :=
+  (Finset.univ.filter fun m => th.eval pk t m = y).card
+
+/-- Every actual hash image has a nonempty fiber. -/
+theorem one_le_preimageCount_image [Fintype M] [DecidableEq Y]
+    (th : TweakableHash PkSeed Tweak M Y) (pk : PkSeed) (t : Tweak) (m : M) :
+    1 ≤ PreimageCount th pk t (th.eval pk t m) := by
+  change 0 < (Finset.univ.filter fun m' => th.eval pk t m' = th.eval pk t m).card
+  rw [Finset.card_pos]
+  exact ⟨m, by simp⟩
+
+/-- No fiber is larger than the finite message space. -/
+theorem preimageCount_le_card [Fintype M] [DecidableEq Y]
+    (th : TweakableHash PkSeed Tweak M Y) (pk : PkSeed) (t : Tweak) (y : Y) :
+    PreimageCount th pk t y ≤ Fintype.card M := by
+  exact Finset.card_le_card (Finset.filter_subset _ _)
+
+/-- The DSPR predicate is exactly the statement that the selected image's fiber has cardinality at
+least two. This is the finite-preimage lemma called `eqv_spex_szprefl` in the EasyCrypt proof. -/
+theorem secondPreimageExists_iff_two_le_preimageCount [Fintype M] [DecidableEq Y]
+    (th : TweakableHash PkSeed Tweak M Y) (pk : PkSeed) (t : Tweak) (m : M) :
+    SecondPreimageExists th pk t m ↔ 2 ≤ PreimageCount th pk t (th.eval pk t m) := by
+  classical
+  let s : Finset M := Finset.univ.filter fun m' => th.eval pk t m' = th.eval pk t m
+  have hm : m ∈ s := by simp [s]
+  change SecondPreimageExists th pk t m ↔ 2 ≤ s.card
+  rw [show 2 ≤ s.card ↔ 1 < s.card by omega, Finset.one_lt_card]
+  constructor
+  · rintro ⟨m', hne, heq⟩
+    exact ⟨m, hm, m', by simp [s, heq], hne⟩
+  · rintro ⟨a, ha, b, hb, hab⟩
+    by_cases ham : a = m
+    · refine ⟨b, ?_, ?_⟩
+      · intro hmb
+        exact hab (ham.trans hmb)
+      · have hbEq : th.eval pk t b = th.eval pk t m := by simpa [s] using hb
+        exact hbEq.symm
+    · refine ⟨a, (fun hma => ham hma.symm), ?_⟩
+      have haEq : th.eval pk t a = th.eval pk t m := by simpa [s] using ha
+      exact haEq.symm
+
+/-! ## Algebra of the fiber-cardinality strata -/
+
+/-- Reciprocal mass subtracted by the DSPR/SPprob gap on fibers of size at least two. -/
+noncomputable def SM_DT_OpenPRE_reciprocalMass {α : Type} [Fintype α]
+    (fiberSize : α → ℕ) (mass : α → ℝ≥0∞) : ℝ≥0∞ :=
+  ∑ a, 1 / (fiberSize a : ℝ≥0∞) * mass a
+
+/-- Collision mass gained by TCR on fibers of size at least two. -/
+noncomputable def SM_DT_OpenPRE_collisionMass {α : Type} [Fintype α]
+    (fiberSize : α → ℕ) (mass : α → ℝ≥0∞) : ℝ≥0∞ :=
+  ∑ a, ((fiberSize a - 1 : ℕ) : ℝ≥0∞) / fiberSize a * mass a
+
+/-- For a fiber of size `n ≥ 2`, the source proof's coefficient inequality is
+`1 + 1/n ≤ 3(n-1)/n`. -/
+theorem openPRE_fiber_coefficient_le (n : ℕ) (hn : 2 ≤ n) :
+    (1 : ℝ≥0∞) + 1 / n ≤ 3 * ((n - 1 : ℕ) / n : ℝ≥0∞) := by
+  have hn0 : (n : ℝ≥0∞) ≠ 0 := by
+    exact_mod_cast (Nat.ne_of_gt (by omega : 0 < n))
+  have hnInf : (n : ℝ≥0∞) ≠ ∞ := ENNReal.coe_ne_top
+  rw [show (1 : ℝ≥0∞) + 1 / n = (n + 1) / n by
+    calc
+      (1 : ℝ≥0∞) + 1 / n = n / n + 1 / n := by rw [ENNReal.div_self hn0 hnInf]
+      _ = (n + 1) / n := by exact ENNReal.div_add_div_same]
+  rw [ENNReal.div_le_iff hn0 hnInf, mul_assoc]
+  rw [ENNReal.div_mul_cancel hn0 hnInf]
+  norm_num
+  exact_mod_cast (by omega : n + 1 ≤ 3 * (n - 1))
+
+/-- Summing the pointwise coefficient inequality over arbitrary fiber-cardinality strata. -/
+theorem openPRE_multipleMass_add_reciprocal_le_three_collision {α : Type} [Fintype α]
+    (fiberSize : α → ℕ) (mass : α → ℝ≥0∞) (hsize : ∀ a, 2 ≤ fiberSize a) :
+    (∑ a, mass a) + SM_DT_OpenPRE_reciprocalMass fiberSize mass ≤
+      3 * SM_DT_OpenPRE_collisionMass fiberSize mass := by
+  rw [SM_DT_OpenPRE_reciprocalMass, SM_DT_OpenPRE_collisionMass,
+    ← Finset.sum_add_distrib, Finset.mul_sum]
+  apply Finset.sum_le_sum
+  intro a _
+  let n := fiberSize a
+  have hn : 2 ≤ n := hsize a
+  have hcoeff := openPRE_fiber_coefficient_le n hn
+  calc
+    mass a + 1 / (fiberSize a : ℝ≥0∞) * mass a =
+        ((1 : ℝ≥0∞) + 1 / n) * mass a := by simp [n, add_mul]
+    _ ≤ (3 * ((n - 1 : ℕ) / n : ℝ≥0∞)) * mass a := by gcongr
+    _ = 3 * (((fiberSize a - 1 : ℕ) : ℝ≥0∞) /
+        fiberSize a * mass a) := by
+      simp only [n]
+      ac_rfl
+
 /-! ## Quantitative reduction target -/
 
 /-- The exact right-hand side of the source reduction, instantiated with the concrete adversaries
@@ -132,5 +228,61 @@ noncomputable def SM_DT_OpenPRE_TCR_DSPR_Bound [Fintype M] [Inhabited M] [Decida
     (adv : SM_DT_OpenPRE_Adversary prob) : ℝ≥0∞ :=
   SM_DT_DSPR_Advantage (SM_DT_OpenPRE_toDSPR adv) +
     3 * SM_DT_TCR_Advantage (SM_DT_OpenPRE_toTCR adv)
+
+/-- The probability decomposition by the selected image's fiber cardinality. `singleMass` is the
+successful OpenPRE mass on fibers of size one. `multipleMass k` is the mass on fibers of size
+`k + 2`, aggregating over all selected target indices. The three fields are exactly the substantive
+probabilistic/coupling obligations remaining from the EasyCrypt proof; none is the desired final
+inequality in disguise. -/
+structure SM_DT_OpenPRE_CountingLemma [Fintype M] [Inhabited M] [DecidableEq Tweak]
+    [DecidableEq M] [DecidableEq Y] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_OpenPRE_Adversary prob) where
+  /-- Successful mass whose selected image has exactly one preimage. -/
+  singleMass : ℝ≥0∞
+  /-- Successful masses for fiber cardinalities `2, …, Fintype.card M`. -/
+  multipleMass : Fin (Fintype.card M - 1) → ℝ≥0∞
+  /-- Decomposition of OpenPRE success by fiber cardinality. -/
+  openPRE_decomposition :
+    SM_DT_OpenPRE_Advantage adv = singleMass + ∑ k, multipleMass k
+  /-- Exact DSPR/SPprob truncated gap: singleton mass minus the reciprocal mass of larger
+  fibers. -/
+  dspr_decomposition :
+    SM_DT_DSPR_Advantage (SM_DT_OpenPRE_toDSPR adv) =
+      singleMass - SM_DT_OpenPRE_reciprocalMass (fun k => k.val + 2) multipleMass
+  /-- TCR success lower-bounds the collision-weighted mass of fibers of size at least two. -/
+  tcr_strata_le :
+    SM_DT_OpenPRE_collisionMass (fun k => k.val + 2) multipleMass ≤
+      SM_DT_TCR_Advantage (SM_DT_OpenPRE_toTCR adv)
+
+/-- Once the named fiber-counting/coupling lemma is supplied, the full quantitative reduction is
+pure ENNReal algebra. This is the exact `OpenPRE ≤ DSPR + 3·TCR` theorem interface. -/
+theorem SM_DT_OpenPRE_le_TCR_DSPR [Fintype M] [Inhabited M] [DecidableEq Tweak]
+    [DecidableEq M] [DecidableEq Y] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_OpenPRE_Adversary prob) (hcount : SM_DT_OpenPRE_CountingLemma adv) :
+    SM_DT_OpenPRE_Advantage adv ≤ SM_DT_OpenPRE_TCR_DSPR_Bound adv := by
+  let reciprocal := SM_DT_OpenPRE_reciprocalMass
+    (fun k : Fin (Fintype.card M - 1) => k.val + 2) hcount.multipleMass
+  let collision := SM_DT_OpenPRE_collisionMass
+    (fun k : Fin (Fintype.card M - 1) => k.val + 2) hcount.multipleMass
+  have hsingle : hcount.singleMass ≤
+      SM_DT_DSPR_Advantage (SM_DT_OpenPRE_toDSPR adv) + reciprocal := by
+    rw [hcount.dspr_decomposition]
+    exact le_tsub_add
+  have hmultiple : (∑ k, hcount.multipleMass k) + reciprocal ≤ 3 * collision := by
+    exact openPRE_multipleMass_add_reciprocal_le_three_collision _ _ (fun _ => by omega)
+  have hcollision : 3 * collision ≤
+      3 * SM_DT_TCR_Advantage (SM_DT_OpenPRE_toTCR adv) := by
+    gcongr
+    exact hcount.tcr_strata_le
+  rw [hcount.openPRE_decomposition]
+  calc
+    hcount.singleMass + ∑ k, hcount.multipleMass k ≤
+        (SM_DT_DSPR_Advantage (SM_DT_OpenPRE_toDSPR adv) + reciprocal) +
+          ∑ k, hcount.multipleMass k := by gcongr
+    _ = SM_DT_DSPR_Advantage (SM_DT_OpenPRE_toDSPR adv) +
+        ((∑ k, hcount.multipleMass k) + reciprocal) := by ac_rfl
+    _ ≤ SM_DT_DSPR_Advantage (SM_DT_OpenPRE_toDSPR adv) + 3 * collision := by gcongr
+    _ ≤ SM_DT_DSPR_Advantage (SM_DT_OpenPRE_toDSPR adv) +
+        3 * SM_DT_TCR_Advantage (SM_DT_OpenPRE_toTCR adv) := by gcongr
 
 end TweakableHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTDSPR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTDSPR.lean
@@ -31,8 +31,8 @@ This matches the finite input type in the EasyCrypt development.
 ## References
 
 - Barbosa, Dupressoir, Hülsing, Meijers and Strub, *A Tight Security Proof for SPHINCS+, Formally
-  Verified*, [ePrint 2024/910](https://eprint.iacr.org/2024/910), Fig. 10 and the EasyCrypt theory
-  `TweakableHashFunctions.SMDTDSPR`.
+  Verified*, [ePrint 2024/910](https://eprint.iacr.org/2024/910), and its EasyCrypt theory
+  `TweakableHashFunctions.SMDTDSPR` in `proofs/TweakableHashFunctions.eca`.
 - Hülsing and Kudinov, *Recovering the Tight Security Proof of SPHINCS+*,
   [ePrint 2022/346](https://eprint.iacr.org/2022/346).
 - Drake, Khovratovich, Kudinov and Wagner, *Hash-Based Multi-Signatures for Post-Quantum Ethereum*,

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTDSPR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTDSPR.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
+public import VCVio.OracleComp.SimSemantics.Append
+
+/-!
+# Single-function, distinct-tweak, multi-target decisional second-preimage resistance
+
+SM-DT-DSPR asks an adversary to predict whether one of the targets it selected has a second
+preimage. The public seed is sampled by the experiment and withheld while targets are selected,
+then revealed for the prediction phase. The adversary may evaluate the other members of a
+tweakable-hash collection while selecting targets. All oracle queries are answered and recorded;
+the experiment loses if the final-validity monitor was poisoned by exceeding the cap, repeating a
+target tweak, or using a target tweak on the collection oracle. This is the source game's
+final-validity semantics, not the rejection-on-arrival semantics of the existing TCR/PRE games.
+
+The security quantity is **not** raw prediction success. `SM_DT_SP_Experiment` is the source
+proof's `SPprob` baseline: it runs the same adversary, including its prediction phase and target
+selection, but accepts exactly when the selected target has a second preimage, independently of
+the guessed bit. `SM_DT_DSPR_Advantage` is the truncated difference
+`Pr[DSPR] - Pr[SPprob]`, i.e. `max 0 (Pr[DSPR] - Pr[SPprob])` in `ℝ≥0∞`.
+
+The message space is finite because the winning predicate decides whether a second preimage exists.
+This matches the finite input type in the EasyCrypt development.
+
+## References
+
+- Barbosa, Dupressoir, Hülsing, Meijers and Strub, *A Tight Security Proof for SPHINCS+, Formally
+  Verified*, [ePrint 2024/910](https://eprint.iacr.org/2024/910), Fig. 10 and the EasyCrypt theory
+  `TweakableHashFunctions.SMDTDSPR`.
+- Hülsing and Kudinov, *Recovering the Tight Security Proof of SPHINCS+*,
+  [ePrint 2022/346](https://eprint.iacr.org/2022/346).
+- Drake, Khovratovich, Kudinov and Wagner, *Hash-Based Multi-Signatures for Post-Quantum Ethereum*,
+  [ePrint 2025/055](https://eprint.iacr.org/2025/055), §3.1.
+-/
+
+@[expose] public section
+
+namespace TweakableHash
+
+open OracleComp OracleSpec ENNReal
+
+variable {ι PkSeed Tweak M Y : Type}
+
+/-! ## The second-preimage predicate -/
+
+/-- `m` has a distinct second preimage under the fixed seed and tweak. -/
+def SecondPreimageExists (th : TweakableHash PkSeed Tweak M Y) (pk : PkSeed) (t : Tweak)
+    (m : M) : Prop :=
+  ∃ m' : M, m ≠ m' ∧ th.eval pk t m = th.eval pk t m'
+
+instance [Fintype M] [DecidableEq M] [DecidableEq Y]
+    (th : TweakableHash PkSeed Tweak M Y) (pk : PkSeed) (t : Tweak) (m : M) :
+    Decidable (SecondPreimageExists th pk t m) :=
+  inferInstanceAs (Decidable (∃ m' : M, m ≠ m' ∧ th.eval pk t m = th.eval pk t m'))
+
+/-! ## The game -/
+
+/-- A DSPR challenge selects a `(tweak, message)` target and always returns its image. -/
+abbrev SM_DT_DSPR_challengeSpec (Tweak M Y : Type) : OracleSpec (Tweak × M) :=
+  (Tweak × M) →ₒ Y
+
+/-- An SM-DT-DSPR problem: attacked hash, shared collection, and target cap. -/
+structure SM_DT_DSPR_Problem (ι PkSeed Tweak M Y : Type) where
+  /-- The tweakable hash whose second-preimage structure is being predicted. -/
+  th : TweakableHash PkSeed Tweak M Y
+  /-- The rest of the collection, available during target selection at the same hidden seed. -/
+  thColl : TweakableHashCollection ι PkSeed Tweak Y
+  /-- The maximum number of challenge queries allowed by final validity. -/
+  numTargets : ℕ
+
+/-- The stand-alone DSPR problem, whose collection oracle is unqueryable. -/
+def SM_DT_DSPR_Problem.standalone (th : TweakableHash PkSeed Tweak M Y) (numTargets : ℕ) :
+    SM_DT_DSPR_Problem Empty PkSeed Tweak M Y where
+  th := th
+  thColl := .empty PkSeed Tweak Y
+  numTargets := numTargets
+
+/-- Shared histories and final-validity poison bit for the DSPR game. -/
+abbrev SM_DT_DSPR_State (Tweak M : Type) : Type := FinalValidityState (Tweak × M) Tweak
+
+/-- An SM-DT-DSPR adversary. The seed and challenge oracles are separated by the phase types. -/
+structure SM_DT_DSPR_Adversary (prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y) where
+  /-- Private state passed from target selection to prediction. -/
+  State : Type
+  /-- Select targets, with private randomness and collection access but without the public seed. -/
+  choose : OracleComp
+    (unifSpec +
+      (SM_DT_DSPR_challengeSpec Tweak M Y + finalValidityCollectionSpec prob.thColl)) State
+  /-- After the seed is revealed, select a target index and predict second-preimage existence. -/
+  guess : State → PkSeed → ProbComp (ℕ × Bool)
+
+/-- The DSPR challenge oracle. Every query is answered and recorded. A cap or tweak-discipline
+violation poisons the state instead of rejecting the query. -/
+def SM_DT_DSPR_challengeOracle [DecidableEq Tweak]
+    (prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl (SM_DT_DSPR_challengeSpec Tweak M Y)
+      (StateT (SM_DT_DSPR_State Tweak M) ProbComp) :=
+  fun tm => do
+    let st ← get
+    set (st.recordTarget prob.numTargets Prod.fst tm)
+    return prob.th.eval pk tm.1 tm.2
+
+/-- Challenge and collection oracles over one state and one hidden public seed. -/
+def SM_DT_DSPR_oracles [DecidableEq Tweak] (prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y)
+    (pk : PkSeed) :
+    QueryImpl (unifSpec +
+      (SM_DT_DSPR_challengeSpec Tweak M Y + finalValidityCollectionSpec prob.thColl))
+      (StateT (SM_DT_DSPR_State Tweak M) ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT (SM_DT_DSPR_State Tweak M) ProbComp) +
+    (SM_DT_DSPR_challengeOracle prob pk +
+      finalValidityCollectionOracle (Q := Tweak × M) Prod.fst prob.thColl pk)
+
+/-- The decisional experiment. The selected target must exist and the guess must equal its actual
+second-preimage-existence bit. -/
+noncomputable def SM_DT_DSPR_Experiment [Fintype M] [DecidableEq Tweak] [DecidableEq M]
+    [DecidableEq Y] {prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_DSPR_Adversary prob) : ProbComp Bool := do
+  let pk ← prob.th.seedGen
+  let (privateState, gameState) ←
+    (simulateQ (SM_DT_DSPR_oracles prob pk) adv.choose).run .initial
+  let (j, b) ← adv.guess privateState pk
+  match gameState.challenges[j]? with
+  | none => return false
+  | some (t, m) =>
+      return gameState.valid && decide (SecondPreimageExists prob.th pk t m ↔ b = true)
+
+/-- The source proof's `SPprob` baseline. It runs exactly the same adversary and uses the same
+selected index, but ignores the guessed bit and accepts iff that target has a second preimage. -/
+noncomputable def SM_DT_SP_Experiment [Fintype M] [DecidableEq Tweak] [DecidableEq M]
+    [DecidableEq Y] {prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_DSPR_Adversary prob) : ProbComp Bool := do
+  let pk ← prob.th.seedGen
+  let (privateState, gameState) ←
+    (simulateQ (SM_DT_DSPR_oracles prob pk) adv.choose).run .initial
+  let (j, _) ← adv.guess privateState pk
+  match gameState.challenges[j]? with
+  | none => return false
+  | some (t, m) =>
+      return gameState.valid && decide (SecondPreimageExists prob.th pk t m)
+
+/-- Raw DSPR prediction success probability. Kept separate from the security advantage so the
+baseline subtraction cannot be accidentally omitted at a call site. -/
+noncomputable def SM_DT_DSPR_Success [Fintype M] [DecidableEq Tweak] [DecidableEq M]
+    [DecidableEq Y] {prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_DSPR_Adversary prob) : ℝ≥0∞ :=
+  Pr[= true | SM_DT_DSPR_Experiment adv]
+
+/-- The `SPprob` baseline success probability. -/
+noncomputable def SM_DT_SP_Probability [Fintype M] [DecidableEq Tweak] [DecidableEq M]
+    [DecidableEq Y] {prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_DSPR_Adversary prob) : ℝ≥0∞ :=
+  Pr[= true | SM_DT_SP_Experiment adv]
+
+/-- SM-DT-DSPR advantage: the ENNReal truncated difference `Pr[DSPR] - Pr[SPprob]`. -/
+noncomputable def SM_DT_DSPR_Advantage [Fintype M] [DecidableEq Tweak] [DecidableEq M]
+    [DecidableEq Y] {prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_DSPR_Adversary prob) : ℝ≥0∞ :=
+  SM_DT_DSPR_Success adv - SM_DT_SP_Probability adv
+
+/-! ## Oracle behavior canaries -/
+
+variable [DecidableEq Tweak] {prob : SM_DT_DSPR_Problem ι PkSeed Tweak M Y} {pk : PkSeed}
+  {t : Tweak} {m : M} {st : SM_DT_DSPR_State Tweak M}
+
+/-- Every challenge query is answered and recorded, even when it poisons final validity. -/
+theorem SM_DT_DSPR_challengeOracle_run :
+    (SM_DT_DSPR_challengeOracle prob pk (t, m)).run st =
+      pure (prob.th.eval pk t m, st.recordTarget prob.numTargets Prod.fst (t, m)) := by
+  simp [SM_DT_DSPR_challengeOracle]
+
+end TweakableHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTDSPR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTDSPR.lean
@@ -17,7 +17,8 @@ then revealed for the prediction phase. The adversary may evaluate the other mem
 tweakable-hash collection while selecting targets. All oracle queries are answered and recorded;
 the experiment loses if the final-validity monitor was poisoned by exceeding the cap, repeating a
 target tweak, or using a target tweak on the collection oracle. This is the source game's
-final-validity semantics, not the rejection-on-arrival semantics of the existing TCR/PRE games.
+final-validity semantics, shared by the TCR, PRE, and OpenPRE games in this directory and distinct
+from the legacy rejection-on-arrival oracle.
 
 The security quantity is **not** raw prediction success. `SM_DT_SP_Experiment` is the source
 proof's `SPprob` baseline: it runs the same adversary, including its prediction phase and target

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTOpenPRE.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTOpenPRE.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 
 module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
+public import VCVio.OracleComp.Constructions.SampleableType
 public import VCVio.OracleComp.SimSemantics.Append
 
 /-!
@@ -57,6 +58,13 @@ structure SM_DT_OpenPRE_Problem (ι PkSeed Tweak M Y : Type) where
   thColl : TweakableHashCollection ι PkSeed Tweak Y
   /-- The number of committed tweaks retained as targets. -/
   numTargets : ℕ
+
+/-- The property on `inputGen` required by the source DSPR/TCR quantitative reduction: every input
+is sampled uniformly with full support. Keeping it separate from the game permits a more general
+OpenPRE definition while making the reduction's additional hypothesis explicit. -/
+def SM_DT_OpenPRE_Problem.HasUniformInputs [SampleableType M]
+    (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) : Prop :=
+  prob.inputGen = $ᵗ M
 
 /-- The stand-alone OpenPRE problem, whose collection oracle is unqueryable. -/
 def SM_DT_OpenPRE_Problem.standalone (th : TweakableHash PkSeed Tweak M Y)

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTOpenPRE.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTOpenPRE.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
+public import VCVio.OracleComp.Constructions.SampleableType
+public import VCVio.OracleComp.SimSemantics.Append
+
+/-!
+# Single-function, distinct-tweak, multi-target open preimage resistance
+
+In SM-DT-OpenPRE the adversary commits to a list of target tweaks before seeing the public seed or
+any target image. The challenger keeps only the first `numTargets` tweaks, samples one input for
+each, and gives their images to the adversary. After the seed is revealed, the adversary may open
+target inputs, but wins only by inverting a target it did not open.
+
+For the collection game, collection queries are available only during `pick`. They are answered at
+the hidden seed and recorded. The final-validity monitor checks distinct target tweaks and
+target/collection disjointness. Taking the bounded prefix is source semantics: a longer committed
+list is truncated, not rejected and not used to poison the game.
+
+The phase types enforce the information boundary. `pick` has no seed, images, or opening oracle;
+`find` receives the seed and images and has only private randomness and the opening oracle.
+
+## Reference
+
+- Barbosa, Dupressoir, Hülsing, Meijers and Strub, *A Tight Security Proof for SPHINCS+, Formally
+  Verified*, [ePrint 2024/910](https://eprint.iacr.org/2024/910), and the exact executable game in
+  `TweakableHashFunctions.SMDTOpenPRE` / `Collection.SMDTOpenPREC` of the accompanying EasyCrypt
+  development.
+-/
+
+@[expose] public section
+
+namespace TweakableHash
+
+open OracleComp OracleSpec ENNReal
+
+variable {ι PkSeed Tweak M Y : Type}
+
+/-! ## The game -/
+
+/-- The opening oracle takes a target index and returns its sampled input. -/
+abbrev SM_DT_OpenPRE_openSpec (M : Type) : OracleSpec ℕ := ℕ →ₒ M
+
+/-- An SM-DT-OpenPRE problem: attacked hash, shared collection, and target cap. -/
+structure SM_DT_OpenPRE_Problem (ι PkSeed Tweak M Y : Type) where
+  /-- The tweakable hash whose open-preimage resistance is in question. -/
+  th : TweakableHash PkSeed Tweak M Y
+  /-- The rest of the collection, available while the adversary commits to target tweaks. -/
+  thColl : TweakableHashCollection ι PkSeed Tweak Y
+  /-- The number of committed tweaks retained as targets. -/
+  numTargets : ℕ
+
+/-- The stand-alone OpenPRE problem, whose collection oracle is unqueryable. -/
+def SM_DT_OpenPRE_Problem.standalone (th : TweakableHash PkSeed Tweak M Y) (numTargets : ℕ) :
+    SM_DT_OpenPRE_Problem Empty PkSeed Tweak M Y where
+  th := th
+  thColl := .empty PkSeed Tweak Y
+  numTargets := numTargets
+
+/-- Target inputs, collection tweaks, and sticky final-validity bit. -/
+abbrev SM_DT_OpenPRE_State (Tweak M : Type) : Type := FinalValidityState (Tweak × M) Tweak
+
+/-- An SM-DT-OpenPRE adversary, split at the seed-revelation boundary. -/
+structure SM_DT_OpenPRE_Adversary (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) where
+  /-- Private state carried from target commitment to inversion. -/
+  State : Type
+  /-- Commit to target tweaks, with private randomness and collection access at the hidden seed. -/
+  pick : OracleComp (unifSpec + finalValidityCollectionSpec prob.thColl) (State × List Tweak)
+  /-- After the seed and target images are revealed, open targets adaptively and return a proposed
+  unopened target index and preimage. -/
+  find : State → PkSeed → List Y →
+    OracleComp (unifSpec + SM_DT_OpenPRE_openSpec M) (ℕ × M)
+
+/-- Private randomness and collection access for the commitment phase. -/
+def SM_DT_OpenPRE_pickOracles [DecidableEq Tweak]
+    (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl (unifSpec + finalValidityCollectionSpec prob.thColl)
+      (StateT (SM_DT_OpenPRE_State Tweak M) ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+      (StateT (SM_DT_OpenPRE_State Tweak M) ProbComp) +
+    finalValidityCollectionOracle (Q := Tweak × M) Prod.fst prob.thColl pk
+
+/-- Sample and record targets for precisely the supplied list. The experiment calls this on the
+bounded prefix of the committed tweak list. -/
+noncomputable def SM_DT_OpenPRE_initializeTargets [DecidableEq Tweak] [SampleableType M]
+    (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    List Tweak → StateT (SM_DT_OpenPRE_State Tweak M) ProbComp (List Y)
+  | [] => pure []
+  | t :: ts => do
+      let x ← (($ᵗ M : ProbComp M) : StateT (SM_DT_OpenPRE_State Tweak M) ProbComp M)
+      let st ← get
+      set (st.recordTarget prob.numTargets Prod.fst (t, x))
+      let ys ← SM_DT_OpenPRE_initializeTargets prob pk ts
+      return prob.th.eval pk t x :: ys
+
+/-- The opening oracle records every requested index. An out-of-range request returns the type's
+fixed witness, as does EasyCrypt's `nth witness`; it cannot itself win because the final selected
+index must refer to a recorded target. -/
+def SM_DT_OpenPRE_openOracle [Inhabited M] (targets : List (Tweak × M)) :
+    QueryImpl (SM_DT_OpenPRE_openSpec M) (StateT (List ℕ) ProbComp) :=
+  fun j => do
+    let opened ← get
+    set (opened ++ [j])
+    return (targets[j]?.map Prod.snd).getD default
+
+/-- Private randomness and adaptive target opening for the inversion phase. -/
+def SM_DT_OpenPRE_findOracles [Inhabited M] (targets : List (Tweak × M)) :
+    QueryImpl (unifSpec + SM_DT_OpenPRE_openSpec M) (StateT (List ℕ) ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT (List ℕ) ProbComp) +
+    SM_DT_OpenPRE_openOracle targets
+
+/-- The exact final-validity SM-DT-OpenPRE experiment. The committed tweak list is truncated before
+target sampling. The selected index must exist, must never have been opened, and must name a valid
+preimage of the corresponding recorded image. -/
+noncomputable def SM_DT_OpenPRE_Experiment [DecidableEq Tweak] [DecidableEq Y] [Inhabited M]
+    [SampleableType M] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_OpenPRE_Adversary prob) : ProbComp Bool := do
+  let pk ← prob.th.seedGen
+  let ((privateState, tweaks), afterPick) ←
+    (simulateQ (SM_DT_OpenPRE_pickOracles prob pk) adv.pick).run .initial
+  let (ys, gameState) ←
+    (SM_DT_OpenPRE_initializeTargets prob pk (tweaks.take prob.numTargets)).run afterPick
+  let ((j, m), opened) ←
+    (simulateQ (SM_DT_OpenPRE_findOracles gameState.challenges)
+      (adv.find privateState pk ys)).run []
+  match gameState.challenges[j]? with
+  | none => return false
+  | some (t, x) =>
+      return gameState.valid && decide (j ∉ opened) &&
+        decide (prob.th.eval pk t m = prob.th.eval pk t x)
+
+/-- The SM-DT-OpenPRE success probability. -/
+noncomputable def SM_DT_OpenPRE_Advantage [DecidableEq Tweak] [DecidableEq Y] [Inhabited M]
+    [SampleableType M] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_OpenPRE_Adversary prob) : ℝ≥0∞ :=
+  Pr[= true | SM_DT_OpenPRE_Experiment adv]
+
+/-! ## Oracle behavior pins -/
+
+variable [Inhabited M] {targets : List (Tweak × M)} {j : ℕ} {opened : List ℕ}
+
+/-- Opening always records the requested index, including an out-of-range one. -/
+theorem SM_DT_OpenPRE_openOracle_run :
+    (SM_DT_OpenPRE_openOracle targets j).run opened =
+      pure ((targets[j]?.map Prod.snd).getD default, opened ++ [j]) := by
+  simp [SM_DT_OpenPRE_openOracle]
+
+end TweakableHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTOpenPRE.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTOpenPRE.lean
@@ -6,7 +6,6 @@ Authors: Quang Dao
 
 module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
-public import VCVio.OracleComp.Constructions.SampleableType
 public import VCVio.OracleComp.SimSemantics.Append
 
 /-!
@@ -50,15 +49,21 @@ abbrev SM_DT_OpenPRE_openSpec (M : Type) : OracleSpec ℕ := ℕ →ₒ M
 structure SM_DT_OpenPRE_Problem (ι PkSeed Tweak M Y : Type) where
   /-- The tweakable hash whose open-preimage resistance is in question. -/
   th : TweakableHash PkSeed Tweak M Y
+  /-- Distribution used to sample the hidden input of each retained target. Keeping this explicit,
+  rather than fixing uniform sampling, matches the source game's abstract proper distribution and
+  permits reductions to instantiate the exact distribution they embed. -/
+  inputGen : ProbComp M
   /-- The rest of the collection, available while the adversary commits to target tweaks. -/
   thColl : TweakableHashCollection ι PkSeed Tweak Y
   /-- The number of committed tweaks retained as targets. -/
   numTargets : ℕ
 
 /-- The stand-alone OpenPRE problem, whose collection oracle is unqueryable. -/
-def SM_DT_OpenPRE_Problem.standalone (th : TweakableHash PkSeed Tweak M Y) (numTargets : ℕ) :
+def SM_DT_OpenPRE_Problem.standalone (th : TweakableHash PkSeed Tweak M Y)
+    (inputGen : ProbComp M) (numTargets : ℕ) :
     SM_DT_OpenPRE_Problem Empty PkSeed Tweak M Y where
   th := th
+  inputGen := inputGen
   thColl := .empty PkSeed Tweak Y
   numTargets := numTargets
 
@@ -87,12 +92,12 @@ def SM_DT_OpenPRE_pickOracles [DecidableEq Tweak]
 
 /-- Sample and record targets for precisely the supplied list. The experiment calls this on the
 bounded prefix of the committed tweak list. -/
-noncomputable def SM_DT_OpenPRE_initializeTargets [DecidableEq Tweak] [SampleableType M]
+def SM_DT_OpenPRE_initializeTargets [DecidableEq Tweak]
     (prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
     List Tweak → StateT (SM_DT_OpenPRE_State Tweak M) ProbComp (List Y)
   | [] => pure []
   | t :: ts => do
-      let x ← (($ᵗ M : ProbComp M) : StateT (SM_DT_OpenPRE_State Tweak M) ProbComp M)
+      let x ← (prob.inputGen : StateT (SM_DT_OpenPRE_State Tweak M) ProbComp M)
       let st ← get
       set (st.recordTarget prob.numTargets Prod.fst (t, x))
       let ys ← SM_DT_OpenPRE_initializeTargets prob pk ts
@@ -118,7 +123,7 @@ def SM_DT_OpenPRE_findOracles [Inhabited M] (targets : List (Tweak × M)) :
 target sampling. The selected index must exist, must never have been opened, and must name a valid
 preimage of the corresponding recorded image. -/
 noncomputable def SM_DT_OpenPRE_Experiment [DecidableEq Tweak] [DecidableEq Y] [Inhabited M]
-    [SampleableType M] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
     (adv : SM_DT_OpenPRE_Adversary prob) : ProbComp Bool := do
   let pk ← prob.th.seedGen
   let ((privateState, tweaks), afterPick) ←
@@ -136,7 +141,7 @@ noncomputable def SM_DT_OpenPRE_Experiment [DecidableEq Tweak] [DecidableEq Y] [
 
 /-- The SM-DT-OpenPRE success probability. -/
 noncomputable def SM_DT_OpenPRE_Advantage [DecidableEq Tweak] [DecidableEq Y] [Inhabited M]
-    [SampleableType M] {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
+    {prob : SM_DT_OpenPRE_Problem ι PkSeed Tweak M Y}
     (adv : SM_DT_OpenPRE_Adversary prob) : ℝ≥0∞ :=
   Pr[= true | SM_DT_OpenPRE_Experiment adv]
 

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTPRE.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTPRE.lean
@@ -5,7 +5,7 @@ Authors: Nicolas Consigny, Matthias Meijers
 -/
 
 module
-public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.OracleComp.Constructions.SampleableType
 public import VCVio.OracleComp.SimSemantics.Append
 
@@ -33,9 +33,9 @@ subspace carved out of `M` by a predicate is the case `M' := Subtype p`, `emb :=
 A strict subspace is needed when the challenge must be distributed as the value a reduction replaces
 — a digest, for a hash chain. SM-TCR carries no subspace: there nothing is drawn.
 
-`numTargets` bounds the accepted challenge queries and is the only query bound the game carries. See
-`TweakableHash.collectionOracle` for why the tweak restrictions are enforced in the oracles rather
-than in the winning condition.
+Every challenge and collection query is answered and recorded. The target cap, distinct target
+tweaks, and cross-oracle disjointness are enforced by the same sticky final-validity monitor as the
+SM-DT-TCR and SM-DT-DSPR games, matching the EasyCrypt final-predicate presentation.
 
 ## References
 
@@ -59,9 +59,9 @@ variable {ι PkSeed Tweak M M' Y : Type}
 
 /-! ## The game -/
 
-/-- The challenge oracle's signature: a query is a tweak alone — the oracle picks the message — and
-the response is `Option Y`, with `none` marking a rejected query. -/
-abbrev SM_DT_PRE_challengeSpec (Tweak Y : Type) : OracleSpec Tweak := Tweak →ₒ Option Y
+/-- The challenge oracle's signature: a query is a tweak alone, and the oracle samples a message
+and always returns its image. -/
+abbrev SM_DT_PRE_challengeSpec (Tweak Y : Type) : OracleSpec Tweak := Tweak →ₒ Y
 
 /-- An SM-PRE problem: the tweakable hash under attack, the subspace `M'` of its message space that
 the challenge oracle samples from, the collection its other members form, and the bound on the
@@ -77,7 +77,7 @@ structure SM_DT_PRE_Problem (ι PkSeed Tweak M M' Y : Type) where
   emb_injective : Function.Injective emb
   /-- The rest of the collection, evaluable by the adversary at the game's seed. -/
   thColl : TweakableHashCollection ι PkSeed Tweak Y
-  /-- The cap on accepted challenge-oracle queries. -/
+  /-- The maximum number of challenge queries allowed by final validity. -/
   numTargets : ℕ
 
 /-- The stand-alone SM-PRE problem, at the empty collection: the collection oracle's query type is
@@ -91,9 +91,8 @@ def SM_DT_PRE_Problem.standalone (th : TweakableHash PkSeed Tweak M Y) (emb : M'
   thColl := .empty PkSeed Tweak Y
   numTargets := numTargets
 
-/-- The state threaded through both oracles of the SM-PRE game: the challenge history of accepted
-`(tweak, sampled message)` targets, and the list of tweaks spent on the collection oracle. -/
-abbrev SM_DT_PRE_State (Tweak M' : Type) : Type := List (Tweak × M') × List Tweak
+/-- Challenge/collection histories and sticky final-validity bit for SM-DT-PRE. -/
+abbrev SM_DT_PRE_State (Tweak M' : Type) : Type := FinalValidityState (Tweak × M') Tweak
 
 /-- An SM-PRE adversary. `choose` selects tweaks through the challenge oracle, may evaluate the rest
 of the collection, and has private uniform randomness without access to the public seed; `invert`
@@ -104,38 +103,31 @@ structure SM_DT_PRE_Adversary (prob : SM_DT_PRE_Problem ι PkSeed Tweak M M' Y) 
   /-- Select tweaks through the challenge oracle, with private uniform randomness and collection
   access. The public seed is not an input. -/
   choose : OracleComp
-    (unifSpec + (SM_DT_PRE_challengeSpec Tweak Y + collectionSpec prob.thColl)) State
+    (unifSpec +
+      (SM_DT_PRE_challengeSpec Tweak Y + finalValidityCollectionSpec prob.thColl)) State
   /-- Given the revealed public seed, name a target index and a preimage in `M'`. -/
   invert : State → PkSeed → ProbComp (ℕ × M')
 
-/-- The challenge oracle at a public seed: it draws a message uniformly from `M'`, answers with the
-hash of that message under the queried tweak, and records the pair in the challenge history. A query
-is rejected with `none` when the target cap is reached, when its tweak already occurs in the
-challenge history, or when its tweak has been spent on the collection oracle; a rejected query
-leaves the state untouched and draws nothing.
-
-Accepted queries are appended, so the history is in issue order and its `j`-th entry is the `j`-th
-target. -/
+/-- The challenge oracle samples a message, always answers and records the query, and poisons final
+validity if the cap or tweak discipline is violated. -/
 noncomputable def SM_DT_PRE_challengeOracle [DecidableEq Tweak] [SampleableType M']
     (prob : SM_DT_PRE_Problem ι PkSeed Tweak M M' Y) (pk : PkSeed) :
     QueryImpl (SM_DT_PRE_challengeSpec Tweak Y) (StateT (SM_DT_PRE_State Tweak M') ProbComp) :=
   fun t => do
-    let (qsChal, twsColl) ← get
-    if prob.numTargets ≤ qsChal.length ∨ ¬ TweakFresh Prod.fst qsChal twsColl t then
-      return none
-    else
-      let x ← (($ᵗ M' : ProbComp M') : StateT (SM_DT_PRE_State Tweak M') ProbComp M')
-      set (qsChal ++ [(t, x)], twsColl)
-      return some (prob.th.eval pk t (prob.emb x))
+    let x ← (($ᵗ M' : ProbComp M') : StateT (SM_DT_PRE_State Tweak M') ProbComp M')
+    let st ← get
+    set (st.recordTarget prob.numTargets Prod.fst (t, x))
+    return prob.th.eval pk t (prob.emb x)
 
 /-- Both oracles of the SM-PRE game over the shared state, at a public seed. -/
 noncomputable def SM_DT_PRE_oracles [DecidableEq Tweak] [SampleableType M']
     (prob : SM_DT_PRE_Problem ι PkSeed Tweak M M' Y) (pk : PkSeed) :
-    QueryImpl (unifSpec + (SM_DT_PRE_challengeSpec Tweak Y + collectionSpec prob.thColl))
+    QueryImpl (unifSpec +
+      (SM_DT_PRE_challengeSpec Tweak Y + finalValidityCollectionSpec prob.thColl))
       (StateT (SM_DT_PRE_State Tweak M') ProbComp) :=
   (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT (SM_DT_PRE_State Tweak M') ProbComp) +
     (SM_DT_PRE_challengeOracle prob pk +
-      collectionOracle (Q := Tweak × M') Prod.fst prob.thColl pk)
+      finalValidityCollectionOracle (Q := Tweak × M') Prod.fst prob.thColl pk)
 
 /-- The SM-PRE experiment. The public seed is sampled, the first phase runs against both oracles
 without it, the second phase runs with it and without them, and the adversary wins by naming a
@@ -145,12 +137,14 @@ noncomputable def SM_DT_PRE_Experiment [DecidableEq Tweak] [DecidableEq Y] [Samp
     {prob : SM_DT_PRE_Problem ι PkSeed Tweak M M' Y} (adv : SM_DT_PRE_Adversary prob) :
     ProbComp Bool := do
   let pk ← prob.th.seedGen
-  let (st, qsChal, _) ← (simulateQ (SM_DT_PRE_oracles prob pk) adv.choose).run ([], [])
-  let (j, m) ← adv.invert st pk
-  match qsChal[j]? with
+  let (privateState, gameState) ←
+    (simulateQ (SM_DT_PRE_oracles prob pk) adv.choose).run .initial
+  let (j, m) ← adv.invert privateState pk
+  match gameState.challenges[j]? with
   | none => return false
   | some (t, x) =>
-      return decide (prob.th.eval pk t (prob.emb m) = prob.th.eval pk t (prob.emb x))
+      return gameState.valid &&
+        decide (prob.th.eval pk t (prob.emb m) = prob.th.eval pk t (prob.emb x))
 
 /-- The SM-PRE advantage of an adversary. -/
 noncomputable def SM_DT_PRE_Advantage [DecidableEq Tweak] [DecidableEq Y] [SampleableType M']
@@ -160,37 +154,13 @@ noncomputable def SM_DT_PRE_Advantage [DecidableEq Tweak] [DecidableEq Y] [Sampl
 /-! ## Basic properties and conventions -/
 
 variable [DecidableEq Tweak] [SampleableType M'] {prob : SM_DT_PRE_Problem ι PkSeed Tweak M M' Y}
-  {pk : PkSeed} {t : Tweak} {qsChal : List (Tweak × M')} {twsColl : List Tweak}
+  {pk : PkSeed} {t : Tweak} {st : SM_DT_PRE_State Tweak M'}
 
-/-- A query with a tweak fresh to both histories, below the target cap, draws its message from `M'`,
-answers with the hash of that message and appends it to the end of the challenge history. -/
-theorem SM_DT_PRE_challengeOracle_run_of_fresh (hlen : qsChal.length < prob.numTargets)
-    (hfresh : TweakFresh Prod.fst qsChal twsColl t) :
-    (SM_DT_PRE_challengeOracle prob pk t).run (qsChal, twsColl) =
-      (fun x => (some (prob.th.eval pk t (prob.emb x)), (qsChal ++ [(t, x)], twsColl))) <$>
-        ($ᵗ M') := by
-  simp [SM_DT_PRE_challengeOracle, Nat.not_le.mpr hlen, hfresh, Functor.map_map]
-
-/-- A query reusing a tweak already in the challenge history is rejected, and the state is
-unchanged. -/
-theorem SM_DT_PRE_challengeOracle_run_of_reused (x : M') (hmem : (t, x) ∈ qsChal) :
-    (SM_DT_PRE_challengeOracle prob pk t).run (qsChal, twsColl) =
-      pure (none, (qsChal, twsColl)) := by
-  have hres : TweakReserved Prod.fst qsChal t := ⟨(t, x), hmem, rfl⟩
-  simp [SM_DT_PRE_challengeOracle, TweakFresh, hres]
-
-/-- A query at the target cap is rejected, and the state is unchanged. -/
-theorem SM_DT_PRE_challengeOracle_run_of_full (hlen : prob.numTargets ≤ qsChal.length) :
-    (SM_DT_PRE_challengeOracle prob pk t).run (qsChal, twsColl) =
-      pure (none, (qsChal, twsColl)) := by
-  simp [SM_DT_PRE_challengeOracle, hlen]
-
-/-- A query at a tweak already spent on the collection oracle is rejected, and the state is
-unchanged. This is the half of the two tweak sets' disjointness that the challenge oracle enforces;
-`collectionOracle_run_of_challenge_clash` is the other. -/
-theorem SM_DT_PRE_challengeOracle_run_of_collection_clash (hmem : t ∈ twsColl) :
-    (SM_DT_PRE_challengeOracle prob pk t).run (qsChal, twsColl) =
-      pure (none, (qsChal, twsColl)) := by
-  simp [SM_DT_PRE_challengeOracle, TweakFresh, hmem]
+/-- Every query samples, answers, and records, including a query that poisons final validity. -/
+theorem SM_DT_PRE_challengeOracle_run :
+    (SM_DT_PRE_challengeOracle prob pk t).run st =
+      (fun x => (prob.th.eval pk t (prob.emb x),
+        st.recordTarget prob.numTargets Prod.fst (t, x))) <$> ($ᵗ M') := by
+  simp [SM_DT_PRE_challengeOracle, Functor.map_map]
 
 end TweakableHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTPRE.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTPRE.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny, Matthias Meijers. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Matthias Meijers, Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny, Matthias Meijers
+Authors: Nicolas Consigny, Matthias Meijers, Quang Dao
 -/
 
 module

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTTCR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTTCR.lean
@@ -5,7 +5,7 @@ Authors: Nicolas Consigny, Matthias Meijers
 -/
 
 module
-public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.OracleComp.SimSemantics.Append
 
 /-!
@@ -23,9 +23,10 @@ never reaches `SM_DT_TCR_Adversary.choose`. The two phases are separate fields a
 `OracleComp (SM_DT_TCR_challengeSpec …)` against `ProbComp`, so "the oracle is removed once the seed
 is revealed" is a typing fact and not a runtime convention: `forge` has no oracle to query.
 
-`numTargets` bounds the accepted challenge queries and is the only query bound the game carries. See
-`TweakableHash.collectionOracle` for why the tweak restrictions are enforced in the oracles rather
-than in the winning condition.
+All challenge and collection queries are answered and recorded. `numTargets`, distinct target
+tweaks, and target/collection disjointness are enforced by a sticky final-validity bit: a violating
+query poisons the bit but is not rejected. This is equivalent to the EasyCrypt/BDHMS final-predicate
+presentation and is intentionally distinct from rejection-on-arrival.
 
 ## References
 
@@ -47,10 +48,9 @@ variable {ι PkSeed Tweak M Y : Type}
 
 /-! ## The game -/
 
-/-- The challenge oracle's signature: a query is a `(tweak, message)` pair, and the response is
-`Option Y`, with `none` marking a rejected query. -/
+/-- The challenge oracle's signature: every `(tweak, message)` query returns its image. -/
 abbrev SM_DT_TCR_challengeSpec (Tweak M Y : Type) : OracleSpec (Tweak × M) :=
-  (Tweak × M) →ₒ Option Y
+  (Tweak × M) →ₒ Y
 
 /-- An SM-TCR problem: the tweakable hash under attack, the collection its other members form, and
 the bound on the number of targets the adversary may select. -/
@@ -59,7 +59,7 @@ structure SM_DT_TCR_Problem (ι PkSeed Tweak M Y : Type) where
   th : TweakableHash PkSeed Tweak M Y
   /-- The rest of the collection, evaluable by the adversary at the game's seed. -/
   thColl : TweakableHashCollection ι PkSeed Tweak Y
-  /-- The cap on accepted challenge-oracle queries. -/
+  /-- The maximum number of challenge queries allowed by final validity. -/
   numTargets : ℕ
 
 /-- The stand-alone SM-TCR problem, at the empty collection: the collection oracle's query type is
@@ -70,9 +70,8 @@ def SM_DT_TCR_Problem.standalone (th : TweakableHash PkSeed Tweak M Y) (numTarge
   thColl := .empty PkSeed Tweak Y
   numTargets := numTargets
 
-/-- The state threaded through both oracles of the SM-TCR game: the challenge history of accepted
-`(tweak, message)` targets, and the list of tweaks spent on the collection oracle. -/
-abbrev SM_DT_TCR_State (Tweak M : Type) : Type := List (Tweak × M) × List Tweak
+/-- Challenge/collection histories and sticky final-validity bit for SM-DT-TCR. -/
+abbrev SM_DT_TCR_State (Tweak M : Type) : Type := FinalValidityState (Tweak × M) Tweak
 
 /-- An SM-TCR adversary. `choose` selects targets through the challenge oracle, may evaluate the
 rest of the collection, and has private uniform randomness without access to the public seed;
@@ -83,36 +82,30 @@ structure SM_DT_TCR_Adversary (prob : SM_DT_TCR_Problem ι PkSeed Tweak M Y) whe
   /-- Select targets through the challenge oracle, with private uniform randomness and collection
   access. The public seed is not an input. -/
   choose : OracleComp
-    (unifSpec + (SM_DT_TCR_challengeSpec Tweak M Y + collectionSpec prob.thColl)) State
+    (unifSpec +
+      (SM_DT_TCR_challengeSpec Tweak M Y + finalValidityCollectionSpec prob.thColl)) State
   /-- Given the revealed public seed, name a target index and a colliding message. -/
   forge : State → PkSeed → ProbComp (ℕ × M)
 
-/-- The challenge oracle at a public seed, answering with the hash of the queried `(tweak, message)`
-pair and recording that pair in the challenge history. A query is rejected with `none` when the
-target cap is reached, when its tweak already occurs in the challenge history, or when its tweak has
-been spent on the collection oracle; a rejected query leaves the state untouched.
-
-Accepted queries are appended, so the history is in issue order and its `j`-th entry is the `j`-th
-target. -/
+/-- The always-answering target oracle. Every query is appended in issue order; a cap, duplicate
+target tweak, or collection clash poisons final validity without changing the returned digest. -/
 def SM_DT_TCR_challengeOracle [DecidableEq Tweak]
     (prob : SM_DT_TCR_Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
     QueryImpl (SM_DT_TCR_challengeSpec Tweak M Y) (StateT (SM_DT_TCR_State Tweak M) ProbComp) :=
   fun tm => do
-    let (qsChal, twsColl) ← get
-    if prob.numTargets ≤ qsChal.length ∨ ¬ TweakFresh Prod.fst qsChal twsColl tm.1 then
-      return none
-    else
-      set (qsChal ++ [tm], twsColl)
-      return some (prob.th.eval pk tm.1 tm.2)
+    let st ← get
+    set (st.recordTarget prob.numTargets Prod.fst tm)
+    return prob.th.eval pk tm.1 tm.2
 
 /-- Both oracles of the SM-TCR game over the shared state, at a public seed. -/
 def SM_DT_TCR_oracles [DecidableEq Tweak] (prob : SM_DT_TCR_Problem ι PkSeed Tweak M Y)
     (pk : PkSeed) :
-    QueryImpl (unifSpec + (SM_DT_TCR_challengeSpec Tweak M Y + collectionSpec prob.thColl))
+    QueryImpl (unifSpec +
+      (SM_DT_TCR_challengeSpec Tweak M Y + finalValidityCollectionSpec prob.thColl))
       (StateT (SM_DT_TCR_State Tweak M) ProbComp) :=
   (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT (SM_DT_TCR_State Tweak M) ProbComp) +
     (SM_DT_TCR_challengeOracle prob pk +
-      collectionOracle (Q := Tweak × M) Prod.fst prob.thColl pk)
+      finalValidityCollectionOracle (Q := Tweak × M) Prod.fst prob.thColl pk)
 
 /-- The SM-TCR experiment. The public seed is sampled, the first phase runs against both oracles
 without it, the second phase runs with it and without them, and the adversary wins by naming a
@@ -122,11 +115,13 @@ noncomputable def SM_DT_TCR_Experiment [DecidableEq Tweak] [DecidableEq M] [Deci
     {prob : SM_DT_TCR_Problem ι PkSeed Tweak M Y} (adv : SM_DT_TCR_Adversary prob) :
     ProbComp Bool := do
   let pk ← prob.th.seedGen
-  let (st, qsChal, _) ← (simulateQ (SM_DT_TCR_oracles prob pk) adv.choose).run ([], [])
-  let (j, m) ← adv.forge st pk
-  match qsChal[j]? with
+  let (privateState, gameState) ←
+    (simulateQ (SM_DT_TCR_oracles prob pk) adv.choose).run .initial
+  let (j, m) ← adv.forge privateState pk
+  match gameState.challenges[j]? with
   | none => return false
-  | some (t, mj) => return decide (m ≠ mj ∧ prob.th.eval pk t m = prob.th.eval pk t mj)
+  | some (t, mj) =>
+      return gameState.valid && decide (m ≠ mj ∧ prob.th.eval pk t m = prob.th.eval pk t mj)
 
 /-- The SM-TCR advantage of an adversary. -/
 noncomputable def SM_DT_TCR_Advantage [DecidableEq Tweak] [DecidableEq M] [DecidableEq Y]
@@ -136,36 +131,12 @@ noncomputable def SM_DT_TCR_Advantage [DecidableEq Tweak] [DecidableEq M] [Decid
 /-! ## Basic properties and conventions -/
 
 variable [DecidableEq Tweak] {prob : SM_DT_TCR_Problem ι PkSeed Tweak M Y} {pk : PkSeed}
-  {t : Tweak} {m : M} {qsChal : List (Tweak × M)} {twsColl : List Tweak}
+  {t : Tweak} {m : M} {st : SM_DT_TCR_State Tweak M}
 
-/-- A query with a tweak fresh to both histories, below the target cap, is answered with the hash
-and appended to the end of the challenge history. -/
-theorem SM_DT_TCR_challengeOracle_run_of_fresh (hlen : qsChal.length < prob.numTargets)
-    (hfresh : TweakFresh Prod.fst qsChal twsColl t) :
-    (SM_DT_TCR_challengeOracle prob pk (t, m)).run (qsChal, twsColl) =
-      pure (some (prob.th.eval pk t m), (qsChal ++ [(t, m)], twsColl)) := by
-  simp [SM_DT_TCR_challengeOracle, Nat.not_le.mpr hlen, hfresh]
-
-/-- A query reusing a tweak already in the challenge history is rejected, and the state is
-unchanged. -/
-theorem SM_DT_TCR_challengeOracle_run_of_reused (m' : M) (hmem : (t, m') ∈ qsChal) :
-    (SM_DT_TCR_challengeOracle prob pk (t, m)).run (qsChal, twsColl) =
-      pure (none, (qsChal, twsColl)) := by
-  have hres : TweakReserved Prod.fst qsChal t := ⟨(t, m'), hmem, rfl⟩
-  simp [SM_DT_TCR_challengeOracle, TweakFresh, hres]
-
-/-- A query at the target cap is rejected, and the state is unchanged. -/
-theorem SM_DT_TCR_challengeOracle_run_of_full (hlen : prob.numTargets ≤ qsChal.length) :
-    (SM_DT_TCR_challengeOracle prob pk (t, m)).run (qsChal, twsColl) =
-      pure (none, (qsChal, twsColl)) := by
-  simp [SM_DT_TCR_challengeOracle, hlen]
-
-/-- A query at a tweak already spent on the collection oracle is rejected, and the state is
-unchanged. This is the half of the two tweak sets' disjointness that the challenge oracle enforces;
-`collectionOracle_run_of_challenge_clash` is the other. -/
-theorem SM_DT_TCR_challengeOracle_run_of_collection_clash (hmem : t ∈ twsColl) :
-    (SM_DT_TCR_challengeOracle prob pk (t, m)).run (qsChal, twsColl) =
-      pure (none, (qsChal, twsColl)) := by
-  simp [SM_DT_TCR_challengeOracle, TweakFresh, hmem]
+/-- Every target query is answered and recorded, including a query that poisons final validity. -/
+theorem SM_DT_TCR_challengeOracle_run :
+    (SM_DT_TCR_challengeOracle prob pk (t, m)).run st =
+      pure (prob.th.eval pk t m, st.recordTarget prob.numTargets Prod.fst (t, m)) := by
+  simp [SM_DT_TCR_challengeOracle]
 
 end TweakableHash

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTTCR.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTTCR.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny, Matthias Meijers. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Matthias Meijers, Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny, Matthias Meijers
+Authors: Nicolas Consigny, Matthias Meijers, Quang Dao
 -/
 
 module

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTUDC.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTUDC.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
+public import VCVio.OracleComp.SimSemantics.Append
+
+/-!
+# Single-function, distinct-tweak, multi-target undetectability in a collection
+
+SM-DT-UD-C asks an adversary to distinguish sampled images of one tweakable hash from samples of
+an explicit output distribution. The public seed is sampled by the experiment and withheld while
+the adversary selects target tweaks through the challenge oracle and evaluates the shared hash
+collection. The seed is revealed only after those oracles have been removed.
+
+In the real world, a challenge at `t` samples `m ← inputGen` and returns `th.eval pk t m`. In the
+ideal world it returns `y ← outputGen`. Both worlds answer and record every query. The sticky
+final-validity monitor checks the target cap, distinct target tweaks, and target/collection
+disjointness only in the experiment's final conjunction; repeated collection-only tweaks remain
+valid.
+
+The exported advantage is the symmetric ENNReal gap
+`max (realSuccess - idealSuccess) (idealSuccess - realSuccess)`. This avoids coercing the game to
+`ℝ` merely to express an absolute difference and does not inherit the repository's older asymmetric
+PRF convention.
+
+## References
+
+- Barbosa, Dupressoir, Grégoire, Hülsing, Meijers and Strub, *Machine-Checked Security for XMSS as
+  in RFC 8391 and SPHINCS+*, [ePrint 2023/408](https://eprint.iacr.org/2023/408), Figs. 5, 6 and 9,
+  and `TweakableHashFunctions.Collection.SMDTUDC` in the accompanying EasyCrypt development.
+- Hülsing and Kudinov, *Recovering the Tight Security Proof of SPHINCS+*,
+  [ePrint 2022/346](https://eprint.iacr.org/2022/346).
+-/
+
+@[expose] public section
+
+namespace TweakableHash
+
+open OracleComp OracleSpec ENNReal
+
+variable {ι PkSeed Tweak M Y : Type}
+
+/-! ## The game -/
+
+/-- Which response distribution the challenge oracle uses. -/
+inductive SM_DT_UD_C_World
+  /-- Sample a hidden input and evaluate the attacked tweakable hash. -/
+  | real
+  /-- Sample directly from the problem's output distribution. -/
+  | ideal
+deriving DecidableEq, Repr
+
+/-- The challenge oracle takes a target tweak and returns a digest in both worlds. -/
+abbrev SM_DT_UD_C_challengeSpec (Tweak Y : Type) : OracleSpec Tweak := Tweak →ₒ Y
+
+/-- An SM-DT-UD-C problem: attacked hash, explicit real and ideal sampling distributions, shared
+collection, and target cap. -/
+structure SM_DT_UD_C_Problem (ι PkSeed Tweak M Y : Type) where
+  /-- The tweakable hash whose sampled images should be indistinguishable from `outputGen`. -/
+  th : TweakableHash PkSeed Tweak M Y
+  /-- Distribution of hidden inputs in the real challenge world. -/
+  inputGen : ProbComp M
+  /-- Distribution of direct challenge outputs in the ideal world. -/
+  outputGen : ProbComp Y
+  /-- The rest of the collection, available during target selection at the same hidden seed. -/
+  thColl : TweakableHashCollection ι PkSeed Tweak Y
+  /-- The maximum number of challenge queries allowed by final validity. -/
+  numTargets : ℕ
+
+/-- The stand-alone SM-DT-UD problem, whose collection oracle is unqueryable. -/
+def SM_DT_UD_C_Problem.standalone (th : TweakableHash PkSeed Tweak M Y)
+    (inputGen : ProbComp M) (outputGen : ProbComp Y) (numTargets : ℕ) :
+    SM_DT_UD_C_Problem Empty PkSeed Tweak M Y where
+  th := th
+  inputGen := inputGen
+  outputGen := outputGen
+  thColl := .empty PkSeed Tweak Y
+  numTargets := numTargets
+
+/-- Target tweaks, collection tweaks, and the sticky final-validity bit. -/
+abbrev SM_DT_UD_C_State (Tweak : Type) : Type := FinalValidityState Tweak Tweak
+
+/-- An SM-DT-UD-C adversary split exactly at the public-seed reveal. -/
+structure SM_DT_UD_C_Adversary (prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y) where
+  /-- Private state passed from target selection to the distinguishing phase. -/
+  State : Type
+  /-- Select target tweaks with private randomness and collection access, but without the seed. -/
+  pick : OracleComp
+    (unifSpec +
+      (SM_DT_UD_C_challengeSpec Tweak Y + finalValidityCollectionSpec prob.thColl)) State
+  /-- After the seed is revealed and both oracles are removed, return the distinguishing bit. -/
+  distinguish : State → PkSeed → ProbComp Bool
+
+/-- One challenge response. Only this distribution differs between the real and ideal worlds. -/
+def SM_DT_UD_C_response (world : SM_DT_UD_C_World)
+    (prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y) (pk : PkSeed) (t : Tweak) : ProbComp Y :=
+  match world with
+  | .real => do
+      let m ← prob.inputGen
+      return prob.th.eval pk t m
+  | .ideal => prob.outputGen
+
+/-- The always-answering challenge oracle. Every query is appended to the target history; a cap,
+duplicate-target, or collection clash poisons final validity without changing the response. -/
+def SM_DT_UD_C_challengeOracle [DecidableEq Tweak] (world : SM_DT_UD_C_World)
+    (prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl (SM_DT_UD_C_challengeSpec Tweak Y)
+      (StateT (SM_DT_UD_C_State Tweak) ProbComp) :=
+  fun t => do
+    let y ← (SM_DT_UD_C_response world prob pk t :
+      StateT (SM_DT_UD_C_State Tweak) ProbComp Y)
+    let st ← get
+    set (st.recordTarget prob.numTargets id t)
+    return y
+
+/-- Challenge and collection access over one final-validity state and one hidden seed. -/
+def SM_DT_UD_C_oracles [DecidableEq Tweak] (world : SM_DT_UD_C_World)
+    (prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl
+      (unifSpec +
+        (SM_DT_UD_C_challengeSpec Tweak Y + finalValidityCollectionSpec prob.thColl))
+      (StateT (SM_DT_UD_C_State Tweak) ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT (SM_DT_UD_C_State Tweak) ProbComp) +
+    (SM_DT_UD_C_challengeOracle world prob pk +
+      finalValidityCollectionOracle (Q := Tweak) id prob.thColl pk)
+
+/-- The source-final-validity SM-DT-UD-C experiment. The seed is hidden during `pick`, revealed to
+`distinguish`, and success is the adversary's bit conjoined with the final validity monitor. -/
+noncomputable def SM_DT_UD_C_Experiment [DecidableEq Tweak]
+    (world : SM_DT_UD_C_World) {prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y}
+    (adv : SM_DT_UD_C_Adversary prob) : ProbComp Bool := do
+  let pk ← prob.th.seedGen
+  let (privateState, gameState) ←
+    (simulateQ (SM_DT_UD_C_oracles world prob pk) adv.pick).run .initial
+  let b ← adv.distinguish privateState pk
+  return gameState.valid && b
+
+/-- Success probability when challenges are sampled hash images. -/
+noncomputable def SM_DT_UD_C_RealSuccess [DecidableEq Tweak]
+    {prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y} (adv : SM_DT_UD_C_Adversary prob) : ℝ≥0∞ :=
+  Pr[= true | SM_DT_UD_C_Experiment .real adv]
+
+/-- Success probability when challenges are sampled directly from `outputGen`. -/
+noncomputable def SM_DT_UD_C_IdealSuccess [DecidableEq Tweak]
+    {prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y} (adv : SM_DT_UD_C_Adversary prob) : ℝ≥0∞ :=
+  Pr[= true | SM_DT_UD_C_Experiment .ideal adv]
+
+/-- SM-DT-UD-C advantage as the symmetric gap of the two ENNReal success probabilities. -/
+noncomputable def SM_DT_UD_C_Advantage [DecidableEq Tweak]
+    {prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y} (adv : SM_DT_UD_C_Adversary prob) : ℝ≥0∞ :=
+  max (SM_DT_UD_C_RealSuccess adv - SM_DT_UD_C_IdealSuccess adv)
+    (SM_DT_UD_C_IdealSuccess adv - SM_DT_UD_C_RealSuccess adv)
+
+/-! ## Canonical collection-parametric API
+
+The collection is already an explicit field of the problem, as for the repository's TCR, PRE, and
+DSPR interfaces. These names therefore omit the redundant `_C` while remaining definitionally the
+same source SM-DT-UD-C game. -/
+
+abbrev SM_DT_UD_World := SM_DT_UD_C_World
+
+abbrev SM_DT_UD_challengeSpec (Tweak Y : Type) : OracleSpec Tweak :=
+  SM_DT_UD_C_challengeSpec Tweak Y
+
+abbrev SM_DT_UD_Problem (ι PkSeed Tweak M Y : Type) :=
+  SM_DT_UD_C_Problem ι PkSeed Tweak M Y
+
+/-- Canonical stand-alone SM-DT-UD problem at the empty collection. -/
+def SM_DT_UD_Problem.standalone (th : TweakableHash PkSeed Tweak M Y)
+    (inputGen : ProbComp M) (outputGen : ProbComp Y) (numTargets : ℕ) :
+    SM_DT_UD_Problem Empty PkSeed Tweak M Y :=
+  SM_DT_UD_C_Problem.standalone th inputGen outputGen numTargets
+
+abbrev SM_DT_UD_State (Tweak : Type) := SM_DT_UD_C_State Tweak
+
+abbrev SM_DT_UD_Adversary {ι PkSeed Tweak M Y : Type}
+    (prob : SM_DT_UD_Problem ι PkSeed Tweak M Y) := SM_DT_UD_C_Adversary prob
+
+/-- Canonically named real/ideal SM-DT-UD experiment. -/
+noncomputable def SM_DT_UD_Experiment [DecidableEq Tweak] (world : SM_DT_UD_World)
+    {prob : SM_DT_UD_Problem ι PkSeed Tweak M Y} (adv : SM_DT_UD_Adversary prob) :
+    ProbComp Bool :=
+  SM_DT_UD_C_Experiment world adv
+
+/-- Canonically named real-world success probability. -/
+noncomputable def SM_DT_UD_RealSuccess [DecidableEq Tweak]
+    {prob : SM_DT_UD_Problem ι PkSeed Tweak M Y} (adv : SM_DT_UD_Adversary prob) : ℝ≥0∞ :=
+  SM_DT_UD_C_RealSuccess adv
+
+/-- Canonically named ideal-world success probability. -/
+noncomputable def SM_DT_UD_IdealSuccess [DecidableEq Tweak]
+    {prob : SM_DT_UD_Problem ι PkSeed Tweak M Y} (adv : SM_DT_UD_Adversary prob) : ℝ≥0∞ :=
+  SM_DT_UD_C_IdealSuccess adv
+
+/-- SM-DT-UD-C advantage in the repository's canonical naming: the same symmetric ENNReal gap. -/
+noncomputable def SM_DT_UD_Advantage [DecidableEq Tweak]
+    {prob : SM_DT_UD_Problem ι PkSeed Tweak M Y} (adv : SM_DT_UD_Adversary prob) : ℝ≥0∞ :=
+  SM_DT_UD_C_Advantage adv
+
+/-! ## Oracle behavior pins -/
+
+variable [DecidableEq Tweak] {world : SM_DT_UD_C_World}
+  {prob : SM_DT_UD_C_Problem ι PkSeed Tweak M Y} {pk : PkSeed} {t : Tweak}
+  {st : SM_DT_UD_C_State Tweak}
+
+/-- Every challenge is answered and recorded, including challenges that poison final validity. -/
+theorem SM_DT_UD_C_challengeOracle_run :
+    (SM_DT_UD_C_challengeOracle world prob pk t).run st =
+      (fun y => (y, st.recordTarget prob.numTargets id t)) <$>
+        SM_DT_UD_C_response world prob pk t := by
+  simp [SM_DT_UD_C_challengeOracle, Functor.map_map]
+
+end TweakableHash

--- a/VCVio/CryptoFoundations/PRF.lean
+++ b/VCVio/CryptoFoundations/PRF.lean
@@ -108,6 +108,20 @@ noncomputable def prfAdvantage [DecidableEq D] [SampleableType R]
   |(Pr[= true | prf.prfRealExp adversary]).toReal -
     (Pr[= true | prfIdealExp adversary]).toReal|
 
+/-- The PRF distinguishing advantage in the common `ENNReal` codomain used by the signature and
+hash-assumption games.  Keeping this coercion at the PRF boundary prevents an aggregate concrete
+security bound from silently mixing real-valued and extended-nonnegative-real advantages. -/
+noncomputable def prfAdvantageENNReal [DecidableEq D] [SampleableType R]
+    (prf : PRFScheme K D R) (adversary : PRFAdversary D R) : ℝ≥0∞ :=
+  ENNReal.ofReal (prfAdvantage prf adversary)
+
+/-- Coercing the nonnegative real-valued PRF advantage to `ENNReal` and back is lossless. -/
+@[simp] theorem prfAdvantageENNReal_toReal [DecidableEq D] [SampleableType R]
+    (prf : PRFScheme K D R) (adversary : PRFAdversary D R) :
+    (prfAdvantageENNReal prf adversary).toReal = prfAdvantage prf adversary := by
+  rw [prfAdvantageENNReal, ENNReal.toReal_ofReal]
+  exact abs_nonneg _
+
 /-! ## Forwarding lemmas for the PRF query implementations
 
 How `prfRealQueryImpl`/`prfIdealQueryImpl` act on a computation lifted in from the ambient

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -340,6 +340,135 @@ noncomputable def strongUnforgeableAdv.advantage
     (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
   Pr[= true | strongUnforgeableExp runtime adv]
 
+/-- Forget pair freshness and regard a strong-unforgeability adversary as an ordinary
+EUF-CMA adversary.  The oracle interface and adversary program are unchanged. -/
+def strongUnforgeableAdv.toUnforgeableAdv
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (adv : strongUnforgeableAdv sigAlg) : unforgeableAdv sigAlg where
+  main := adv.main
+
+/-- The extra event separating SUF-CMA from EUF-CMA: the adversary returns a valid, new
+signature for a message that it did submit to the signing oracle.  This event is intentionally
+defined without assigning it to a cryptographic assumption; doing so is scheme-specific (for
+example, it may require signature binding or a rerandomization argument). -/
+noncomputable def sameMessageStrongUnforgeableExp
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) : SPMF Bool :=
+  letI : DecidableEq M := Classical.decEq M
+  letI : DecidableEq S := Classical.decEq S
+  runtime.evalSPMF do
+    let (pk, sk) ← sigAlg.keygen
+    let impl : QueryImpl (spec + (M →ₒ S))
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+      (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+        sigAlg.signingOracle pk sk
+    let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+      simulateQ impl (adv.main pk)
+    let ((msg, σ), log) ← simAdv.run
+    let verified ← sigAlg.verify pk msg σ
+    return log.wasQueried msg && !signingLogContains log msg σ && verified
+
+/-- Probability of the same-message, new-signature event in the strong-unforgeability
+experiment. -/
+noncomputable def strongUnforgeableAdv.sameMessageAdvantage
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
+  Pr[= true | sameMessageStrongUnforgeableExp runtime adv]
+
+omit [DecidableEq M] [DecidableEq S] in
+/-- **Generic SUF-to-EUF partition.** Every strong forgery either uses a message never queried
+to the signing oracle (an ordinary EUF-CMA forgery) or is a new valid signature for a previously
+queried message.  Consequently SUF-CMA is EUF-CMA plus precisely the latter, scheme-specific
+same-message event.
+
+The `h_pull` hypothesis is the same runtime-factoring law used by the EUF freshness lemma above.
+It is satisfied by the standard state-oracle runtimes used by VCVio. -/
+lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h_pull : ∀ {α β : Type} (f : α → β) (mx : OracleComp spec α),
+      runtime.evalSPMF (mx >>= fun x => pure (f x)) = f <$> runtime.evalSPMF mx)
+    (adv : strongUnforgeableAdv sigAlg) :
+    adv.advantage runtime ≤
+      adv.toUnforgeableAdv.advantage runtime + adv.sameMessageAdvantage runtime := by
+  let : DecidableEq M := Classical.decEq M
+  let : DecidableEq S := Classical.decEq S
+  unfold strongUnforgeableAdv.advantage strongUnforgeableExp
+    unforgeableAdv.advantage unforgeableExp
+    strongUnforgeableAdv.sameMessageAdvantage sameMessageStrongUnforgeableExp
+  set joint : OracleComp spec (M × S × QueryLog (M →ₒ S) × Bool) := do
+    let (pk, sk) ← sigAlg.keygen
+    let impl : QueryImpl (spec + (M →ₒ S))
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+      (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+        sigAlg.signingOracle pk sk
+    let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+      simulateQ impl (adv.main pk)
+    let ((msg, σ), log) ← simAdv.run
+    let verified ← sigAlg.verify pk msg σ
+    pure (msg, σ, log, verified) with hjoint_def
+  have hSuf : (runtime.evalSPMF do
+        let (pk, sk) ← sigAlg.keygen
+        let impl : QueryImpl (spec + (M →ₒ S))
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+          (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+            sigAlg.signingOracle pk sk
+        let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+          simulateQ impl (adv.main pk)
+        let ((msg, σ), log) ← simAdv.run
+        let verified ← sigAlg.verify pk msg σ
+        pure (!signingLogContains log msg σ && verified)) =
+      (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+        !signingLogContains t.2.2.1 t.1 t.2.1 && t.2.2.2) <$> runtime.evalSPMF joint := by
+    rw [← h_pull]
+    congr 1
+    simp only [hjoint_def, monad_norm]
+  have hEuf : (runtime.evalSPMF do
+        let (pk, sk) ← sigAlg.keygen
+        let impl : QueryImpl (spec + (M →ₒ S))
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+          (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+            sigAlg.signingOracle pk sk
+        let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+          simulateQ impl (adv.toUnforgeableAdv.main pk)
+        let ((msg, σ), log) ← simAdv.run
+        let verified ← sigAlg.verify pk msg σ
+        pure (!log.wasQueried msg && verified)) =
+      (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+        !t.2.2.1.wasQueried t.1 && t.2.2.2) <$> runtime.evalSPMF joint := by
+    rw [← h_pull]
+    congr 1
+    simp only [strongUnforgeableAdv.toUnforgeableAdv, hjoint_def, monad_norm]
+  have hSame : (runtime.evalSPMF do
+        let (pk, sk) ← sigAlg.keygen
+        let impl : QueryImpl (spec + (M →ₒ S))
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+          (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+            sigAlg.signingOracle pk sk
+        let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+          simulateQ impl (adv.main pk)
+        let ((msg, σ), log) ← simAdv.run
+        let verified ← sigAlg.verify pk msg σ
+        pure (log.wasQueried msg && !signingLogContains log msg σ && verified)) =
+      (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+        t.2.2.1.wasQueried t.1 &&
+          !signingLogContains t.2.2.1 t.1 t.2.1 && t.2.2.2) <$> runtime.evalSPMF joint := by
+    rw [← h_pull]
+    congr 1
+    simp only [hjoint_def, monad_norm]
+  rw [hSuf, hEuf, hSame, ← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput,
+    ← probEvent_eq_eq_probOutput, probEvent_map, probEvent_map, probEvent_map]
+  exact (probEvent_mono'' fun t h => by
+    by_cases hm : t.2.2.1.wasQueried t.1 = true <;> simp_all).trans
+      (probEvent_or_le (runtime.evalSPMF joint) _ _)
+
 end strongUnforgeable
 
 section eufNma

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -354,7 +354,7 @@ example, it may require signature binding or a rerandomization argument). -/
 noncomputable def sameMessageStrongUnforgeableExp
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec))
-    (adv : strongUnforgeableAdv sigAlg) : SPMF Bool :=
+    (adv : strongUnforgeableAdv sigAlg) :=
   letI : DecidableEq M := Classical.decEq M
   letI : DecidableEq S := Classical.decEq S
   runtime.evalSPMF do

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -378,6 +378,13 @@ noncomputable def strongUnforgeableAdv.sameMessageAdvantage
     (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
   Pr[= true | sameMessageStrongUnforgeableExp runtime adv]
 
+/-- Quantitative scheme property needed in addition to EUF-CMA for strong unforgeability: every
+adversary has at most `ε` probability of returning a new valid signature for a message previously
+submitted to the signing oracle. -/
+def SameMessageBinding (sigAlg : SignatureAlg (OracleComp spec) M PK SK S)
+    (runtime : ProbCompRuntime (OracleComp spec)) (ε : ℝ≥0∞) : Prop :=
+  ∀ adv : strongUnforgeableAdv sigAlg, adv.sameMessageAdvantage runtime ≤ ε
+
 omit [DecidableEq M] [DecidableEq S] in
 /-- **Generic SUF-to-EUF partition.** Every strong forgery either uses a message never queried
 to the signing oracle (an ordinary EUF-CMA forgery) or is a new valid signature for a previously
@@ -468,6 +475,19 @@ lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
   exact (probEvent_mono'' fun t h => by
     by_cases hm : t.2.2.1.wasQueried t.1 = true <;> simp_all).trans
       (probEvent_or_le (runtime.evalSPMF joint) _ _)
+
+omit [DecidableEq M] [DecidableEq S] in
+/-- SUF-CMA from EUF-CMA plus a quantitative same-message binding property. -/
+lemma strongUnforgeableAdv.advantage_le_euf_add_of_sameMessageBinding
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h_pull : ∀ {α β : Type} (f : α → β) (mx : OracleComp spec α),
+      runtime.evalSPMF (mx >>= fun x => pure (f x)) = f <$> runtime.evalSPMF mx)
+    {ε : ℝ≥0∞} (hbinding : sigAlg.SameMessageBinding runtime ε)
+    (adv : strongUnforgeableAdv sigAlg) :
+    adv.advantage runtime ≤ adv.toUnforgeableAdv.advantage runtime + ε :=
+  (adv.advantage_le_euf_add_sameMessage runtime h_pull).trans
+    (add_le_add le_rfl (hbinding adv))
 
 end strongUnforgeable
 

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -27,8 +27,9 @@ and signature space `S`.
 * `SignatureAlg`: a signature scheme as a `keygen`/`sign`/`verify` triple in a monad `m`.
 * `SignatureAlg.Complete`: completeness up to an error `δ`, with `PerfectlyComplete` the `δ = 0`
   case.
-* `SignatureAlg.unforgeableExp`, `eufNmaExp`, `managedRoNmaExp`: the EUF-CMA, EUF-NMA, and
-  managed-random-oracle NMA security experiments, with the corresponding adversary advantages.
+* `SignatureAlg.unforgeableExp`, `strongUnforgeableExp`, `eufNmaExp`, `managedRoNmaExp`: the
+  EUF-CMA, SUF-CMA, EUF-NMA, and managed-random-oracle NMA security experiments, with the
+  corresponding adversary advantages.
 -/
 
 @[expose] public section
@@ -55,9 +56,9 @@ variable {m : Type → Type v} [Monad m] {M PK SK S : Type}
 /-- The signing oracle for `sigAlg` under public key `pk` and secret key `sk`: the
 `QueryImpl` that answers each queried message by running `sigAlg.sign pk sk` on it.
 
-Every produced signature is recorded in a `WriterT (QueryLog (M →ₒ S))` writer layer, so an
-experiment running an adversary against this oracle can later read off which messages were
-signed and check the freshness of a forged message. -/
+Every successful response is recorded as its exact `(message, signature)` pair in a
+`WriterT (QueryLog (M →ₒ S))` writer layer. EUF-CMA projects this trace to queried messages;
+SUF-CMA checks whether the exact final pair occurs in it. -/
 def signingOracle (sigAlg : SignatureAlg m M PK SK S) (pk : PK) (sk : SK) :
     QueryImpl (M →ₒ S) (WriterT (QueryLog (M →ₒ S)) m) :=
   QueryImpl.withLogging (sigAlg.sign pk sk)
@@ -281,6 +282,65 @@ lemma unforgeableAdv.advantage_le_unforgeableExpNoFresh
   exact probEvent_mono fun _ _ => Bool.and_elim_right
 
 end unforgeable
+
+section strongUnforgeable
+
+variable {ι : Type u} {spec : OracleSpec ι} {M PK SK S : Type}
+  [DecidableEq M] [DecidableEq S]
+
+/-- Whether the signing-oracle trace contains the exact returned pair `(msg, σ)`. Unlike
+`QueryLog.wasQueried`, this predicate distinguishes two signatures returned for the same message. -/
+def signingLogContains (log : QueryLog (M →ₒ S)) (msg : M) (σ : S) : Bool :=
+  decide (⟨msg, σ⟩ ∈ log)
+
+@[simp]
+lemma signingLogContains_nil (msg : M) (σ : S) :
+    signingLogContains ([] : QueryLog (M →ₒ S)) msg σ = false := by
+  simp [signingLogContains]
+
+@[simp]
+lemma signingLogContains_singleton_self (msg : M) (σ : S) :
+    signingLogContains ([⟨msg, σ⟩] : QueryLog (M →ₒ S)) msg σ = true := by
+  simp [signingLogContains]
+
+/-- A SUF-CMA (strong unforgeability under chosen-message attack) adversary. As in EUF-CMA it
+receives the public key and has access to the scheme's ambient oracles plus the signing oracle,
+but its final pair is fresh when that exact `(message, signature)` pair was never returned. -/
+structure strongUnforgeableAdv (_sigAlg : SignatureAlg (OracleComp spec) M PK SK S) where
+  main (pk : PK) : OracleComp (spec + (M →ₒ S)) (M × S)
+
+/-- Strong unforgeability under chosen-message attack. The signing oracle logs every successful
+returned `(message, signature)` pair. The adversary succeeds exactly when its final pair verifies
+and that pair does not occur in the returned-pair log. In particular, a different valid signature
+for a previously signed message remains an eligible strong forgery. -/
+noncomputable def strongUnforgeableExp
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) :=
+  letI : DecidableEq M := Classical.decEq M
+  letI : DecidableEq S := Classical.decEq S
+  runtime.evalSPMF do
+    let (pk, sk) ← sigAlg.keygen
+    let impl : QueryImpl (spec + (M →ₒ S))
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+      (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+        sigAlg.signingOracle pk sk
+    let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+      simulateQ impl (adv.main pk)
+    let ((msg, σ), log) ← simAdv.run
+    let verified ← sigAlg.verify pk msg σ
+    return !signingLogContains log msg σ && verified
+
+/-- The SUF-CMA success probability: the probability of outputting a valid pair not previously
+returned by the signing oracle. -/
+noncomputable def strongUnforgeableAdv.advantage
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
+  Pr[= true | strongUnforgeableExp runtime adv]
+
+end strongUnforgeable
 
 section eufNma
 

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -303,6 +303,84 @@ lemma signingLogContains_singleton_self (msg : M) (σ : S) :
     signingLogContains ([⟨msg, σ⟩] : QueryLog (M →ₒ S)) msg σ = true := by
   simp [signingLogContains]
 
+/-- Whether the signing trace contains a response for the same message whose signature has the
+same scheme-specific key.  Taking `key` to be a signature randomizer partitions a same-message
+strong forgery according to freshness of the signed `(randomizer, message)` pair. -/
+def signingLogContainsMessageKey {K : Type} [DecidableEq K] (key : S → K)
+    (log : QueryLog (M →ₒ S)) (msg : M) (σ : S) : Bool :=
+  log.any fun q => decide (q.1 = msg ∧ key q.2 = key σ)
+
+omit [DecidableEq S] in
+/-- Membership characterization of `signingLogContainsMessageKey`. -/
+lemma signingLogContainsMessageKey_eq_true_iff {K : Type} [DecidableEq K]
+    (key : S → K) (log : QueryLog (M →ₒ S)) (msg : M) (σ : S) :
+    signingLogContainsMessageKey key log msg σ = true ↔
+      ∃ σ' : S, ⟨msg, σ'⟩ ∈ log ∧ key σ' = key σ := by
+  simp only [signingLogContainsMessageKey, List.any_eq_true, decide_eq_true_eq]
+  constructor
+  · rintro ⟨⟨msg', σ'⟩, hmem, hmsg, hkey⟩
+    change msg' = msg at hmsg
+    subst msg'
+    exact ⟨σ', hmem, hkey⟩
+  · rintro ⟨σ', hmem, hkey⟩
+    exact ⟨⟨msg, σ'⟩, hmem, rfl, hkey⟩
+
+/-- A logged response with the same message and key implies that the message was queried. -/
+lemma signingLogContainsMessageKey_implies_wasQueried {K : Type} [DecidableEq K]
+    (key : S → K) (log : QueryLog (M →ₒ S)) (msg : M) (σ : S)
+    (h : signingLogContainsMessageKey key log msg σ = true) :
+    log.wasQueried msg = true := by
+  rw [signingLogContainsMessageKey_eq_true_iff] at h
+  obtain ⟨σ', hmem, _⟩ := h
+  rw [QueryLog.wasQueried_eq_decide_mem_map_fst, decide_eq_true_eq]
+  exact List.mem_map.mpr ⟨⟨msg, σ'⟩, hmem, rfl⟩
+
+/-- Exact pair reuse implies reuse of every key extracted from the signature. -/
+lemma signingLogContains_implies_messageKey {K : Type} [DecidableEq K]
+    (key : S → K) (log : QueryLog (M →ₒ S)) (msg : M) (σ : S)
+    (h : signingLogContains log msg σ = true) :
+    signingLogContainsMessageKey key log msg σ = true := by
+  simp only [signingLogContains, decide_eq_true_eq] at h
+  rw [signingLogContainsMessageKey_eq_true_iff]
+  exact ⟨σ, h, rfl⟩
+
+/-- Exact Boolean partition of the generic same-message residual.  Its left branch has a fresh
+`(key σ, msg)` pair; its right branch reuses that pair while the full signature remains fresh. -/
+lemma sameMessageResidual_messageKey_partition {K : Type} [DecidableEq K]
+    (key : S → K) (log : QueryLog (M →ₒ S)) (msg : M) (σ : S) :
+    (log.wasQueried msg && !signingLogContains log msg σ) =
+      ((log.wasQueried msg && !signingLogContainsMessageKey key log msg σ) ||
+        (signingLogContainsMessageKey key log msg σ && !signingLogContains log msg σ)) := by
+  apply Bool.eq_iff_iff.mpr
+  simp only [Bool.and_eq_true, Bool.or_eq_true, Bool.not_eq_true_eq_eq_false]
+  constructor
+  · rintro ⟨hmsg, hfresh⟩
+    by_cases hkey : signingLogContainsMessageKey key log msg σ = true
+    · exact Or.inr ⟨hkey, hfresh⟩
+    · exact Or.inl ⟨hmsg, Bool.eq_false_of_not_eq_true hkey⟩
+  · rintro (⟨hmsg, hkey⟩ | ⟨hkey, hfresh⟩)
+    · refine ⟨hmsg, ?_⟩
+      by_contra hexact
+      have hexact' : signingLogContains log msg σ = true :=
+        Bool.eq_true_of_not_eq_false hexact
+      have := signingLogContains_implies_messageKey key log msg σ hexact'
+      simp [hkey] at this
+    · exact ⟨signingLogContainsMessageKey_implies_wasQueried key log msg σ hkey, hfresh⟩
+
+/-- In the reused-key branch, the log contains a distinct signature for the same message and
+key.  This is the exact pointwise witness a scheme-specific binding reduction must consume. -/
+lemma signingLogContainsMessageKey_distinct_witness {K : Type} [DecidableEq K]
+    (key : S → K) (log : QueryLog (M →ₒ S)) (msg : M) (σ : S)
+    (hkey : signingLogContainsMessageKey key log msg σ = true)
+    (hfresh : signingLogContains log msg σ = false) :
+    ∃ σ' : S, ⟨msg, σ'⟩ ∈ log ∧ key σ' = key σ ∧ σ' ≠ σ := by
+  rw [signingLogContainsMessageKey_eq_true_iff] at hkey
+  obtain ⟨σ', hmem, hsame⟩ := hkey
+  refine ⟨σ', hmem, hsame, ?_⟩
+  intro heq
+  subst σ'
+  simp [signingLogContains, hmem] at hfresh
+
 /-- A SUF-CMA (strong unforgeability under chosen-message attack) adversary. As in EUF-CMA it
 receives the public key and has access to the scheme's ambient oracles plus the signing oracle,
 but its final pair is fresh when that exact `(message, signature)` pair was never returned. -/

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -27,6 +27,7 @@ public import VCVioTest.QueryHom
 public import VCVioTest.RoundByRound.OneRound
 public import VCVioTest.SampleableType
 public import VCVioTest.SMDTDSPR
+public import VCVioTest.SMDTOpenPRE
 public import VCVioTest.SMDTPRE
 public import VCVioTest.Smoke
 public import VCVioTest.UniformOn

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -25,6 +25,7 @@ public import VCVioTest.PerfectMerkleTree
 public import VCVioTest.ProbabilityTactics
 public import VCVioTest.QueryHom
 public import VCVioTest.RoundByRound.OneRound
+public import VCVioTest.SMDTUDC
 public import VCVioTest.SampleableType
 public import VCVioTest.SMDTDSPR
 public import VCVioTest.SMDTOpenPRE

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -9,6 +9,7 @@ public import VCVioTest.CryptoFoundations.SymmEncAlgMeasure
 public import VCVioTest.ForkMeasure
 public import VCVioTest.Forking.WithoutReplacement
 public import VCVioTest.GrindFailFast
+public import VCVioTest.ITSR
 public import VCVioTest.KernelSemantics
 public import VCVioTest.LongChainPrograms
 public import VCVioTest.MeasureSemantics

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -5,6 +5,7 @@ public import VCVioTest.CryptoFoundations.ComplexityAdapters
 public import VCVioTest.CryptoFoundations.ComplexityTactics
 public import VCVioTest.CryptoFoundations.ComputationalComplexitySoundness
 public import VCVioTest.CryptoFoundations.OracleClosure
+public import VCVioTest.CryptoFoundations.SignatureAlg
 public import VCVioTest.CryptoFoundations.SymmEncAlgMeasure
 public import VCVioTest.ForkMeasure
 public import VCVioTest.Forking.WithoutReplacement

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -25,11 +25,11 @@ public import VCVioTest.PerfectMerkleTree
 public import VCVioTest.ProbabilityTactics
 public import VCVioTest.QueryHom
 public import VCVioTest.RoundByRound.OneRound
-public import VCVioTest.SMDTUDC
-public import VCVioTest.SampleableType
 public import VCVioTest.SMDTDSPR
 public import VCVioTest.SMDTOpenPRE
 public import VCVioTest.SMDTPRE
+public import VCVioTest.SMDTUDC
+public import VCVioTest.SampleableType
 public import VCVioTest.Smoke
 public import VCVioTest.UniformOn
 public import VCVioTest.UniversePolymorphism

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -25,6 +25,7 @@ public import VCVioTest.ProbabilityTactics
 public import VCVioTest.QueryHom
 public import VCVioTest.RoundByRound.OneRound
 public import VCVioTest.SampleableType
+public import VCVioTest.SMDTDSPR
 public import VCVioTest.Smoke
 public import VCVioTest.UniformOn
 public import VCVioTest.UniversePolymorphism

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -27,6 +27,7 @@ public import VCVioTest.QueryHom
 public import VCVioTest.RoundByRound.OneRound
 public import VCVioTest.SampleableType
 public import VCVioTest.SMDTDSPR
+public import VCVioTest.SMDTPRE
 public import VCVioTest.Smoke
 public import VCVioTest.UniformOn
 public import VCVioTest.UniversePolymorphism

--- a/VCVioTest/CryptoFoundations/SignatureAlg.lean
+++ b/VCVioTest/CryptoFoundations/SignatureAlg.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.SignatureAlg
+
+/-!
+# Signature security-game canaries
+
+Executable symbolic canaries for the generic SUF-CMA endpoint. The toy scheme deliberately has
+two valid signatures for each message, while honest signing returns only one of them. This makes
+the distinction between message freshness and exact returned-pair freshness observable.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SignatureAlgTest
+
+/-- The toy signature records the message in its first bit and has an ignored rerandomization
+bit. Both values of the second bit verify. -/
+abbrev ToySignature := Bool × Bool
+
+/-- A deterministic scheme with two valid signatures per message. Honest signing uses
+rerandomization bit `false`. -/
+def twoSignatureAlg : SignatureAlg ProbComp Bool Unit Unit ToySignature where
+  keygen := pure ((), ())
+  sign _ _ msg := pure (msg, false)
+  verify _ msg σ := pure (σ.1 == msg)
+
+/-- Query one signature and replay the exact pair. -/
+def replayAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
+  main _ := do
+    let σ ← (unifSpec + (Bool →ₒ ToySignature)).query (Sum.inr false)
+    return (false, σ)
+
+/-- Query a signature, then flip its ignored rerandomization bit. -/
+def rerandomizeAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
+  main _ := do
+    let _ ← (unifSpec + (Bool →ₒ ToySignature)).query (Sum.inr false)
+    return (false, (false, true))
+
+/-- Forge directly on a fresh message without calling the signing oracle. -/
+def freshMessageAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
+  main _ := pure (true, (true, true))
+
+/-- Replaying an exact signing-oracle response loses SUF-CMA. -/
+example :
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp replayAdv = pure false := by
+  simp [SignatureAlg.strongUnforgeableExp, replayAdv, twoSignatureAlg,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- A different valid signature on an already queried message is an eligible strong forgery. -/
+example :
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp rerandomizeAdv = pure true := by
+  simp [SignatureAlg.strongUnforgeableExp, rerandomizeAdv, twoSignatureAlg,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- A valid signature on a fresh message wins exactly as in the ordinary unforgeability game. -/
+example :
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp freshMessageAdv = pure true := by
+  simp [SignatureAlg.strongUnforgeableExp, freshMessageAdv, twoSignatureAlg,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- The ENNReal advantage endpoint assigns zero to replay and one to the two valid fresh-pair
+forgeries in this deterministic scheme. -/
+example : replayAdv.advantage ProbCompRuntime.probComp = 0 ∧
+    rerandomizeAdv.advantage ProbCompRuntime.probComp = 1 ∧
+    freshMessageAdv.advantage ProbCompRuntime.probComp = 1 := by
+  simp [SignatureAlg.strongUnforgeableAdv.advantage,
+    SignatureAlg.strongUnforgeableExp, replayAdv, rerandomizeAdv, freshMessageAdv,
+    twoSignatureAlg, SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+end SignatureAlgTest

--- a/VCVioTest/CryptoFoundations/SignatureAlg.lean
+++ b/VCVioTest/CryptoFoundations/SignatureAlg.lean
@@ -79,4 +79,20 @@ example : replayAdv.advantage ProbCompRuntime.probComp = 0 ∧
     twoSignatureAlg, SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
+/-- The SUF partition is exact on the two qualitatively different forgery branches: rerandomizing
+an already signed message contributes only to the same-message term, while a fresh-message
+forgery contributes only to EUF. -/
+example :
+    rerandomizeAdv.toUnforgeableAdv.advantage ProbCompRuntime.probComp = 0 ∧
+      rerandomizeAdv.sameMessageAdvantage ProbCompRuntime.probComp = 1 ∧
+      freshMessageAdv.toUnforgeableAdv.advantage ProbCompRuntime.probComp = 1 ∧
+      freshMessageAdv.sameMessageAdvantage ProbCompRuntime.probComp = 0 := by
+  simp [SignatureAlg.unforgeableAdv.advantage, SignatureAlg.unforgeableExp,
+    SignatureAlg.strongUnforgeableAdv.sameMessageAdvantage,
+    SignatureAlg.sameMessageStrongUnforgeableExp,
+    SignatureAlg.strongUnforgeableAdv.toUnforgeableAdv,
+    rerandomizeAdv, freshMessageAdv, twoSignatureAlg, SignatureAlg.signingOracle,
+    SignatureAlg.signingLogContains, QueryLog.wasQueried,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
 end SignatureAlgTest

--- a/VCVioTest/ITSR.lean
+++ b/VCVioTest/ITSR.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.KeyedHash.ITSR
+
+/-! # ITSR source-game canaries -/
+
+public section
+
+open OracleComp KeyedHash
+
+namespace ITSRTest
+
+def parityProblem : ITSRProblem Bool Nat Bool Nat where
+  khf := { keygen := $ᵗ Bool, hash := fun k x => k == decide (x % 2 = 0) }
+  indices := fun y => if y then [0] else [1]
+
+def constantIndexProblem : ITSRProblem Bool Nat Unit Nat where
+  khf := { keygen := $ᵗ Bool, hash := fun _ _ => () }
+  indices := fun _ => [0]
+
+/-- The candidate pair must be fresh even when its semantic index is covered. -/
+example : ¬ parityProblem.Wins [(true, 2)] (true, 2) := by decide
+
+/-- Pair freshness permits reusing a target key at a fresh input. -/
+example : constantIndexProblem.Wins [(true, 1)] (true, 2) := by decide
+
+/-- Pair freshness also permits reusing a target input under a fresh key. -/
+example : constantIndexProblem.Wins [(true, 1)] (false, 1) := by decide
+
+/-- A fresh pair loses when its selected index is not covered by the transcript. -/
+example : ¬ parityProblem.Wins [(true, 2)] (true, 3) := by decide
+
+/-- The target oracle's state theorem pins append-in-issue-order semantics. -/
+example (x : Nat) (targets : ITSRTranscript Bool Nat) :
+    (ITSRTargetOracle constantIndexProblem x).run targets =
+      constantIndexProblem.khf.keygen >>= fun k => pure (k, targets ++ [(k, x)]) :=
+  ITSRTargetOracle_run constantIndexProblem x targets
+
+end ITSRTest

--- a/VCVioTest/MultiTargetCollection.lean
+++ b/VCVioTest/MultiTargetCollection.lean
@@ -9,13 +9,12 @@ module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
 
 /-!
-# Multi-target collection-oracle canary
+# Multi-target final-validity collection canary
 
-One end-to-end producer canary checks both directions of the security-critical tweak-separation
-rule. A collection query at an existing challenge tweak must return `none`; the adversary branches
-on that rejection, so forgetting the check turns its toy collision into a loss. In the other order,
-a challenge query at a tweak already spent on the collection oracle is rejected and leaves no
-target to forge against.
+The target and collection oracles answer every query. A tweak clash in either order is recorded and
+poisons the final-validity bit, so even a concrete collision loses. Repeated collection-only tweaks
+remain valid. These canaries fail if the game is mutated back to rejection-on-arrival, forgets one
+cross-oracle direction, or incorrectly requires collection tweaks to be distinct.
 -/
 
 @[expose] public section
@@ -40,7 +39,7 @@ def hash : TweakableHash Seed Bool Bool Bool where
 
 def collection : TweakableHashCollection Unit Seed Bool Bool where
   Msg _ := Bool
-  eval _ _ _ _ := false
+  eval _ _ _ m := m
 
 def problem : TweakableHash.SM_DT_TCR_Problem Unit Seed Bool Bool Bool where
   th := hash
@@ -49,78 +48,101 @@ def problem : TweakableHash.SM_DT_TCR_Problem Unit Seed Bool Bool Bool where
 
 @[simp] lemma problem_seedGen : problem.th.seedGen = pure .only := rfl
 
-@[simp] lemma problem_eval (pk : Seed) (tweak message : Bool) :
-    problem.th.eval pk tweak message = false := rfl
+abbrev Specs := unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
+  TweakableHash.finalValidityCollectionSpec problem.thColl)
+
+def challenge (t m : Bool) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inl (t, m))))
+
+def collectionQuery (t : Bool) (m : problem.thColl.Msg ()) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inr ⟨(), t, m⟩)))
 
 def challengeOnly : TweakableHash.SM_DT_TCR_Adversary problem where
   State := Unit
-  choose := do
-    let _ ← (liftM ((unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-      TweakableHash.collectionSpec problem.thColl)).query (.inr (.inl (false, false)))) :
-      OracleComp (unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-        TweakableHash.collectionSpec problem.thColl)) (Option Bool))
-    return ()
+  choose := challenge false false *> pure ()
   forge _ _ := pure (0, true)
 
 def challengeThenCollection : TweakableHash.SM_DT_TCR_Adversary problem where
-  State := Option Bool
+  State := Bool × Bool
   choose := do
-    let _ ← (liftM ((unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-      TweakableHash.collectionSpec problem.thColl)).query (.inr (.inl (false, false)))) :
-      OracleComp (unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-        TweakableHash.collectionSpec problem.thColl)) (Option Bool))
-    liftM ((unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-      TweakableHash.collectionSpec problem.thColl)).query (.inr (.inr ⟨(), false, false⟩)))
-  forge answer _ := match answer with
-    | none => pure (0, true)
-    | some _ => pure (0, false)
+    let y₁ ← challenge false false
+    let y₂ ← collectionQuery false true
+    return (y₁, y₂)
+  forge _ _ := pure (0, true)
 
 def collectionThenChallenge : TweakableHash.SM_DT_TCR_Adversary problem where
-  State := Unit
+  State := Bool × Bool
   choose := do
-    let _ ← (liftM ((unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-      TweakableHash.collectionSpec problem.thColl)).query (.inr (.inr ⟨(), false, false⟩))) :
-      OracleComp (unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-        TweakableHash.collectionSpec problem.thColl)) (Option Bool))
-    let _ ← (liftM ((unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-      TweakableHash.collectionSpec problem.thColl)).query (.inr (.inl (false, false)))) :
-      OracleComp (unifSpec + (TweakableHash.SM_DT_TCR_challengeSpec Bool Bool Bool +
-        TweakableHash.collectionSpec problem.thColl)) (Option Bool))
-    return ()
+    let y₁ ← collectionQuery false true
+    let y₂ ← challenge false false
+    return (y₁, y₂)
+  forge _ _ := pure (0, true)
+
+/-- Repeating a collection tweak is permitted; the subsequent fresh challenge remains valid. -/
+def repeatedCollection : TweakableHash.SM_DT_TCR_Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← collectionQuery false false
+    let y₂ ← collectionQuery false true
+    let _ ← challenge true false
+    return (y₁, y₂)
   forge _ _ := pure (0, true)
 
 private lemma run_challengeOnly :
-    (simulateQ (TweakableHash.SM_DT_TCR_oracles problem .only) challengeOnly.choose).run ([], []) =
-      pure ((), ([(false, false)], [])) := by
+    (simulateQ (TweakableHash.SM_DT_TCR_oracles problem .only) challengeOnly.choose).run .initial =
+      pure ((), ⟨[(false, false)], [], true⟩) := by
   rfl
 
 private lemma run_challengeThenCollection :
     (simulateQ (TweakableHash.SM_DT_TCR_oracles problem .only)
-      challengeThenCollection.choose).run ([], []) =
-      pure (none, ([(false, false)], [])) := by
+      challengeThenCollection.choose).run .initial =
+      pure ((false, true), ⟨[(false, false)], [false], false⟩) := by
   rfl
 
 private lemma run_collectionThenChallenge :
     (simulateQ (TweakableHash.SM_DT_TCR_oracles problem .only)
-      collectionThenChallenge.choose).run ([], []) =
-      pure ((), ([], [false])) := by
+      collectionThenChallenge.choose).run .initial =
+      pure ((true, false), ⟨[(false, false)], [false], false⟩) := by
   rfl
 
-/-- Both query orders enforce challenge/collection tweak separation. -/
-theorem oracle_separation_canary :
+private lemma run_repeatedCollection :
+    (simulateQ (TweakableHash.SM_DT_TCR_oracles problem .only)
+      repeatedCollection.choose).run .initial =
+      pure ((false, true), ⟨[(true, false)], [false, false], true⟩) := by
+  rfl
+
+private lemma experiment_challengeOnly :
+    TweakableHash.SM_DT_TCR_Experiment challengeOnly = pure true := by
+  simp only [TweakableHash.SM_DT_TCR_Experiment, problem_seedGen, pure_bind]
+  rw [run_challengeOnly]
+  rfl
+
+private lemma experiment_challengeThenCollection :
+    TweakableHash.SM_DT_TCR_Experiment challengeThenCollection = pure false := by
+  simp only [TweakableHash.SM_DT_TCR_Experiment, problem_seedGen, pure_bind]
+  rw [run_challengeThenCollection]
+  rfl
+
+private lemma experiment_collectionThenChallenge :
+    TweakableHash.SM_DT_TCR_Experiment collectionThenChallenge = pure false := by
+  simp only [TweakableHash.SM_DT_TCR_Experiment, problem_seedGen, pure_bind]
+  rw [run_collectionThenChallenge]
+  rfl
+
+private lemma experiment_repeatedCollection :
+    TweakableHash.SM_DT_TCR_Experiment repeatedCollection = pure true := by
+  simp only [TweakableHash.SM_DT_TCR_Experiment, problem_seedGen, pure_bind]
+  rw [run_repeatedCollection]
+  rfl
+
+/-- Both clash orders are answered and recorded but lose through final validity; repeated
+collection tweaks remain legal. -/
+theorem final_validity_collection_canary :
     TweakableHash.SM_DT_TCR_Experiment challengeOnly = pure true ∧
-      TweakableHash.SM_DT_TCR_Experiment challengeThenCollection = pure true ∧
-      TweakableHash.SM_DT_TCR_Experiment collectionThenChallenge = pure false := by
-  constructor
-  · simp only [TweakableHash.SM_DT_TCR_Experiment, problem_seedGen, pure_bind]
-    rw [run_challengeOnly]
-    simp [challengeOnly, problem_eval]
-  · constructor
-    · simp only [TweakableHash.SM_DT_TCR_Experiment, problem_seedGen, pure_bind]
-      rw [run_challengeThenCollection]
-      simp [challengeThenCollection, problem_eval]
-    · simp only [TweakableHash.SM_DT_TCR_Experiment, problem_seedGen, pure_bind]
-      rw [run_collectionThenChallenge]
-      rfl
+      TweakableHash.SM_DT_TCR_Experiment challengeThenCollection = pure false ∧
+      TweakableHash.SM_DT_TCR_Experiment collectionThenChallenge = pure false ∧
+      TweakableHash.SM_DT_TCR_Experiment repeatedCollection = pure true :=
+  ⟨experiment_challengeOnly, experiment_challengeThenCollection,
+    experiment_collectionThenChallenge, experiment_repeatedCollection⟩
 
 end MultiTargetCollectionTest

--- a/VCVioTest/SMDTDSPR.lean
+++ b/VCVioTest/SMDTDSPR.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTDSPR
+
+/-!
+# SM-DT-DSPR mutation canaries
+
+These small executable games pin the security-critical parts of the definition: the hidden-seed
+phase split, always-answering final-validity semantics, cap and cross-oracle poisoning, and the
+`SPprob` subtraction in the exported advantage.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SMDTDSPRTest
+
+inductive Seed
+  | only
+
+instance : SampleableType Seed where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+@[simp] lemma uniformSample_seed : ($ᵗ Seed : ProbComp Seed) = pure .only := rfl
+
+/-- Every Boolean target has a second preimage. -/
+def collidingHash : TweakableHash Seed Bool Bool Bool where
+  seedGen := $ᵗ Seed
+  eval _ _ _ := false
+
+/-- No Boolean target has a second preimage. -/
+def injectiveHash : TweakableHash Seed Bool Bool Bool where
+  seedGen := $ᵗ Seed
+  eval _ _ m := m
+
+def collection : TweakableHashCollection Unit Seed Bool Bool where
+  Msg _ := Bool
+  eval _ _ _ m := m
+
+def collidingProblem : TweakableHash.SM_DT_DSPR_Problem Unit Seed Bool Bool Bool where
+  th := collidingHash
+  thColl := collection
+  numTargets := 1
+
+def injectiveProblem : TweakableHash.SM_DT_DSPR_Problem Unit Seed Bool Bool Bool where
+  th := injectiveHash
+  thColl := collection
+  numTargets := 1
+
+@[simp] lemma collidingProblem_seedGen : collidingProblem.th.seedGen = pure .only := rfl
+
+@[simp] lemma injectiveProblem_seedGen : injectiveProblem.th.seedGen = pure .only := rfl
+
+abbrev Specs (prob : TweakableHash.SM_DT_DSPR_Problem Unit Seed Bool Bool Bool) :=
+  unifSpec + (TweakableHash.SM_DT_DSPR_challengeSpec Bool Bool Bool +
+    TweakableHash.finalValidityCollectionSpec prob.thColl)
+
+def challenge (prob : TweakableHash.SM_DT_DSPR_Problem Unit Seed Bool Bool Bool)
+    (t m : Bool) : OracleComp (Specs prob) Bool :=
+  liftM ((Specs prob).query (.inr (.inl (t, m))))
+
+def collectionQuery (prob : TweakableHash.SM_DT_DSPR_Problem Unit Seed Bool Bool Bool)
+    (t : Bool) (m : prob.thColl.Msg ()) : OracleComp (Specs prob) Bool :=
+  liftM ((Specs prob).query (.inr (.inr ⟨(), t, m⟩)))
+
+/-- This adversary predicts the collision that always exists for `collidingHash`. -/
+def predictCollision : TweakableHash.SM_DT_DSPR_Adversary collidingProblem where
+  State := Unit
+  choose := challenge collidingProblem false false *> pure ()
+  guess _ _ := pure (0, true)
+
+/-- This adversary correctly predicts that the injective target has no second preimage. -/
+def predictNoCollision : TweakableHash.SM_DT_DSPR_Adversary injectiveProblem where
+  State := Unit
+  choose := challenge injectiveProblem false false *> pure ()
+  guess _ _ := pure (0, false)
+
+/-- A second target query exceeds the cap but is still answered and recorded. -/
+def exceedCap : TweakableHash.SM_DT_DSPR_Adversary collidingProblem where
+  State := Bool
+  choose := do
+    let _ ← challenge collidingProblem false false
+    challenge collidingProblem true false
+  guess answer _ := pure (if answer then 1 else 0, true)
+
+/-- A challenge/collection tweak clash is answered by both oracles but poisons the game. -/
+def clashCollection : TweakableHash.SM_DT_DSPR_Adversary collidingProblem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← challenge collidingProblem false false
+    let y₂ ← collectionQuery collidingProblem false true
+    return (y₁, y₂)
+  guess _ _ := pure (0, true)
+
+private lemma run_predictCollision :
+    (simulateQ (TweakableHash.SM_DT_DSPR_oracles collidingProblem .only)
+      predictCollision.choose).run .initial =
+      pure ((), ⟨[(false, false)], [], true⟩) := by
+  rfl
+
+private lemma run_predictNoCollision :
+    (simulateQ (TweakableHash.SM_DT_DSPR_oracles injectiveProblem .only)
+      predictNoCollision.choose).run .initial =
+      pure ((), ⟨[(false, false)], [], true⟩) := by
+  rfl
+
+private lemma run_exceedCap :
+    (simulateQ (TweakableHash.SM_DT_DSPR_oracles collidingProblem .only)
+      exceedCap.choose).run .initial =
+      pure (false, ⟨[(false, false), (true, false)], [], false⟩) := by
+  rfl
+
+private lemma run_clashCollection :
+    (simulateQ (TweakableHash.SM_DT_DSPR_oracles collidingProblem .only)
+      clashCollection.choose).run .initial =
+      pure ((false, true), ⟨[(false, false)], [false], false⟩) := by
+  rfl
+
+private lemma experiment_predictCollision :
+    TweakableHash.SM_DT_DSPR_Experiment predictCollision = pure true := by
+  simp only [TweakableHash.SM_DT_DSPR_Experiment, collidingProblem_seedGen, pure_bind]
+  rw [run_predictCollision]
+  rfl
+
+private lemma baseline_predictCollision :
+    TweakableHash.SM_DT_SP_Experiment predictCollision = pure true := by
+  simp only [TweakableHash.SM_DT_SP_Experiment, collidingProblem_seedGen, pure_bind]
+  rw [run_predictCollision]
+  rfl
+
+private lemma experiment_predictNoCollision :
+    TweakableHash.SM_DT_DSPR_Experiment predictNoCollision = pure true := by
+  simp only [TweakableHash.SM_DT_DSPR_Experiment, injectiveProblem_seedGen, pure_bind]
+  rw [run_predictNoCollision]
+  rfl
+
+private lemma baseline_predictNoCollision :
+    TweakableHash.SM_DT_SP_Experiment predictNoCollision = pure false := by
+  simp only [TweakableHash.SM_DT_SP_Experiment, injectiveProblem_seedGen, pure_bind]
+  rw [run_predictNoCollision]
+  rfl
+
+private lemma experiment_exceedCap :
+    TweakableHash.SM_DT_DSPR_Experiment exceedCap = pure false := by
+  simp only [TweakableHash.SM_DT_DSPR_Experiment, collidingProblem_seedGen, pure_bind]
+  rw [run_exceedCap]
+  rfl
+
+private lemma baseline_exceedCap :
+    TweakableHash.SM_DT_SP_Experiment exceedCap = pure false := by
+  simp only [TweakableHash.SM_DT_SP_Experiment, collidingProblem_seedGen, pure_bind]
+  rw [run_exceedCap]
+  rfl
+
+private lemma experiment_clashCollection :
+    TweakableHash.SM_DT_DSPR_Experiment clashCollection = pure false := by
+  simp only [TweakableHash.SM_DT_DSPR_Experiment, collidingProblem_seedGen, pure_bind]
+  rw [run_clashCollection]
+  rfl
+
+private lemma baseline_clashCollection :
+    TweakableHash.SM_DT_SP_Experiment clashCollection = pure false := by
+  simp only [TweakableHash.SM_DT_SP_Experiment, collidingProblem_seedGen, pure_bind]
+  rw [run_clashCollection]
+  rfl
+
+/-- Prediction success and `SPprob` differ on the no-second-preimage instance, while both equal one
+on the collision instance. This pins the baseline subtraction: the corresponding advantages are
+respectively one and zero. -/
+theorem baseline_subtraction_canary :
+    TweakableHash.SM_DT_DSPR_Experiment predictCollision = pure true ∧
+      TweakableHash.SM_DT_SP_Experiment predictCollision = pure true ∧
+      TweakableHash.SM_DT_DSPR_Advantage predictCollision = 0 ∧
+      TweakableHash.SM_DT_DSPR_Experiment predictNoCollision = pure true ∧
+      TweakableHash.SM_DT_SP_Experiment predictNoCollision = pure false ∧
+      TweakableHash.SM_DT_DSPR_Advantage predictNoCollision = 1 := by
+  simp [experiment_predictCollision, baseline_predictCollision, experiment_predictNoCollision,
+    baseline_predictNoCollision, TweakableHash.SM_DT_DSPR_Advantage,
+    TweakableHash.SM_DT_DSPR_Success, TweakableHash.SM_DT_SP_Probability]
+
+/-- Invalid queries are not rejected: their concrete answers are visible in the private state, all
+queries are recorded, and only the sticky final-validity bit makes both experiments lose. -/
+theorem poison_not_rejection_canary :
+    TweakableHash.SM_DT_DSPR_Experiment exceedCap = pure false ∧
+      TweakableHash.SM_DT_SP_Experiment exceedCap = pure false ∧
+      TweakableHash.SM_DT_DSPR_Experiment clashCollection = pure false ∧
+      TweakableHash.SM_DT_SP_Experiment clashCollection = pure false := by
+  exact ⟨experiment_exceedCap, baseline_exceedCap, experiment_clashCollection,
+    baseline_clashCollection⟩
+
+/-- The phase types themselves pin seed/oracle access: `choose` gets the oracle bundle but no seed,
+whereas `guess` gets the seed but has type `ProbComp` and therefore no challenge oracle. -/
+example : OracleComp (Specs collidingProblem) predictCollision.State :=
+  predictCollision.choose
+
+example : predictCollision.State → Seed → ProbComp (ℕ × Bool) := predictCollision.guess
+
+end SMDTDSPRTest

--- a/VCVioTest/SMDTOpenPRE.lean
+++ b/VCVioTest/SMDTOpenPRE.lean
@@ -193,6 +193,7 @@ lemma no_multiple_index (k : Fin (Fintype.card Input - 1)) : False :=
 /-- Concrete witness that the quantitative theorem interface asks for a cardinality-stratified
 decomposition rather than assuming its conclusion. -/
 noncomputable def validCountingLemma : TweakableHash.SM_DT_OpenPRE_CountingLemma valid where
+  uniformInputs := rfl
   singleMass := 1
   multipleMass := fun k => (no_multiple_index k).elim
   openPRE_decomposition := by

--- a/VCVioTest/SMDTOpenPRE.lean
+++ b/VCVioTest/SMDTOpenPRE.lean
@@ -27,6 +27,10 @@ instance : Fintype Input where
   elems := {.only}
   complete x := by cases x; simp
 
+instance : Unique Input where
+  default := .only
+  uniq x := by cases x; rfl
+
 instance : SampleableType Seed where
   selectElem := pure .only
   mem_support_selectElem := by simp
@@ -162,6 +166,54 @@ private lemma dspr_reduction_openedSelected :
     TweakableHash.SM_DT_DSPR_Experiment
       (TweakableHash.SM_DT_OpenPRE_toDSPR openedSelected) = pure false := by
   rfl
+
+private lemma sp_reduction_valid :
+    TweakableHash.SM_DT_SP_Experiment (TweakableHash.SM_DT_OpenPRE_toDSPR valid) =
+      pure false := by
+  rfl
+
+/-- The singleton canary has a fiber of size one and no second preimage. -/
+theorem preimage_count_canary :
+    TweakableHash.PreimageCount hash .only false false = 1 ∧
+      ¬TweakableHash.SecondPreimageExists hash .only false .only := by
+  constructor
+  · have hle : TweakableHash.PreimageCount hash .only false false ≤ 1 := by
+      calc
+        TweakableHash.PreimageCount hash .only false false ≤ Fintype.card Input :=
+          TweakableHash.preimageCount_le_card hash .only false false
+        _ = 1 := Fintype.card_unique
+    have hge : 1 ≤ TweakableHash.PreimageCount hash .only false false :=
+      TweakableHash.one_le_preimageCount_image hash .only false .only
+    exact Nat.le_antisymm hle hge
+  · simp [TweakableHash.SecondPreimageExists]
+
+lemma no_multiple_index (k : Fin (Fintype.card Input - 1)) : False :=
+  Fin.elim0 k
+
+/-- Concrete witness that the quantitative theorem interface asks for a cardinality-stratified
+decomposition rather than assuming its conclusion. -/
+noncomputable def validCountingLemma : TweakableHash.SM_DT_OpenPRE_CountingLemma valid where
+  singleMass := 1
+  multipleMass := fun k => (no_multiple_index k).elim
+  openPRE_decomposition := by
+    simp only [TweakableHash.SM_DT_OpenPRE_Advantage, experiment_valid]
+    rw [Finset.sum_eq_zero (fun k _ => (no_multiple_index k).elim)]
+    simp
+  dspr_decomposition := by
+    simp only [TweakableHash.SM_DT_DSPR_Advantage, TweakableHash.SM_DT_DSPR_Success,
+      TweakableHash.SM_DT_SP_Probability, dspr_reduction_valid, sp_reduction_valid,
+      TweakableHash.SM_DT_OpenPRE_reciprocalMass]
+    rw [Finset.sum_eq_zero (fun k _ => (no_multiple_index k).elim)]
+    simp
+  tcr_strata_le := by
+    simp only [TweakableHash.SM_DT_OpenPRE_collisionMass]
+    rw [Finset.sum_eq_zero (fun k _ => (no_multiple_index k).elim)]
+    simp
+
+theorem quantitative_reduction_interface_canary :
+    TweakableHash.SM_DT_OpenPRE_Advantage valid ≤
+      TweakableHash.SM_DT_OpenPRE_TCR_DSPR_Bound valid :=
+  TweakableHash.SM_DT_OpenPRE_le_TCR_DSPR valid validCountingLemma
 
 /-- Mutation-resistant pins for prefix truncation, final validity, and the adaptive opening
 phase. -/

--- a/VCVioTest/SMDTOpenPRE.lean
+++ b/VCVioTest/SMDTOpenPRE.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTOpenPRE
+
+/-! # SM-DT-OpenPRE exact-game canaries -/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SMDTOpenPRETest
+
+inductive Seed
+  | only
+
+inductive Input
+  | only
+  deriving Inhabited
+
+instance : SampleableType Seed where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+instance : SampleableType Input where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+@[simp] lemma uniformSample_seed : ($ᵗ Seed : ProbComp Seed) = pure .only := rfl
+
+@[simp] lemma uniformSample_input : ($ᵗ Input : ProbComp Input) = pure .only := rfl
+
+def hash : TweakableHash Seed Bool Input Bool where
+  seedGen := $ᵗ Seed
+  eval _ _ _ := false
+
+def collection : TweakableHashCollection Unit Seed Bool Bool where
+  Msg _ := Bool
+  eval _ _ _ m := m
+
+def problem1 : TweakableHash.SM_DT_OpenPRE_Problem Unit Seed Bool Input Bool where
+  th := hash
+  thColl := collection
+  numTargets := 1
+
+def problem2 : TweakableHash.SM_DT_OpenPRE_Problem Unit Seed Bool Input Bool where
+  th := hash
+  thColl := collection
+  numTargets := 2
+
+@[simp] lemma problem1_seedGen : problem1.th.seedGen = pure .only := rfl
+
+@[simp] lemma problem2_seedGen : problem2.th.seedGen = pure .only := rfl
+
+def collectionQuery1 (t m : Bool) :
+    OracleComp (unifSpec + TweakableHash.finalValidityCollectionSpec problem1.thColl) Bool :=
+  liftM ((unifSpec + TweakableHash.finalValidityCollectionSpec problem1.thColl).query
+    (.inr ⟨(), t, m⟩))
+
+def open1 (j : ℕ) :
+    OracleComp (unifSpec + TweakableHash.SM_DT_OpenPRE_openSpec Input) Input :=
+  liftM ((unifSpec + TweakableHash.SM_DT_OpenPRE_openSpec Input).query (.inr j))
+
+def valid : TweakableHash.SM_DT_OpenPRE_Adversary problem1 where
+  State := Unit
+  pick := pure ((), [false])
+  find _ _ _ := pure (0, .only)
+
+/-- A committed list longer than the cap must be truncated, not used to poison validity. -/
+def overlong : TweakableHash.SM_DT_OpenPRE_Adversary problem1 where
+  State := Unit
+  pick := pure ((), [false, true])
+  find _ _ _ := pure (0, .only)
+
+def collectionClash : TweakableHash.SM_DT_OpenPRE_Adversary problem1 where
+  State := Bool
+  pick := do
+    let y ← collectionQuery1 false true
+    return (y, [false])
+  find _ _ _ := pure (0, .only)
+
+def openedSelected : TweakableHash.SM_DT_OpenPRE_Adversary problem1 where
+  State := Unit
+  pick := pure ((), [false])
+  find _ _ _ := do
+    let _ ← open1 0
+    return (0, .only)
+
+def duplicateTargets : TweakableHash.SM_DT_OpenPRE_Adversary problem2 where
+  State := Unit
+  pick := pure ((), [false, false])
+  find _ _ _ := pure (0, .only)
+
+/-- Opening a different target remains legal. -/
+def openedOther : TweakableHash.SM_DT_OpenPRE_Adversary problem2 where
+  State := Unit
+  pick := pure ((), [false, true])
+  find _ _ _ := do
+    let _ ← open1 1
+    return (0, .only)
+
+private lemma initialize_one :
+    (TweakableHash.SM_DT_OpenPRE_initializeTargets problem1 .only [false]).run .initial =
+      pure ([false], ⟨[(false, .only)], [], true⟩) := by
+  rfl
+
+/-- This pins the source's bounded-prefix behavior independently of the final winning predicate. -/
+private lemma initialize_bounded_prefix :
+    (TweakableHash.SM_DT_OpenPRE_initializeTargets problem1 .only
+      ([false, true].take problem1.numTargets)).run .initial =
+      pure ([false], ⟨[(false, .only)], [], true⟩) := by
+  rfl
+
+private lemma experiment_valid :
+    TweakableHash.SM_DT_OpenPRE_Experiment valid = pure true := by
+  rfl
+
+private lemma experiment_overlong :
+    TweakableHash.SM_DT_OpenPRE_Experiment overlong = pure true := by
+  rfl
+
+private lemma experiment_collectionClash :
+    TweakableHash.SM_DT_OpenPRE_Experiment collectionClash = pure false := by
+  rfl
+
+private lemma experiment_openedSelected :
+    TweakableHash.SM_DT_OpenPRE_Experiment openedSelected = pure false := by
+  rfl
+
+private lemma experiment_duplicateTargets :
+    TweakableHash.SM_DT_OpenPRE_Experiment duplicateTargets = pure false := by
+  rfl
+
+private lemma experiment_openedOther :
+    TweakableHash.SM_DT_OpenPRE_Experiment openedOther = pure true := by
+  rfl
+
+/-- Mutation-resistant pins for prefix truncation, final validity, and the adaptive opening
+phase. -/
+theorem exact_game_canary :
+    TweakableHash.SM_DT_OpenPRE_Experiment valid = pure true ∧
+      TweakableHash.SM_DT_OpenPRE_Experiment overlong = pure true ∧
+      TweakableHash.SM_DT_OpenPRE_Experiment collectionClash = pure false ∧
+      TweakableHash.SM_DT_OpenPRE_Experiment openedSelected = pure false ∧
+      TweakableHash.SM_DT_OpenPRE_Experiment duplicateTargets = pure false ∧
+      TweakableHash.SM_DT_OpenPRE_Experiment openedOther = pure true :=
+  ⟨experiment_valid, experiment_overlong, experiment_collectionClash,
+    experiment_openedSelected, experiment_duplicateTargets, experiment_openedOther⟩
+
+end SMDTOpenPRETest

--- a/VCVioTest/SMDTOpenPRE.lean
+++ b/VCVioTest/SMDTOpenPRE.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 
 module
 
-public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTOpenPRE
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.OpenPREFromTCRDSPR
 
 /-! # SM-DT-OpenPRE exact-game canaries -/
 
@@ -21,7 +21,11 @@ inductive Seed
 
 inductive Input
   | only
-  deriving Inhabited
+  deriving DecidableEq, Inhabited
+
+instance : Fintype Input where
+  elems := {.only}
+  complete x := by cases x; simp
 
 instance : SampleableType Seed where
   selectElem := pure .only
@@ -144,6 +148,21 @@ private lemma experiment_openedOther :
     TweakableHash.SM_DT_OpenPRE_Experiment openedOther = pure true := by
   rfl
 
+private lemma tcr_reduction_valid :
+    TweakableHash.SM_DT_TCR_Experiment (TweakableHash.SM_DT_OpenPRE_toTCR valid) =
+      pure false := by
+  rfl
+
+private lemma dspr_reduction_valid :
+    TweakableHash.SM_DT_DSPR_Experiment (TweakableHash.SM_DT_OpenPRE_toDSPR valid) =
+      pure true := by
+  rfl
+
+private lemma dspr_reduction_openedSelected :
+    TweakableHash.SM_DT_DSPR_Experiment
+      (TweakableHash.SM_DT_OpenPRE_toDSPR openedSelected) = pure false := by
+  rfl
+
 /-- Mutation-resistant pins for prefix truncation, final validity, and the adaptive opening
 phase. -/
 theorem exact_game_canary :
@@ -152,8 +171,15 @@ theorem exact_game_canary :
       TweakableHash.SM_DT_OpenPRE_Experiment collectionClash = pure false ∧
       TweakableHash.SM_DT_OpenPRE_Experiment openedSelected = pure false ∧
       TweakableHash.SM_DT_OpenPRE_Experiment duplicateTargets = pure false ∧
-      TweakableHash.SM_DT_OpenPRE_Experiment openedOther = pure true :=
+      TweakableHash.SM_DT_OpenPRE_Experiment openedOther = pure true ∧
+      TweakableHash.SM_DT_TCR_Experiment (TweakableHash.SM_DT_OpenPRE_toTCR valid) =
+        pure false ∧
+      TweakableHash.SM_DT_DSPR_Experiment (TweakableHash.SM_DT_OpenPRE_toDSPR valid) =
+        pure true ∧
+      TweakableHash.SM_DT_DSPR_Experiment
+        (TweakableHash.SM_DT_OpenPRE_toDSPR openedSelected) = pure false :=
   ⟨experiment_valid, experiment_overlong, experiment_collectionClash,
-    experiment_openedSelected, experiment_duplicateTargets, experiment_openedOther⟩
+    experiment_openedSelected, experiment_duplicateTargets, experiment_openedOther,
+    tcr_reduction_valid, dspr_reduction_valid, dspr_reduction_openedSelected⟩
 
 end SMDTOpenPRETest

--- a/VCVioTest/SMDTOpenPRE.lean
+++ b/VCVioTest/SMDTOpenPRE.lean
@@ -47,11 +47,13 @@ def collection : TweakableHashCollection Unit Seed Bool Bool where
 
 def problem1 : TweakableHash.SM_DT_OpenPRE_Problem Unit Seed Bool Input Bool where
   th := hash
+  inputGen := $ᵗ Input
   thColl := collection
   numTargets := 1
 
 def problem2 : TweakableHash.SM_DT_OpenPRE_Problem Unit Seed Bool Input Bool where
   th := hash
+  inputGen := $ᵗ Input
   thColl := collection
   numTargets := 2
 

--- a/VCVioTest/SMDTPRE.lean
+++ b/VCVioTest/SMDTPRE.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
+
+/-! # SM-DT-PRE final-validity canaries -/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SMDTPRETest
+
+inductive Seed
+  | only
+
+inductive Input
+  | only
+
+instance : SampleableType Seed where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+@[simp] lemma uniformSample_seed : ($ᵗ Seed : ProbComp Seed) = pure .only := rfl
+
+instance : SampleableType Input where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+@[simp] lemma uniformSample_input : ($ᵗ Input : ProbComp Input) = pure .only := rfl
+
+def hash : TweakableHash Seed Bool Bool Bool where
+  seedGen := $ᵗ Seed
+  eval _ _ _ := false
+
+def collection : TweakableHashCollection Unit Seed Bool Bool where
+  Msg _ := Bool
+  eval _ _ _ m := m
+
+def problem : TweakableHash.SM_DT_PRE_Problem Unit Seed Bool Bool Input Bool where
+  th := hash
+  emb _ := false
+  emb_injective := fun _ _ _ => rfl
+  thColl := collection
+  numTargets := 1
+
+@[simp] lemma problem_seedGen : problem.th.seedGen = pure .only := rfl
+
+abbrev Specs := unifSpec + (TweakableHash.SM_DT_PRE_challengeSpec Bool Bool +
+  TweakableHash.finalValidityCollectionSpec problem.thColl)
+
+def challenge (t : Bool) : OracleComp Specs Bool := liftM (Specs.query (.inr (.inl t)))
+
+def collectionQuery (t : Bool) (m : problem.thColl.Msg ()) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inr ⟨(), t, m⟩)))
+
+def valid : TweakableHash.SM_DT_PRE_Adversary problem where
+  State := Bool
+  choose := challenge false
+  invert _ _ := pure (0, .only)
+
+def duplicateTarget : TweakableHash.SM_DT_PRE_Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← challenge false
+    let y₂ ← challenge false
+    return (y₁, y₂)
+  invert _ _ := pure (0, .only)
+
+def collectionClash : TweakableHash.SM_DT_PRE_Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← collectionQuery false true
+    let y₂ ← challenge false
+    return (y₁, y₂)
+  invert _ _ := pure (0, .only)
+
+private lemma run_valid :
+    (simulateQ (TweakableHash.SM_DT_PRE_oracles problem .only) valid.choose).run .initial =
+      pure (false, ⟨[(false, .only)], [], true⟩) := by
+  rfl
+
+private lemma run_duplicateTarget :
+    (simulateQ (TweakableHash.SM_DT_PRE_oracles problem .only)
+      duplicateTarget.choose).run .initial =
+      pure ((false, false), ⟨[(false, .only), (false, .only)], [], false⟩) := by
+  rfl
+
+private lemma run_collectionClash :
+    (simulateQ (TweakableHash.SM_DT_PRE_oracles problem .only)
+      collectionClash.choose).run .initial =
+      pure ((true, false), ⟨[(false, .only)], [false], false⟩) := by
+  rfl
+
+private lemma experiment_valid : TweakableHash.SM_DT_PRE_Experiment valid = pure true := by
+  simp only [TweakableHash.SM_DT_PRE_Experiment, problem_seedGen, pure_bind]
+  rw [run_valid]
+  rfl
+
+private lemma experiment_duplicateTarget :
+    TweakableHash.SM_DT_PRE_Experiment duplicateTarget = pure false := by
+  simp only [TweakableHash.SM_DT_PRE_Experiment, problem_seedGen, pure_bind]
+  rw [run_duplicateTarget]
+  rfl
+
+private lemma experiment_collectionClash :
+    TweakableHash.SM_DT_PRE_Experiment collectionClash = pure false := by
+  simp only [TweakableHash.SM_DT_PRE_Experiment, problem_seedGen, pure_bind]
+  rw [run_collectionClash]
+  rfl
+
+/-- Valid inversion wins, while answered-and-recorded duplicate/cross queries poison the game. -/
+theorem final_validity_canary :
+    TweakableHash.SM_DT_PRE_Experiment valid = pure true ∧
+      TweakableHash.SM_DT_PRE_Experiment duplicateTarget = pure false ∧
+      TweakableHash.SM_DT_PRE_Experiment collectionClash = pure false :=
+  ⟨experiment_valid, experiment_duplicateTarget, experiment_collectionClash⟩
+
+end SMDTPRETest

--- a/VCVioTest/SMDTUDC.lean
+++ b/VCVioTest/SMDTUDC.lean
@@ -1,0 +1,261 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTUDC
+
+/-!
+# SM-DT-UD-C final-validity canaries
+
+These executable games pin real/ideal separation, always-answering cap/duplicate/cross poisoning,
+and the fact that repeated collection-only tweaks remain valid.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SMDTUDCTest
+
+inductive Seed
+  | only
+
+instance : SampleableType Seed where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+@[simp] lemma uniformSample_seed : ($ᵗ Seed : ProbComp Seed) = pure .only := rfl
+
+/-- Real challenges are always `false`; ideal challenges are always `true`. -/
+def hash : TweakableHash Seed Bool Bool Bool where
+  seedGen := $ᵗ Seed
+  eval _ _ m := m
+
+def collection : TweakableHashCollection Unit Seed Bool Bool where
+  Msg _ := Bool
+  eval _ _ _ m := m
+
+def problem : TweakableHash.SM_DT_UD_C_Problem Unit Seed Bool Bool Bool where
+  th := hash
+  inputGen := pure false
+  outputGen := pure true
+  thColl := collection
+  numTargets := 1
+
+@[simp] lemma problem_seedGen : problem.th.seedGen = pure .only := rfl
+
+abbrev Specs := unifSpec +
+  (TweakableHash.SM_DT_UD_C_challengeSpec Bool Bool +
+    TweakableHash.finalValidityCollectionSpec problem.thColl)
+
+def challenge (t : Bool) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inl t)))
+
+def collectionQuery (t : Bool) (m : problem.thColl.Msg ()) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inr ⟨(), t, m⟩)))
+
+/-- The response itself distinguishes the deliberately separated real and ideal generators. -/
+def separate : TweakableHash.SM_DT_UD_C_Adversary problem where
+  State := Bool
+  pick := challenge false
+  distinguish y _ := pure (!y)
+
+/-- The reverse distinguisher pins the other direction of the symmetric advantage. -/
+def separateReverse : TweakableHash.SM_DT_UD_C_Adversary problem where
+  State := Bool
+  pick := challenge false
+  distinguish y _ := pure y
+
+/-- The second distinct target exceeds the cap, but its answer is still returned. -/
+def exceedCap : TweakableHash.SM_DT_UD_C_Adversary problem where
+  State := Bool × Bool
+  pick := do
+    let y₁ ← challenge false
+    let y₂ ← challenge true
+    return (y₁, y₂)
+  distinguish _ _ := pure true
+
+/-- Reusing a target tweak is answered twice and poisons final validity. -/
+def duplicateTarget : TweakableHash.SM_DT_UD_C_Adversary problem where
+  State := Bool × Bool
+  pick := do
+    let y₁ ← challenge false
+    let y₂ ← challenge false
+    return (y₁, y₂)
+  distinguish _ _ := pure true
+
+/-- A collection query at a target tweak is answered and poisons final validity. -/
+def crossClash : TweakableHash.SM_DT_UD_C_Adversary problem where
+  State := Bool × Bool
+  pick := do
+    let y₁ ← challenge false
+    let y₂ ← collectionQuery false true
+    return (y₁, y₂)
+  distinguish _ _ := pure true
+
+/-- Repeating a collection-only tweak is valid; collection tweaks need not be distinct. -/
+def repeatCollection : TweakableHash.SM_DT_UD_C_Adversary problem where
+  State := Bool × Bool
+  pick := do
+    let y₁ ← collectionQuery false false
+    let y₂ ← collectionQuery false false
+    return (y₁, y₂)
+  distinguish _ _ := pure true
+
+private lemma run_separate_real :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .real problem .only)
+      separate.pick).run .initial =
+      pure (false, ⟨[false], [], true⟩) := by
+  rfl
+
+private lemma run_separate_ideal :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .ideal problem .only)
+      separate.pick).run .initial =
+      pure (true, ⟨[false], [], true⟩) := by
+  rfl
+
+private lemma run_separateReverse_real :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .real problem .only)
+      separateReverse.pick).run .initial =
+      pure (false, ⟨[false], [], true⟩) := by
+  rfl
+
+private lemma run_separateReverse_ideal :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .ideal problem .only)
+      separateReverse.pick).run .initial =
+      pure (true, ⟨[false], [], true⟩) := by
+  rfl
+
+private lemma run_exceedCap_real :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .real problem .only)
+      exceedCap.pick).run .initial =
+      pure ((false, false), ⟨[false, true], [], false⟩) := by
+  rfl
+
+private lemma run_duplicateTarget_real :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .real problem .only)
+      duplicateTarget.pick).run .initial =
+      pure ((false, false), ⟨[false, false], [], false⟩) := by
+  rfl
+
+private lemma run_crossClash_real :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .real problem .only)
+      crossClash.pick).run .initial =
+      pure ((false, true), ⟨[false], [false], false⟩) := by
+  rfl
+
+private lemma run_repeatCollection_real :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .real problem .only)
+      repeatCollection.pick).run .initial =
+      pure ((false, false), ⟨[], [false, false], true⟩) := by
+  rfl
+
+private lemma run_repeatCollection_ideal :
+    (simulateQ (TweakableHash.SM_DT_UD_C_oracles .ideal problem .only)
+      repeatCollection.pick).run .initial =
+      pure ((false, false), ⟨[], [false, false], true⟩) := by
+  rfl
+
+private lemma experiment_separate_real :
+    TweakableHash.SM_DT_UD_C_Experiment .real separate = pure true := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_separate_real]
+  rfl
+
+private lemma experiment_separate_ideal :
+    TweakableHash.SM_DT_UD_C_Experiment .ideal separate = pure false := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_separate_ideal]
+  rfl
+
+private lemma experiment_separateReverse_real :
+    TweakableHash.SM_DT_UD_C_Experiment .real separateReverse = pure false := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_separateReverse_real]
+  rfl
+
+private lemma experiment_separateReverse_ideal :
+    TweakableHash.SM_DT_UD_C_Experiment .ideal separateReverse = pure true := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_separateReverse_ideal]
+  rfl
+
+private lemma experiment_exceedCap_real :
+    TweakableHash.SM_DT_UD_C_Experiment .real exceedCap = pure false := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_exceedCap_real]
+  rfl
+
+private lemma experiment_duplicateTarget_real :
+    TweakableHash.SM_DT_UD_C_Experiment .real duplicateTarget = pure false := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_duplicateTarget_real]
+  rfl
+
+private lemma experiment_crossClash_real :
+    TweakableHash.SM_DT_UD_C_Experiment .real crossClash = pure false := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_crossClash_real]
+  rfl
+
+private lemma experiment_repeatCollection_real :
+    TweakableHash.SM_DT_UD_C_Experiment .real repeatCollection = pure true := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_repeatCollection_real]
+  rfl
+
+private lemma experiment_repeatCollection_ideal :
+    TweakableHash.SM_DT_UD_C_Experiment .ideal repeatCollection = pure true := by
+  simp only [TweakableHash.SM_DT_UD_C_Experiment, problem_seedGen, pure_bind]
+  rw [run_repeatCollection_ideal]
+  rfl
+
+/-- The explicit input/output generators separate the worlds, and the symmetric gap is one. -/
+theorem real_ideal_separation_canary :
+    TweakableHash.SM_DT_UD_C_Experiment .real separate = pure true ∧
+      TweakableHash.SM_DT_UD_C_Experiment .ideal separate = pure false ∧
+      TweakableHash.SM_DT_UD_C_RealSuccess separate = 1 ∧
+      TweakableHash.SM_DT_UD_C_IdealSuccess separate = 0 ∧
+      TweakableHash.SM_DT_UD_C_Advantage separate = 1 ∧
+      TweakableHash.SM_DT_UD_Advantage separate = 1 := by
+  simp [experiment_separate_real, experiment_separate_ideal,
+    TweakableHash.SM_DT_UD_C_RealSuccess, TweakableHash.SM_DT_UD_C_IdealSuccess,
+    TweakableHash.SM_DT_UD_C_Advantage, TweakableHash.SM_DT_UD_Advantage]
+
+/-- The reverse gap is also one. A one-sided `real - ideal` definition would make this zero. -/
+theorem symmetric_gap_reverse_canary :
+    TweakableHash.SM_DT_UD_C_Experiment .real separateReverse = pure false ∧
+      TweakableHash.SM_DT_UD_C_Experiment .ideal separateReverse = pure true ∧
+      TweakableHash.SM_DT_UD_C_RealSuccess separateReverse = 0 ∧
+      TweakableHash.SM_DT_UD_C_IdealSuccess separateReverse = 1 ∧
+      TweakableHash.SM_DT_UD_C_Advantage separateReverse = 1 := by
+  simp [experiment_separateReverse_real, experiment_separateReverse_ideal,
+    TweakableHash.SM_DT_UD_C_RealSuccess, TweakableHash.SM_DT_UD_C_IdealSuccess,
+    TweakableHash.SM_DT_UD_C_Advantage]
+
+/-- Cap, duplicate-target, and cross-oracle violations poison only the final conjunction: all
+queries returned their concrete real-world answers and were recorded in the run lemmas above. -/
+theorem final_validity_poison_canary :
+    TweakableHash.SM_DT_UD_C_Experiment .real exceedCap = pure false ∧
+      TweakableHash.SM_DT_UD_C_Experiment .real duplicateTarget = pure false ∧
+      TweakableHash.SM_DT_UD_C_Experiment .real crossClash = pure false := by
+  exact ⟨experiment_exceedCap_real, experiment_duplicateTarget_real,
+    experiment_crossClash_real⟩
+
+/-- Repeated collection-only tweaks remain valid in both worlds. -/
+theorem repeated_collection_allowed_canary :
+    TweakableHash.SM_DT_UD_C_Experiment .real repeatCollection = pure true ∧
+      TweakableHash.SM_DT_UD_C_Experiment .ideal repeatCollection = pure true := by
+  exact ⟨experiment_repeatCollection_real, experiment_repeatCollection_ideal⟩
+
+/-- The phase types expose the challenge/collection bundle only before seed reveal. -/
+example : OracleComp Specs separate.State := separate.pick
+
+example : separate.State → Seed → ProbComp Bool := separate.distinguish
+
+end SMDTUDCTest


### PR DESCRIPTION
## Stack

Depends on #573. This is the single working PR for the focused SLH-DSA sprint and remains draft because the program-level reductions listed below are still theorem inputs.

## What is machine-checked

- source-final-validity SM-DT-TCR, PRE, DSPR, OpenPRE, and UD-C games, including executable stand-alone FORS-leaf OpenPRE-to-DSPR/TCR adversaries and collection games for the remaining hash terms
- the exact EasyCrypt low-level accounting:
  `PRF_sk + PRF_msg + ITSR_Hmsg + DSPR_F + 3*TCR_F + TCR_FORS-tree + TCR_FORS-roots + (w-2)*UD_F + TCR_F + PRE_F + TCR_WOTS-pk + TCR_XMSS-tree`
- exact `d = 1` target caps, reachable ADRS enumerations, and `Nodup` proofs for the seven target families
- restricted injectivity of compressed SHA-2 `ADRSc` on every reachable target family (without a false global injectivity assumption)
- injectivity of the concrete full-width WOTS base-4 message encoding
- concrete SHA2-128-24 conditional EUF-CMA theorem with the WOTS coefficient reduced to exactly `2`
- concrete conditional SUF-CMA theorem equal to the EUF expression plus the exact same-message/new-signature residual
- an exact pointwise split of that SUF residual into fresh `(R, M)` and reused `(R, M)`, with a distinct logged-signature witness in the reused branch
- deterministic FORS/WOTS/XMSS witness translations, including the source WOTS TCR-or-PRE chain split and an exhaustive XMSS root-forgery split into honest WOTS consistency, WOTS-PK TCR, or XMSS-tree TCR
- mutation-relevant exact-game canaries for phase boundaries, final validity, opening, freshness, and malformed signatures

The low-level expression is source-faithful and quantitative, but conditional: all representation-level gates are proved; the four composition inequalities and OpenPRE coupling below are still explicit certificate fields rather than constructed transformations.

## Semantic disposition relative to #573

#573 deliberately chose reject-on-arrival TCR/PRE collection games, while recording that the BDHMS final-predicate games are distinct adaptive experiments. This stack intentionally replaces those public TCR/PRE definitions with the source-final-validity semantics needed for the recovered SPHINCS+ proof: every query is answered and recorded, and a sticky bit is equivalent to the final validity predicate.

This is not a mechanical extension of #573. Before this stack is ready, maintainers must approve that semantic replacement (or request distinct names for both variants), and all consumers must be audited against that choice.

## Open proof obligations

1. Construct and prove the top-level, M-FORS, fixed-length XMSS, and WOTS program transformations currently represented by the four inequalities in `D1CompositionCertificate`. The deterministic WOTS TCR/PRE extraction and XMSS event inclusion are proved; constructing the source-game adversaries and transporting these facts through their transcripts remain.
2. Prove the program-level probability coupling behind `SM_DT_OpenPRE_CountingLemma`. The finite-fiber algebra, uniform-input condition, executable DSPR/TCR reductions, and final inequality are already proved; the remaining work identifies the actual experiment probabilities with the singleton/larger-fiber strata.
3. For genuine SUF-CMA, lift the proved `(R, M)` partition to experiments: route the fresh-pair branch through pair-fresh Hmsg ITSR, and reduce the reused-pair branch to fixed-pair FORS/WOTS/XMSS binding. The cited source proves EUF only, so the proposed binding extension remains separate and is not called negligible here.

Target-versus-collection cross-disjointness belongs to the concrete reduction transcripts and is enforced by the final-validity games; it is not hidden inside the per-family `Nodup` certificate. The certificate's parameter/encoding/separation fields are explicit future-constructor gates; the current algebraic theorem projects only `composition` and `openPreCounting`.

## Source crosswalk

- Barbosa et al., [A Tight Security Proof for SPHINCS+, Formally Verified](https://eprint.iacr.org/2024/910)
- [EasyCrypt artifact](https://github.com/MM45/FV-SPHINCSPLUS-EC), especially `proofs/SPHINCS_PLUS.ec`, `FORS_ES.ec`, `WOTS_TW_ES.ec`, `FL_SL_XMSS_MT_ES.ec`, and the OpenPRE/TCR/DSPR theories
- [FIPS 205](https://csrc.nist.gov/pubs/fips/205/final) for SLH-DSA
- [SP 800-230 Initial Public Draft](https://csrc.nist.gov/pubs/sp/800/230/ipd) for the reduced SHA2-128-24 profile and its `2^24` signature/key usage cap; this PR does not describe that draft profile as general-purpose FIPS approval

## Validation

- exact final head `840b7623` full project build and style gate are green (3,730 jobs)
- exact final head axiom sweep is green (16,106 declarations across 502 modules; no new `sorryAx`, native trust, or non-standard axioms); the sweep's fixture matrix also passes
- exact-head targeted builds for the games, reductions, concrete theorem, `VCVioTest`, and `HashSigTest` are green
- SHA2-128-24 and C13 differential KATs pass locally and in hosted CI; the proof-only `Fintype (Bytes 16)` is kept local to `Concrete.Security`, so executable imports do not eagerly enumerate the `2^128` node space
- PMF/SPMF boundary is unchanged from the stacked base (1,923 occurrences versus 1,923)
- PolyFun, complexity-backend, Interop, Extern, generated-import, agent-documentation, downstream-consumer, diff, and style gates pass
- independent `review-lean-formalization` re-gate at `840b7623` reports no P0–P3 findings and PASS for the intended draft/foundations milestone

Exact-head GitHub CI is green. This PR must remain draft until the program-level proof obligations above are discharged.
