### PR TITLE
feat(SLHDSA): validate all FIPS 205 parameter sets

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -88,4 +88,4 @@ jobs:
       # project deliberately defines no `lint-style` exe, so it does not link the
       # FFI backends). Pass the libraries explicitly for full coverage.
       - name: Run text-based style linters
-        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Scheme HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT
+        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Params HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Scheme HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT

--- a/HashSig/SLHDSA/Params.lean
+++ b/HashSig/SLHDSA/Params.lean
@@ -11,10 +11,10 @@ public import VCVio.OracleComp.Constructions.SampleableType
 /-!
 # SLH-DSA Parameters
 
-Fixed constants and the named parameter sets for SLH-DSA (SPHINCS+, FIPS 205). The development
-stays generic over the variable parameters while exposing the named instantiation we target
-first, **SLH-DSA-SHA2-128-24** (the NIST SP 800-230 reduced parameter set:
-`n=16, h=22, d=1, h'=22, a=24, k=6, w=4`).
+Raw arithmetic parameters, their mathematical validity conditions, and the named parameter sets
+for SLH-DSA (SPHINCS+, FIPS 205). `FipsParameterSet` enumerates all twelve approved FIPS 205
+instantiations. The SP 800-230 reduced `SLH-DSA-SHA2-128-24` profile is kept separately in
+`LimitedParameterSet`.
 
 The Winternitz and FORS lengths are derived from the primary parameters exactly as in FIPS 205
 §5 (Eqs 5.1–5.3) and §9 (the message-digest length `m`); see `Params.len1`, `Params.len2`,
@@ -57,6 +57,55 @@ deriving Repr, DecidableEq
 
 namespace Params
 
+/-- Mathematical well-formedness conditions shared by the generic SLH-DSA algorithms.
+
+Hash-family-specific address bounds do not belong here; they are properties of concrete
+instantiations and their reachable addresses. -/
+structure Valid (p : Params) : Prop where
+  /-- Hash outputs contain at least one byte. -/
+  n_pos : 0 < p.n
+  /-- A hypertree contains at least one layer. -/
+  d_pos : 0 < p.d
+  /-- Every XMSS tree has positive height. -/
+  hp_pos : 0 < p.hp
+  /-- Every FORS tree has positive height. -/
+  a_pos : 0 < p.a
+  /-- FORS contains at least one tree. -/
+  k_pos : 0 < p.k
+  /-- The Winternitz base exponent is positive. -/
+  lgw_pos : 0 < p.lgw
+  /-- WOTS+ message digits consume exactly the `n` input bytes without a zero-filled tail. -/
+  wots_input_aligned : p.lgw ∣ 8 * p.n
+  /-- The total height is exactly the sum of the equal-height XMSS layers. -/
+  h_eq_layers : p.h = p.d * p.hp
+
+instance (p : Params) : Decidable p.Valid :=
+  if hn : 0 < p.n then
+    if hd : 0 < p.d then
+      if hhp : 0 < p.hp then
+        if ha : 0 < p.a then
+          if hk : 0 < p.k then
+            if hlgw : 0 < p.lgw then
+              if haligned : p.lgw ∣ 8 * p.n then
+                if hh : p.h = p.d * p.hp then
+                  isTrue ⟨hn, hd, hhp, ha, hk, hlgw, haligned, hh⟩
+                else
+                  isFalse fun h => hh h.h_eq_layers
+              else
+                isFalse fun h => haligned h.wots_input_aligned
+            else
+              isFalse fun h => hlgw h.lgw_pos
+          else
+            isFalse fun h => hk h.k_pos
+        else
+          isFalse fun h => ha h.a_pos
+      else
+        isFalse fun h => hhp h.hp_pos
+    else
+      isFalse fun h => hd h.d_pos
+  else
+    isFalse fun h => hn h.n_pos
+
 /-- The Winternitz parameter `w = 2^lgw` (FIPS 205 Eq 5.1). -/
 def w (p : Params) : ℕ := 2 ^ p.lgw
 
@@ -97,24 +146,203 @@ def secretKeyBytes (p : Params) : ℕ := 4 * p.n
 
 end Params
 
-/-- The named SLH-DSA parameter sets supported here. Currently only the SHA-2 128-24 reduced
-set; SHAKE / 192 / 256 / C-series variants are future additions. -/
-inductive ParameterSet where
+/-- Raw SLH-DSA parameters paired with a proof of their mathematical validity.
+
+Generic multi-layer algorithms should accept this bundle instead of accepting a bare `Params`.
+There is deliberately no coercion back to `Params`: consumers must project `.params`, making the
+point at which a validity proof is discarded visible. -/
+structure ValidatedParams where
+  /-- The executable arithmetic parameters. -/
+  params : Params
+  /-- Evidence that the arithmetic parameters are well formed. -/
+  valid : params.Valid
+
+namespace Params
+
+/-- Check raw arithmetic parameters and package them with the resulting validity proof. -/
+def validate (p : Params) : Option ValidatedParams :=
+  if h : p.Valid then some ⟨p, h⟩ else none
+
+@[simp]
+theorem validate_eq_none_iff (p : Params) : p.validate = none ↔ ¬p.Valid := by
+  simp [validate]
+
+@[simp]
+theorem validate_isSome_iff (p : Params) : p.validate.isSome = true ↔ p.Valid := by
+  simp [validate]
+
+end Params
+
+/-- Hash families approved for SLH-DSA by FIPS 205. -/
+inductive HashFamily where
+  | sha2
+  | shake
+deriving Repr, DecidableEq, BEq
+
+/-- The twelve approved parameter-set names from FIPS 205, Table 2. -/
+inductive FipsParameterSet where
+  | SLHDSA_SHA2_128s
+  | SLHDSA_SHA2_128f
+  | SLHDSA_SHA2_192s
+  | SLHDSA_SHA2_192f
+  | SLHDSA_SHA2_256s
+  | SLHDSA_SHA2_256f
+  | SLHDSA_SHAKE_128s
+  | SLHDSA_SHAKE_128f
+  | SLHDSA_SHAKE_192s
+  | SLHDSA_SHAKE_192f
+  | SLHDSA_SHAKE_256s
+  | SLHDSA_SHAKE_256f
+deriving Repr, DecidableEq, BEq
+
+/-- Reference byte lengths fixed by the FIPS 205 parameter-set table. -/
+structure FipsExpectedSizes where
+  /-- Output length of `H_msg`. -/
+  digest : ℕ
+  /-- Encoded public-key length. -/
+  publicKey : ℕ
+  /-- Encoded secret-key length. -/
+  secretKey : ℕ
+  /-- Encoded signature length. -/
+  signature : ℕ
+deriving Repr, DecidableEq, BEq
+
+namespace FipsParameterSet
+
+/-- All FIPS 205 parameter sets in family-major order, with SHA2 followed by SHAKE. -/
+def all : List FipsParameterSet :=
+  [.SLHDSA_SHA2_128s, .SLHDSA_SHA2_128f, .SLHDSA_SHA2_192s, .SLHDSA_SHA2_192f,
+    .SLHDSA_SHA2_256s, .SLHDSA_SHA2_256f, .SLHDSA_SHAKE_128s, .SLHDSA_SHAKE_128f,
+    .SLHDSA_SHAKE_192s, .SLHDSA_SHAKE_192f, .SLHDSA_SHAKE_256s, .SLHDSA_SHAKE_256f]
+
+/-- The exact standardized spelling of a FIPS 205 parameter-set name. -/
+def name : FipsParameterSet → String
+  | .SLHDSA_SHA2_128s => "SLH-DSA-SHA2-128s"
+  | .SLHDSA_SHA2_128f => "SLH-DSA-SHA2-128f"
+  | .SLHDSA_SHA2_192s => "SLH-DSA-SHA2-192s"
+  | .SLHDSA_SHA2_192f => "SLH-DSA-SHA2-192f"
+  | .SLHDSA_SHA2_256s => "SLH-DSA-SHA2-256s"
+  | .SLHDSA_SHA2_256f => "SLH-DSA-SHA2-256f"
+  | .SLHDSA_SHAKE_128s => "SLH-DSA-SHAKE-128s"
+  | .SLHDSA_SHAKE_128f => "SLH-DSA-SHAKE-128f"
+  | .SLHDSA_SHAKE_192s => "SLH-DSA-SHAKE-192s"
+  | .SLHDSA_SHAKE_192f => "SLH-DSA-SHAKE-192f"
+  | .SLHDSA_SHAKE_256s => "SLH-DSA-SHAKE-256s"
+  | .SLHDSA_SHAKE_256f => "SLH-DSA-SHAKE-256f"
+
+/-- The hash family selected by a FIPS 205 parameter set. -/
+def hashFamily : FipsParameterSet → HashFamily
+  | .SLHDSA_SHA2_128s | .SLHDSA_SHA2_128f | .SLHDSA_SHA2_192s | .SLHDSA_SHA2_192f
+  | .SLHDSA_SHA2_256s | .SLHDSA_SHA2_256f => .sha2
+  | .SLHDSA_SHAKE_128s | .SLHDSA_SHAKE_128f | .SLHDSA_SHAKE_192s | .SLHDSA_SHAKE_192f
+  | .SLHDSA_SHAKE_256s | .SLHDSA_SHAKE_256f => .shake
+
+/-- Interpret a FIPS 205 parameter-set name as its exact arithmetic parameters. -/
+def params : FipsParameterSet → Params
+  | .SLHDSA_SHA2_128s | .SLHDSA_SHAKE_128s =>
+      { n := 16, h := 63, d := 7, hp := 9, a := 12, k := 14, lgw := 4 }
+  | .SLHDSA_SHA2_128f | .SLHDSA_SHAKE_128f =>
+      { n := 16, h := 66, d := 22, hp := 3, a := 6, k := 33, lgw := 4 }
+  | .SLHDSA_SHA2_192s | .SLHDSA_SHAKE_192s =>
+      { n := 24, h := 63, d := 7, hp := 9, a := 14, k := 17, lgw := 4 }
+  | .SLHDSA_SHA2_192f | .SLHDSA_SHAKE_192f =>
+      { n := 24, h := 66, d := 22, hp := 3, a := 8, k := 33, lgw := 4 }
+  | .SLHDSA_SHA2_256s | .SLHDSA_SHAKE_256s =>
+      { n := 32, h := 64, d := 8, hp := 8, a := 14, k := 22, lgw := 4 }
+  | .SLHDSA_SHA2_256f | .SLHDSA_SHAKE_256f =>
+      { n := 32, h := 68, d := 17, hp := 4, a := 9, k := 35, lgw := 4 }
+
+/-- Reference sizes from FIPS 205, rather than values recomputed from `params`. -/
+def expectedSizes : FipsParameterSet → FipsExpectedSizes
+  | .SLHDSA_SHA2_128s | .SLHDSA_SHAKE_128s =>
+      { digest := 30, publicKey := 32, secretKey := 64, signature := 7856 }
+  | .SLHDSA_SHA2_128f | .SLHDSA_SHAKE_128f =>
+      { digest := 34, publicKey := 32, secretKey := 64, signature := 17088 }
+  | .SLHDSA_SHA2_192s | .SLHDSA_SHAKE_192s =>
+      { digest := 39, publicKey := 48, secretKey := 96, signature := 16224 }
+  | .SLHDSA_SHA2_192f | .SLHDSA_SHAKE_192f =>
+      { digest := 42, publicKey := 48, secretKey := 96, signature := 35664 }
+  | .SLHDSA_SHA2_256s | .SLHDSA_SHAKE_256s =>
+      { digest := 47, publicKey := 64, secretKey := 128, signature := 29792 }
+  | .SLHDSA_SHA2_256f | .SLHDSA_SHAKE_256f =>
+      { digest := 49, publicKey := 64, secretKey := 128, signature := 49856 }
+
+/-- Every named FIPS 205 parameter set has mathematically valid arithmetic parameters. -/
+theorem params_valid (ps : FipsParameterSet) : ps.params.Valid := by
+  cases ps <;> decide
+
+/-- A FIPS 205 parameter set packaged for generic algorithms that require validity. -/
+def validatedParams (ps : FipsParameterSet) : ValidatedParams :=
+  ⟨ps.params, ps.params_valid⟩
+
+/-- Derived digest, key, and signature sizes agree with the independent FIPS table constants. -/
+theorem derived_sizes_eq_expected (ps : FipsParameterSet) :
+    ps.params.m = ps.expectedSizes.digest ∧
+    ps.params.publicKeyBytes = ps.expectedSizes.publicKey ∧
+    ps.params.secretKeyBytes = ps.expectedSizes.secretKey ∧
+    ps.params.signatureBytes = ps.expectedSizes.signature := by
+  cases ps <;> decide
+
+/-- `all` contains every FIPS 205 parameter set. -/
+@[simp]
+theorem mem_all (ps : FipsParameterSet) : ps ∈ all := by
+  cases ps <;> simp [all]
+
+/-- `all` contains no duplicate parameter-set name. -/
+theorem all_nodup : all.Nodup := by
+  decide
+
+end FipsParameterSet
+
+/-- Recognize the arithmetic shapes underlying FIPS 205 parameter sets.
+
+The raw record does not encode the hash family, so a SHA2 set and the corresponding SHAKE set
+have the same `Params` value. -/
+def Params.IsFipsShape (p : Params) : Prop :=
+  ∃ ps : FipsParameterSet, ps.params = p
+
+/-- Nonstandard limited-use SLH-DSA profiles that are not FIPS 205 parameter sets. -/
+inductive LimitedParameterSet where
   | SLHDSA_SHA2_128_24
 deriving Repr, DecidableEq
 
+namespace LimitedParameterSet
+
+/-- Interpret a limited-use profile as its arithmetic parameters. -/
+def params : LimitedParameterSet → Params
+  | .SLHDSA_SHA2_128_24 => { n := 16, h := 22, d := 1, hp := 22, a := 24, k := 6, lgw := 2 }
+
+/-- Every named limited-use profile has mathematically valid arithmetic parameters. -/
+theorem params_valid (ps : LimitedParameterSet) : ps.params.Valid := by
+  cases ps
+  decide
+
+/-- A limited-use profile packaged for generic algorithms that require validity. -/
+def validatedParams (ps : LimitedParameterSet) : ValidatedParams :=
+  ⟨ps.params, ps.params_valid⟩
+
+end LimitedParameterSet
+
+/-- Compatibility name for the former reduced-profile-only parameter enumeration. -/
+@[deprecated LimitedParameterSet (since := "2026-08-30")]
+abbrev ParameterSet := LimitedParameterSet
+
 namespace ParameterSet
 
-/-- Interpret a named parameter set as the corresponding parameter record. -/
-def params : ParameterSet → Params
-  | .SLHDSA_SHA2_128_24 => { n := 16, h := 22, d := 1, hp := 22, a := 24, k := 6, lgw := 2 }
+/-- Compatibility interpretation of a reduced-profile parameter name. -/
+@[deprecated LimitedParameterSet.params (since := "2026-08-30")]
+abbrev params : ParameterSet → Params := LimitedParameterSet.params
 
 end ParameterSet
 
 /-- The SLH-DSA-SHA2-128-24 parameter record (NIST SP 800-230 reduced set). -/
-def slhdsaSha2_128_24 : Params := ParameterSet.params .SLHDSA_SHA2_128_24
+def slhdsaSha2_128_24 : Params := LimitedParameterSet.params .SLHDSA_SHA2_128_24
 
-/-- Recognize the parameter sets supported by this development. -/
-def Params.isApproved (p : Params) : Prop := p = slhdsaSha2_128_24
+/-- Recognize the named limited-use parameter profiles. -/
+def Params.IsLimited (p : Params) : Prop := p = slhdsaSha2_128_24
+
+/-- Compatibility spelling for the previously supported reduced profile. -/
+@[deprecated Params.IsLimited (since := "2026-08-30")]
+abbrev Params.isApproved (p : Params) : Prop := p.IsLimited
 
 end SLHDSA

--- a/HashSigTest/SLHDSA/Params.lean
+++ b/HashSigTest/SLHDSA/Params.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import HashSig.SLHDSA.Params
+
+/-!
+# SLH-DSA parameter canaries
+
+Executable checks for the twelve FIPS 205 parameter sets, their exact derived byte lengths, and
+the boundary between raw and validated parameters. The expected values are written independently
+of `FipsParameterSet.params` and `FipsParameterSet.expectedSizes` so a table mutation cannot make
+both sides of a test change together.
+-/
+
+public section
+
+namespace SLHDSA.ParamsTest
+
+open FipsParameterSet
+
+/-- Every standardized name is present exactly once and in the documented family-major order. -/
+example : all.map name =
+  ["SLH-DSA-SHA2-128s", "SLH-DSA-SHA2-128f", "SLH-DSA-SHA2-192s",
+    "SLH-DSA-SHA2-192f", "SLH-DSA-SHA2-256s", "SLH-DSA-SHA2-256f",
+    "SLH-DSA-SHAKE-128s", "SLH-DSA-SHAKE-128f", "SLH-DSA-SHAKE-192s",
+    "SLH-DSA-SHAKE-192f", "SLH-DSA-SHAKE-256s", "SLH-DSA-SHAKE-256f"] := by
+  decide
+
+/-- The twelve names select the intended family independently of their shared numerical shapes. -/
+example : all.map hashFamily =
+  [.sha2, .sha2, .sha2, .sha2, .sha2, .sha2,
+    .shake, .shake, .shake, .shake, .shake, .shake] := by
+  decide
+
+/-- Raw fields match the six FIPS 205 numerical shapes for both hash families. -/
+example : all.map (fun ps =>
+    let p := ps.params
+    [p.n, p.h, p.d, p.hp, p.a, p.k, p.lgw]) =
+  [[16, 63, 7, 9, 12, 14, 4], [16, 66, 22, 3, 6, 33, 4],
+    [24, 63, 7, 9, 14, 17, 4], [24, 66, 22, 3, 8, 33, 4],
+    [32, 64, 8, 8, 14, 22, 4], [32, 68, 17, 4, 9, 35, 4],
+    [16, 63, 7, 9, 12, 14, 4], [16, 66, 22, 3, 6, 33, 4],
+    [24, 63, 7, 9, 14, 17, 4], [24, 66, 22, 3, 8, 33, 4],
+    [32, 64, 8, 8, 14, 22, 4], [32, 68, 17, 4, 9, 35, 4]] := by
+  decide
+
+/-- WOTS+ base, message digits, checksum digits, and total chains are derived independently. -/
+example : all.map (fun ps =>
+    let p := ps.params
+    [p.w, p.len1, p.len2, p.len]) =
+  [[16, 32, 3, 35], [16, 32, 3, 35],
+    [16, 48, 3, 51], [16, 48, 3, 51],
+    [16, 64, 3, 67], [16, 64, 3, 67],
+    [16, 32, 3, 35], [16, 32, 3, 35],
+    [16, 48, 3, 51], [16, 48, 3, 51],
+    [16, 64, 3, 67], [16, 64, 3, 67]] := by
+  decide
+
+/-- The three independently rounded `H_msg` components match all six numerical shapes. -/
+example : all.map (fun ps =>
+    let p := ps.params
+    [p.digestBytes, p.treeIdxBytes, p.leafIdxBytes]) =
+  [[21, 7, 2], [25, 8, 1], [30, 7, 2], [33, 8, 1], [39, 7, 1], [40, 8, 1],
+    [21, 7, 2], [25, 8, 1], [30, 7, 2], [33, 8, 1], [39, 7, 1], [40, 8, 1]] := by
+  decide
+
+/-- `H_msg`, public-key, secret-key, and signature lengths are derived from the raw formulas. -/
+example : all.map (fun ps =>
+    let p := ps.params
+    [p.m, p.publicKeyBytes, p.secretKeyBytes, p.signatureBytes]) =
+  [[30, 32, 64, 7856], [34, 32, 64, 17088],
+    [39, 48, 96, 16224], [42, 48, 96, 35664],
+    [47, 64, 128, 29792], [49, 64, 128, 49856],
+    [30, 32, 64, 7856], [34, 32, 64, 17088],
+    [39, 48, 96, 16224], [42, 48, 96, 35664],
+    [47, 64, 128, 29792], [49, 64, 128, 49856]] := by
+  decide
+
+/-- Every approved set and the explicitly nonstandard reduced profile validates. -/
+example : all.all (fun ps => ps.params.validate.isSome) = true := by decide
+example : slhdsaSha2_128_24.validate.isSome = true := by decide
+
+/-- Zero node length is rejected even when the layer equation still holds. -/
+example : (Params.validate
+    { n := 0, h := 63, d := 7, hp := 9, a := 12, k := 14, lgw := 4 }).isNone = true := by
+  decide
+
+/-- Zero layers are rejected. -/
+example : (Params.validate
+    { n := 16, h := 0, d := 0, hp := 9, a := 12, k := 14, lgw := 4 }).isNone = true := by
+  decide
+
+/-- Zero per-layer height is rejected. -/
+example : (Params.validate
+    { n := 16, h := 0, d := 7, hp := 0, a := 12, k := 14, lgw := 4 }).isNone = true := by
+  decide
+
+/-- Zero FORS tree height is rejected. -/
+example : (Params.validate
+    { n := 16, h := 2, d := 1, hp := 2, a := 0, k := 1, lgw := 4 }).isNone = true := by
+  decide
+
+/-- An empty FORS forest is rejected. -/
+example : (Params.validate
+    { n := 16, h := 2, d := 1, hp := 2, a := 1, k := 0, lgw := 4 }).isNone = true := by
+  decide
+
+/-- Zero Winternitz exponent is rejected. -/
+example : (Params.validate
+    { n := 16, h := 63, d := 7, hp := 9, a := 12, k := 14, lgw := 0 }).isNone = true := by
+  decide
+
+/-- An off-by-one total height is rejected despite all primary fields being positive. -/
+example : (Params.validate
+    { n := 16, h := 64, d := 7, hp := 9, a := 12, k := 14, lgw := 4 }).isNone = true := by
+  decide
+
+/-- WOTS+ parameters that require more than the available `n` input bytes are rejected. -/
+example : (Params.validate
+    { n := 1, h := 2, d := 1, hp := 2, a := 1, k := 1, lgw := 3 }).isNone = true := by
+  decide
+
+/-- Input alignment is general: a non-FIPS profile with `lgw = 3` validates when `3 ∣ 8n`. -/
+example : (Params.validate
+    { n := 3, h := 2, d := 1, hp := 2, a := 1, k := 1, lgw := 3 }).isSome = true := by
+  decide
+
+/-- The reduced profile remains distinct from every approved FIPS arithmetic shape. -/
+example : slhdsaSha2_128_24.IsLimited := rfl
+
+example : ¬slhdsaSha2_128_24.IsFipsShape := by
+  intro h
+  obtain ⟨ps, hps⟩ := h
+  cases ps <;> simp [FipsParameterSet.params, slhdsaSha2_128_24,
+    LimitedParameterSet.params] at hps
+
+end SLHDSA.ParamsTest


### PR DESCRIPTION
## Summary

This PR lands G1 of the reviewed SLH-DSA generalization plan: a validity boundary for raw arithmetic parameters, all twelve named FIPS 205 parameter sets, and a deliberately separate namespace for the existing SP 800-230 reduced profile.

It now:

- distinguishes raw `Params`, `Params.Valid`, and proof-carrying `ValidatedParams`;
- enumerates every SHA2 and SHAKE FIPS 205 parameter-set name with its exact arithmetic shape and independent reference sizes;
- rejects malformed or degenerate schedules before later digest, hypertree, and signature-shape code consumes them; and
- pins the raw fields, WOTS dimensions, digest partition, key sizes, and signature sizes with mutation-sensitive executable canaries.

Normative design: [`docs/design/slh-dsa-fips205-generalization.md`](https://github.com/Verified-zkEVM/VCVio/blob/main/docs/design/slh-dsa-fips205-generalization.md)

### Diff metadata

- Base: `a9dd3bd2895d2ca8bbe02af480c1df7c3be64e24` (`main`)
- Head: `0caf09ca831ba0686db549b596ddfeb121de69ac`
- Commits: 1
- Files changed: 3
- Diff: 384 insertions, 14 deletions
- Owner slice: G1 — validated parameters and all FIPS parameter sets

## Motivation

Before this cut, `Params` was a bare record and the only named set was the non-FIPS `SLH-DSA-SHA2-128-24` reduced profile. Any raw arithmetic tuple could flow into generic algorithms, including inconsistent layer heights, WOTS inputs that do not satisfy the FIPS `base_2^b` input bound, or degenerate FORS dimensions.

That was insufficient for the general scheme because G2–G5 need one reusable proof that their dimensions are meaningful, while FIPS approval must remain a separate closed-name decision that also records the hash family.

## Architecture

```mermaid
flowchart LR
    Raw[Raw Params] --> Check[Params.validate]
    Check --> Valid[ValidatedParams]
    Named[FipsParameterSet<br/>12 closed names + hash family] --> Shape[exact Params]
    Shape --> Valid
    Limited[LimitedParameterSet<br/>SP 800-230 profile] --> Valid
    Valid --> Later[G2-G5 generic algorithms]
```

## Change-surface overview

| Area | Before | After |
| --- | --- | --- |
| Arithmetic input | Unchecked `Params` | `Params.Valid` and `Params.validate` |
| Algorithm boundary | Bare parameter record | Proof-carrying `ValidatedParams` |
| FIPS names | None | Closed `FipsParameterSet` with 12 names and `HashFamily` |
| Reduced profile | The sole `ParameterSet` | Explicitly nonstandard `LimitedParameterSet` |
| Conformance evidence | One reduced-profile shape | Independent component and aggregate canaries for all FIPS shapes |
| CI ownership | No parameter test module | `HashSigTest.SLHDSA.Params` included in explicit text lint coverage |

## Validated arithmetic boundary

`Params.Valid` requires:

- positive node length, layer count, per-layer height, FORS height/tree count, and Winternitz exponent;
- `h = d * h'`, so the hypertree is exactly partitioned into equal-height XMSS layers; and
- `lgw ∣ 8n`, so WOTS message digits consume the available `n` bytes without relying on the repository helper's zero-filled missing-bit behavior.

`Params.validate` returns `Option ValidatedParams`. The bundle deliberately has no coercion back to `Params`; consumers must project `.params`, keeping any discarded proof boundary visible in source.

The validity predicate remains more general than the approved table. A non-FIPS but aligned `n = 3`, `lgw = 3` profile validates, while zero dimensions, inconsistent heights, and the misaligned `n = 1`, `lgw = 3` near miss are rejected.

## FIPS and limited parameter sets

`FipsParameterSet` is the approval-bearing API. It records all twelve standardized names and selects `.sha2` or `.shake` independently of the six shared numerical shapes. `params_valid` packages every named set for generic consumers, and `derived_sizes_eq_expected` proves that the existing formulas agree with independently written reference constants.

Because raw `Params` does not encode a hash family, `Params.IsFipsShape` intentionally recognizes only an arithmetic shape; it is not named or exposed as approval evidence.

The SP 800-230 `SLH-DSA-SHA2-128-24` profile remains available through `LimitedParameterSet`. Deprecated compatibility spellings preserve the former `ParameterSet`, `ParameterSet.params`, and `Params.isApproved` source surface while directing new code to the explicit limited-profile API.

## Tests and mutation resistance

`HashSigTest/SLHDSA/Params.lean` independently pins:

- all twelve standardized names and their family-major enumeration;
- all primary arithmetic fields for both hash families;
- WOTS `[w, len1, len2, len]` dimensions;
- `H_msg` `[digestBytes, treeIdxBytes, leafIdxBytes]` partitions;
- aggregate digest, public-key, secret-key, and signature byte sizes; and
- rejection of each invalid boundary, including zero FORS dimensions, bad layer arithmetic, and WOTS input misalignment.

Writing component and aggregate expectations separately prevents compensating formula changes from keeping a total size test green while changing a downstream G2/G3 partition.

## Security and trust boundary

- No concrete hash primitive, address encoder, codec, signing algorithm, or security theorem is added here.
- The FIPS enum carries family identity; a matching raw arithmetic shape alone is not treated as approval.
- No `unsafe`, custom axiom, `sorryAx`, `native_decide`, `Extern`, `Interop`, `noncomputable`, or `partial` surface is introduced.
- The PMF/SPMF source count remains unchanged at `1923`.

## Compatibility

This is an additive architectural cut for new generic consumers. Existing reduced-profile code remains source-compatible through deprecated aliases. No wire format or algorithm behavior changes in G1.

## Validation completed at `0caf09ca`

The exact local review object passed:

- focused `Params` and `HashSigTest.SLHDSA.Params` build (`2649` jobs);
- targeted text-style lint including the new test module;
- full `lake build HashSig HashSigTest` (`2732` jobs);
- full axiom sweep (`15643` declarations across `493` modules; no new axiom or `sorry` taint);
- `git diff --check`;
- Extern link-safety and Interop TCB isolation checks;
- agent-documentation checks; and
- PMF boundary report (`1923 → 1923`).

The dedicated `review-lean-formalization` gate reports no active P0–P3 findings at this exact head. Hosted CI is triggered by this PR and is not pre-declared green.

## Deferred scope

This PR owns G1 only. It does not implement digest splitting or layer indices (G2), intrinsically shaped signatures (G3), the general hypertree or scheme (G4–G5), codecs/concrete suites/APIs/KATs (G6–G10), or any SLH-DSA security reduction.

## Reviewer map

Suggested review order:

1. `Params.Valid`, its `Decidable` instance, and `ValidatedParams`;
2. `FipsParameterSet.params`, `expectedSizes`, and their proofs;
3. the FIPS-shape versus limited-profile compatibility boundary;
4. independent parameter canaries; and
5. explicit lint-target registration.