### PR TITLE
feat(CryptoFoundations): add final-validity tweakable-hash games

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "ToMathlib/**/*.lean"
       - "VCVio/**/*.lean"
+      - "VCVioTest/SMDTPREFinalValidity.lean"
+      - "VCVioTest/SMDTTCRFinalValidity.lean"
       - "Extern/**/*.lean"
       - "LatticeCrypto/**/*.lean"
       - "HashSig.lean"
@@ -27,6 +29,8 @@ on:
     paths:
       - "ToMathlib/**/*.lean"
       - "VCVio/**/*.lean"
+      - "VCVioTest/SMDTPREFinalValidity.lean"
+      - "VCVioTest/SMDTTCRFinalValidity.lean"
       - "Extern/**/*.lean"
       - "LatticeCrypto/**/*.lean"
       - "HashSig.lean"
@@ -88,4 +92,9 @@ jobs:
       # project deliberately defines no `lint-style` exe, so it does not link the
       # FFI backends). Pass the libraries explicitly for full coverage.
       - name: Run text-based style linters
-        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Scheme HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT
+        run: >-
+          lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets
+          Interop VCVioTest.SMDTPREFinalValidity VCVioTest.SMDTTCRFinalValidity
+          HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss
+          HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Scheme
+          HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -52,8 +52,11 @@ public import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
 public import VCVio.CryptoFoundations.HardnessAssumptions.NoisyLearning
 public import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPREFinalValidity
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCRFinalValidity
 public import VCVio.CryptoFoundations.HashCommitment
 public import VCVio.CryptoFoundations.IdenSchemeWithAbort
 public import VCVio.CryptoFoundations.KEMDEM

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
+
+/-!
+# Source-final-validity monitoring for multi-target tweakable-hash games
+
+The source-final-validity games answer and record every target and collection query, then require
+at the end that the target cap, distinct-target-tweak condition, and target/collection disjointness
+all hold. This file packages an equivalent sticky poison-bit monitor: every query remains answered
+and recorded, while the first validity violation changes `State.valid` permanently to `false`.
+
+The monitor is intentionally separate from `TweakableHash.collectionOracle`, whose
+rejection-on-arrival semantics define a different adaptive experiment. A reduction can use this
+monitor when it targets the source final-predicate experiment or supplies a separate game bridge.
+-/
+
+@[expose] public section
+
+namespace TweakableHash.SourceFinalValidity
+
+open OracleComp OracleSpec
+
+variable {ι PkSeed Tweak Y Q : Type}
+
+/-- Histories and sticky validity bit shared by a target oracle and a collection oracle. -/
+structure State (Q Tweak : Type) where
+  /-- Every target query, including queries issued after the game became invalid. -/
+  challenges : List Q
+  /-- Every collection tweak, including queries issued after the game became invalid. -/
+  collectionTweaks : List Tweak
+  /-- Sticky validity bit for the target cap and tweak-separation conditions. -/
+  valid : Bool
+
+/-- The initially valid empty source-final-validity state. -/
+def State.initial : State Q Tweak := ⟨[], [], true⟩
+
+/-- The final predicate: no more than `numTargets` targets, pairwise-distinct target tweaks, and no
+target tweak used by the collection oracle. -/
+def Valid (numTargets : ℕ) (tweakOf : Q → Tweak) (st : State Q Tweak) : Prop :=
+  st.challenges.length ≤ numTargets ∧
+    (st.challenges.map tweakOf).Nodup ∧
+    (st.challenges.map tweakOf).Disjoint st.collectionTweaks
+
+instance [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak) (st : State Q Tweak) :
+    Decidable (Valid numTargets tweakOf st) :=
+  decidable_of_iff
+    (st.challenges.length ≤ numTargets ∧
+      (st.challenges.map tweakOf).Nodup ∧
+      ∀ a ∈ st.challenges.map tweakOf, ∀ b ∈ st.collectionTweaks, a ≠ b)
+    (and_congr Iff.rfl (and_congr Iff.rfl List.disjoint_iff_ne.symm))
+
+/-- Executable form of `Valid`. The disjointness conjunct is expanded elementwise so the decision
+procedure is explicit. -/
+def validBool [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : State Q Tweak) : Bool :=
+  decide (st.challenges.length ≤ numTargets) &&
+    decide (st.challenges.map tweakOf).Nodup &&
+    decide (∀ a ∈ st.challenges.map tweakOf, ∀ b ∈ st.collectionTweaks, a ≠ b)
+
+/-- The monitor invariant: the sticky bit is exactly the decision procedure for the final
+predicate, rather than merely a one-way soundness flag. -/
+def Invariant [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : State Q Tweak) : Prop :=
+  st.valid = validBool numTargets tweakOf st
+
+/-- Record a target query and poison the state if the target cap or tweak discipline is violated.
+The query is always recorded; hashing and returning its answer is the caller's responsibility. -/
+def State.recordTarget [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (st : State Q Tweak) (q : Q) : State Q Tweak where
+  challenges := st.challenges ++ [q]
+  collectionTweaks := st.collectionTweaks
+  valid := st.valid && st.challenges.length < numTargets &&
+    decide (TweakFresh tweakOf st.challenges st.collectionTweaks (tweakOf q))
+
+/-- Record a collection tweak and poison the state if it was already reserved by a target query.
+Repeated collection tweaks are valid and remain recorded. -/
+def State.recordCollection [DecidableEq Tweak] (tweakOf : Q → Tweak)
+    (st : State Q Tweak) (t : Tweak) : State Q Tweak where
+  challenges := st.challenges
+  collectionTweaks := st.collectionTweaks ++ [t]
+  valid := st.valid && decide (¬TweakReserved tweakOf st.challenges t)
+
+/-! ## Correspondence to the final predicate -/
+
+section Correspondence
+
+variable [DecidableEq Tweak]
+
+/-- The executable check recognizes exactly the final predicate. -/
+theorem validBool_eq_true_iff (numTargets : ℕ) (tweakOf : Q → Tweak) (st : State Q Tweak) :
+    validBool numTargets tweakOf st = true ↔ Valid numTargets tweakOf st := by
+  simp [validBool, Valid, List.disjoint_iff_ne]
+  tauto
+
+/-- The invariant has the literal `decide (Valid …)` form. -/
+theorem Invariant.eq_decide (numTargets : ℕ) (tweakOf : Q → Tweak) (st : State Q Tweak)
+    (hinv : Invariant numTargets tweakOf st) :
+    st.valid = decide (Valid numTargets tweakOf st) := by
+  rw [hinv]
+  apply Bool.eq_iff_iff.mpr
+  simp [validBool_eq_true_iff]
+
+/-- The initial monitor satisfies the exact final predicate. -/
+theorem invariant_initial (numTargets : ℕ) (tweakOf : Q → Tweak) :
+    Invariant numTargets tweakOf (.initial : State Q Tweak) := by
+  simp [Invariant, State.initial, validBool]
+
+/-- Recording a target query preserves exact correspondence between the poison bit and the final
+predicate. -/
+theorem Invariant.recordTarget (numTargets : ℕ) (tweakOf : Q → Tweak) (st : State Q Tweak)
+    (q : Q) (hinv : Invariant numTargets tweakOf st) :
+    Invariant numTargets tweakOf (st.recordTarget numTargets tweakOf q) := by
+  rcases st with ⟨challenges, collectionTweaks, valid⟩
+  simp only [Invariant, State.recordTarget] at hinv ⊢
+  rw [hinv]
+  apply Bool.eq_iff_iff.mpr
+  have hcore :
+      ((((challenges.length ≤ numTargets ∧ (challenges.map tweakOf).Nodup) ∧
+          ∀ a ∈ challenges, ∀ b ∈ collectionTweaks, tweakOf a ≠ b) ∧
+          challenges.length < numTargets) ∧
+        (∀ x ∈ challenges, tweakOf x ≠ tweakOf q) ∧
+          tweakOf q ∉ collectionTweaks) ↔
+        ((challenges.length < numTargets ∧ (challenges.map tweakOf).Nodup ∧
+            ∀ x ∈ challenges, tweakOf x ≠ tweakOf q) ∧
+          ∀ a : Tweak, (∃ x ∈ challenges, tweakOf x = a) ∨ a = tweakOf q →
+            ∀ b ∈ collectionTweaks, a ≠ b) := by
+    constructor
+    · rintro ⟨⟨⟨⟨hlen, hnodup⟩, hdisjoint⟩, hlt⟩, hfresh, hnotColl⟩
+      refine ⟨⟨hlt, hnodup, hfresh⟩, ?_⟩
+      intro a ha b hb
+      rcases ha with ⟨x, hx, rfl⟩ | rfl
+      · exact hdisjoint x hx b hb
+      · intro heq
+        exact hnotColl (heq ▸ hb)
+    · rintro ⟨⟨hlt, hnodup, hfresh⟩, hdisjoint⟩
+      refine ⟨⟨⟨⟨Nat.le_of_lt hlt, hnodup⟩, ?_⟩, hlt⟩, hfresh, ?_⟩
+      · intro x hx b hb
+        exact hdisjoint (tweakOf x) (Or.inl ⟨x, hx, rfl⟩) b hb
+      · intro hmem
+        exact hdisjoint (tweakOf q) (Or.inr rfl) (tweakOf q) hmem rfl
+  simpa [validBool, TweakFresh, TweakReserved, List.nodup_append] using hcore
+
+/-- Recording a collection query preserves exact correspondence between the poison bit and the
+final predicate. -/
+theorem Invariant.recordCollection (numTargets : ℕ) (tweakOf : Q → Tweak) (st : State Q Tweak)
+    (t : Tweak) (hinv : Invariant numTargets tweakOf st) :
+    Invariant numTargets tweakOf (st.recordCollection tweakOf t) := by
+  rcases st with ⟨challenges, collectionTweaks, valid⟩
+  simp only [Invariant, State.recordCollection] at hinv ⊢
+  rw [hinv]
+  apply Bool.eq_iff_iff.mpr
+  have hcore :
+      (((challenges.length ≤ numTargets ∧ (challenges.map tweakOf).Nodup) ∧
+          ∀ a ∈ challenges, ∀ b ∈ collectionTweaks, tweakOf a ≠ b) ∧
+        ∀ x ∈ challenges, tweakOf x ≠ t) ↔
+        ((challenges.length ≤ numTargets ∧ (challenges.map tweakOf).Nodup) ∧
+          ∀ a ∈ challenges, ∀ b : Tweak, (b ∈ collectionTweaks ∨ b = t) →
+            tweakOf a ≠ b) := by
+    constructor
+    · rintro ⟨⟨⟨hlen, hnodup⟩, hdisjoint⟩, hunreserved⟩
+      refine ⟨⟨hlen, hnodup⟩, ?_⟩
+      intro x hx b hb
+      rcases hb with hb | rfl
+      · exact hdisjoint x hx b hb
+      · exact hunreserved x hx
+    · rintro ⟨⟨hlen, hnodup⟩, hdisjoint⟩
+      refine ⟨⟨⟨hlen, hnodup⟩, ?_⟩, ?_⟩
+      · intro x hx b hb
+        exact hdisjoint x hx b (Or.inl hb)
+      · intro x hx
+        exact hdisjoint x hx t (Or.inr rfl)
+  simpa [validBool, TweakReserved] using hcore
+
+end Correspondence
+
+/-- Source-final-validity collection queries return a digest directly: invalid queries poison the
+monitor but are never rejected. -/
+abbrev collectionSpec (thColl : TweakableHashCollection ι PkSeed Tweak Y) :
+    OracleSpec ((i : ι) × Tweak × thColl.Msg i) :=
+  _ →ₒ Y
+
+/-- The always-answering collection oracle for source-final-validity games. -/
+def collectionOracle [DecidableEq Tweak] (tweakOf : Q → Tweak)
+    (thColl : TweakableHashCollection ι PkSeed Tweak Y) (pk : PkSeed) :
+    QueryImpl (collectionSpec thColl) (StateT (State Q Tweak) ProbComp) :=
+  fun q => do
+    let st ← get
+    set (st.recordCollection tweakOf q.2.1)
+    return thColl.eval q.1 pk q.2.1 q.2.2
+
+/-! ## Semantic pins -/
+
+variable [DecidableEq Tweak] (tweakOf : Q → Tweak)
+  {st : State Q Tweak} {q : Q} {t : Tweak}
+
+/-- Target queries are still recorded after violating the cap; the validity bit is poisoned. -/
+theorem recordTarget_at_cap :
+    (st.recordTarget 0 tweakOf q).challenges = st.challenges ++ [q] ∧
+      (st.recordTarget 0 tweakOf q).valid = false := by
+  simp [State.recordTarget]
+
+/-- Repeating a collection tweak does not poison an otherwise valid state when no target reserved
+it. This fails if collection tweaks are incorrectly required to be distinct. -/
+theorem recordCollection_repeated_of_unreserved (hvalid : st.valid = true)
+    (hunreserved : ¬TweakReserved tweakOf st.challenges t) :
+    ((st.recordCollection tweakOf t).recordCollection tweakOf t).valid = true := by
+  simp [State.recordCollection, hvalid, hunreserved]
+
+end TweakableHash.SourceFinalValidity

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
@@ -194,6 +194,15 @@ def collectionOracle [DecidableEq Tweak] (tweakOf : Q → Tweak)
     set (st.recordCollection tweakOf q.2.1)
     return thColl.eval q.1 pk q.2.1 q.2.2
 
+/-- Every collection query returns its real digest and is appended to the history, even when the
+incoming state is already poisoned. -/
+theorem collectionOracle_run [DecidableEq Tweak] (tweakOf : Q → Tweak)
+    (thColl : TweakableHashCollection ι PkSeed Tweak Y) (pk : PkSeed)
+    (q : (i : ι) × Tweak × thColl.Msg i) (st : State Q Tweak) :
+    (collectionOracle tweakOf thColl pk q).run st =
+      pure (thColl.eval q.1 pk q.2.1 q.2.2, st.recordCollection tweakOf q.2.1) := by
+  simp [collectionOracle]
+
 /-! ## Semantic pins -/
 
 variable [DecidableEq Tweak] (tweakOf : Q → Tweak)

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTPREFinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTPREFinalValidity.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Nicolas Consigny, Matthias Meijers, Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nicolas Consigny, Matthias Meijers, Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
+
+/-!
+# Source-final-validity SM-DT-PRE
+
+This module defines the single-function, distinct-tweak, multi-target preimage-resistance
+experiment with source final-predicate semantics. The challenge oracle samples a message from the
+declared subspace for every query, returns the corresponding image, and records the target. The
+target cap and tweak-separation conditions enter the final winning condition through the shared
+sticky monitor.
+
+`TweakableHash.SM_DT_PRE_Experiment` is the live rejection-on-arrival experiment. The declarations
+in `TweakableHash.SM_DT_PRE_SourceFinalValidity` name a distinct adaptive game and leave that
+experiment unchanged.
+
+## References
+
+- Hülsing and Kudinov, *Recovering the Tight Security Proof of SPHINCS+*,
+  [ePrint 2022/346](https://eprint.iacr.org/2022/346), Def. 3 and Def. 7.
+- Barbosa, Dupressoir, Hülsing, Meijers and Strub, *A Tight Security Proof for SPHINCS+, Formally
+  Verified*, [ePrint 2024/910](https://eprint.iacr.org/2024/910), Fig. 7, Fig. 10, and Fig. 11.
+-/
+
+@[expose] public section
+
+namespace TweakableHash.SM_DT_PRE_SourceFinalValidity
+
+open OracleComp OracleSpec ENNReal
+
+variable {ι PkSeed Tweak M M' Y : Type}
+
+/-- A source-final-validity SM-DT-PRE problem: the attacked tweakable hash, the sampled subspace,
+the collection of other members, and the final cap on challenge queries. -/
+structure Problem (ι PkSeed Tweak M M' Y : Type) where
+  /-- The tweakable hash whose preimage resistance is in question. -/
+  th : TweakableHash PkSeed Tweak M Y
+  /-- The map into `M` of the subspace sampled by the challenge oracle. -/
+  emb : M' → M
+  /-- `emb` identifies `M'` with a subset of `M`. -/
+  emb_injective : Function.Injective emb
+  /-- The rest of the collection, evaluable by the adversary at the game's seed. -/
+  thColl : TweakableHashCollection ι PkSeed Tweak Y
+  /-- The maximum number of challenge queries allowed by final validity. -/
+  numTargets : ℕ
+
+/-- The stand-alone source-final-validity problem at the empty collection. -/
+def Problem.standalone (th : TweakableHash PkSeed Tweak M Y) (emb : M' → M)
+    (emb_injective : Function.Injective emb) (numTargets : ℕ) :
+    Problem Empty PkSeed Tweak M M' Y where
+  th := th
+  emb := emb
+  emb_injective := emb_injective
+  thColl := .empty PkSeed Tweak Y
+  numTargets := numTargets
+
+/-- A source-final-validity challenge query is a tweak; the response is the sampled message's
+image, never an optional rejection. -/
+abbrev challengeSpec (Tweak Y : Type) : OracleSpec Tweak := Tweak →ₒ Y
+
+/-- Challenge/collection histories and sticky source-final-validity bit. -/
+abbrev State (Tweak M' : Type) : Type := SourceFinalValidity.State (Tweak × M') Tweak
+
+/-- An adversary for source-final-validity SM-DT-PRE. The seed is unavailable to `choose`; `invert`
+receives it after both first-phase oracles have been removed. -/
+structure Adversary (prob : Problem ι PkSeed Tweak M M' Y) where
+  /-- Private state carried from `choose` to `invert`. -/
+  State : Type
+  /-- Select tweaks with private randomness and collection access, without the public seed. -/
+  choose : OracleComp
+    (unifSpec + (challengeSpec Tweak Y + SourceFinalValidity.collectionSpec prob.thColl)) State
+  /-- Given the revealed public seed, name a target index and a preimage in `M'`. -/
+  invert : State → PkSeed → ProbComp (ℕ × M')
+
+/-- The always-answering target oracle. Every query samples a message and records the target; a
+cap, duplicate target tweak, or collection clash poisons final validity without suppressing the
+sample or digest. -/
+noncomputable def challengeOracle [DecidableEq Tweak] [SampleableType M']
+    (prob : Problem ι PkSeed Tweak M M' Y) (pk : PkSeed) :
+    QueryImpl (challengeSpec Tweak Y) (StateT (State Tweak M') ProbComp) :=
+  fun t => do
+    let x ← (($ᵗ M' : ProbComp M') : StateT (State Tweak M') ProbComp M')
+    let st ← get
+    set (st.recordTarget prob.numTargets Prod.fst (t, x))
+    return prob.th.eval pk t (prob.emb x)
+
+/-- The source-final-validity challenge and collection oracles over their shared monitor. -/
+noncomputable def oracles [DecidableEq Tweak] [SampleableType M']
+    (prob : Problem ι PkSeed Tweak M M' Y) (pk : PkSeed) :
+    QueryImpl
+      (unifSpec + (challengeSpec Tweak Y + SourceFinalValidity.collectionSpec prob.thColl))
+      (StateT (State Tweak M') ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT (State Tweak M') ProbComp) +
+    (challengeOracle prob pk +
+      SourceFinalValidity.collectionOracle (Q := Tweak × M') Prod.fst prob.thColl pk)
+
+/-- The source-final-validity SM-DT-PRE experiment. An inversion wins exactly when final validity
+holds and it names a recorded target with an agreeing preimage from `M'`. -/
+noncomputable def Experiment [DecidableEq Tweak] [DecidableEq Y] [SampleableType M']
+    {prob : Problem ι PkSeed Tweak M M' Y} (adv : Adversary prob) : ProbComp Bool := do
+  let pk ← prob.th.seedGen
+  let (privateState, gameState) ← (simulateQ (oracles prob pk) adv.choose).run .initial
+  let (j, m) ← adv.invert privateState pk
+  match gameState.challenges[j]? with
+  | none => return false
+  | some (t, x) =>
+      return gameState.valid &&
+        decide (prob.th.eval pk t (prob.emb m) = prob.th.eval pk t (prob.emb x))
+
+/-- The source-final-validity SM-DT-PRE advantage. -/
+noncomputable def Advantage [DecidableEq Tweak] [DecidableEq Y] [SampleableType M']
+    {prob : Problem ι PkSeed Tweak M M' Y} (adv : Adversary prob) : ℝ≥0∞ :=
+  Pr[= true | Experiment adv]
+
+variable [DecidableEq Tweak] [SampleableType M']
+  {prob : Problem ι PkSeed Tweak M M' Y} {pk : PkSeed} {t : Tweak} {st : State Tweak M'}
+
+/-- Every query samples, answers, and records, including a query that poisons final validity. -/
+theorem challengeOracle_run :
+    (challengeOracle prob pk t).run st =
+      (fun x => (prob.th.eval pk t (prob.emb x),
+        st.recordTarget prob.numTargets Prod.fst (t, x))) <$> ($ᵗ M') := by
+  simp [challengeOracle, Functor.map_map]
+
+end TweakableHash.SM_DT_PRE_SourceFinalValidity

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTTCRFinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTTCRFinalValidity.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 Nicolas Consigny, Matthias Meijers, Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nicolas Consigny, Matthias Meijers, Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
+
+/-!
+# Source-final-validity SM-DT-TCR
+
+This module defines the single-function, distinct-tweak, multi-target target-collision-resistance
+experiment with the source final-predicate semantics used by the EasyCrypt/BDHMS development.
+Every challenge and collection query is answered and recorded. The target cap, distinct target
+tweaks, and target/collection disjointness are checked by a sticky final-validity monitor and enter
+the final winning condition.
+
+`TweakableHash.SM_DT_TCR_Experiment` is the live rejection-on-arrival experiment. The declarations
+in `TweakableHash.SM_DT_TCR_SourceFinalValidity` name a distinct adaptive game and do not alter that
+experiment's oracle result types or winning condition.
+
+## References
+
+- Hülsing and Kudinov, *Recovering the Tight Security Proof of SPHINCS+*,
+  [ePrint 2022/346](https://eprint.iacr.org/2022/346), Def. 2 and Def. 7.
+- Barbosa, Dupressoir, Hülsing, Meijers and Strub, *A Tight Security Proof for SPHINCS+, Formally
+  Verified*, [ePrint 2024/910](https://eprint.iacr.org/2024/910), Fig. 5 and Fig. 6.
+-/
+
+@[expose] public section
+
+namespace TweakableHash.SM_DT_TCR_SourceFinalValidity
+
+open OracleComp OracleSpec ENNReal
+
+variable {ι PkSeed Tweak M Y : Type}
+
+/-- A source-final-validity SM-DT-TCR problem: the attacked tweakable hash, the collection of other
+members available to the adversary, and the final cap on challenge queries. -/
+structure Problem (ι PkSeed Tweak M Y : Type) where
+  /-- The tweakable hash whose target-collision resistance is in question. -/
+  th : TweakableHash PkSeed Tweak M Y
+  /-- The rest of the collection, evaluable by the adversary at the game's seed. -/
+  thColl : TweakableHashCollection ι PkSeed Tweak Y
+  /-- The maximum number of challenge queries allowed by final validity. -/
+  numTargets : ℕ
+
+/-- The stand-alone source-final-validity problem at the empty collection. -/
+def Problem.standalone (th : TweakableHash PkSeed Tweak M Y) (numTargets : ℕ) :
+    Problem Empty PkSeed Tweak M Y where
+  th := th
+  thColl := .empty PkSeed Tweak Y
+  numTargets := numTargets
+
+/-- Every `(tweak, message)` challenge query returns its image. -/
+abbrev challengeSpec (Tweak M Y : Type) : OracleSpec (Tweak × M) :=
+  (Tweak × M) →ₒ Y
+
+/-- Challenge/collection histories and sticky source-final-validity bit. -/
+abbrev State (Tweak M : Type) : Type := SourceFinalValidity.State (Tweak × M) Tweak
+
+/-- An adversary for source-final-validity SM-DT-TCR. The seed is unavailable to `choose`; `forge`
+receives it after both first-phase oracles have been removed. -/
+structure Adversary (prob : Problem ι PkSeed Tweak M Y) where
+  /-- Private state carried from `choose` to `forge`. -/
+  State : Type
+  /-- Select targets with private randomness and collection access, without the public seed. -/
+  choose : OracleComp
+    (unifSpec + (challengeSpec Tweak M Y + SourceFinalValidity.collectionSpec prob.thColl)) State
+  /-- Given the revealed public seed, name a target index and a colliding message. -/
+  forge : State → PkSeed → ProbComp (ℕ × M)
+
+/-- The always-answering target oracle. Every query is appended in issue order; a cap, duplicate
+target tweak, or collection clash poisons final validity without changing the returned digest. -/
+def challengeOracle [DecidableEq Tweak] (prob : Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl (challengeSpec Tweak M Y) (StateT (State Tweak M) ProbComp) :=
+  fun tm => do
+    let st ← get
+    set (st.recordTarget prob.numTargets Prod.fst tm)
+    return prob.th.eval pk tm.1 tm.2
+
+/-- The source-final-validity challenge and collection oracles over their shared monitor. -/
+def oracles [DecidableEq Tweak] (prob : Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl
+      (unifSpec + (challengeSpec Tweak M Y + SourceFinalValidity.collectionSpec prob.thColl))
+      (StateT (State Tweak M) ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT (State Tweak M) ProbComp) +
+    (challengeOracle prob pk +
+      SourceFinalValidity.collectionOracle (Q := Tweak × M) Prod.fst prob.thColl pk)
+
+/-- The source-final-validity SM-DT-TCR experiment. A forgery wins exactly when final validity
+holds and it names a recorded target with a distinct colliding message. -/
+noncomputable def Experiment [DecidableEq Tweak] [DecidableEq M] [DecidableEq Y]
+    {prob : Problem ι PkSeed Tweak M Y} (adv : Adversary prob) : ProbComp Bool := do
+  let pk ← prob.th.seedGen
+  let (privateState, gameState) ← (simulateQ (oracles prob pk) adv.choose).run .initial
+  let (j, m) ← adv.forge privateState pk
+  match gameState.challenges[j]? with
+  | none => return false
+  | some (t, mj) =>
+      return gameState.valid && decide (m ≠ mj ∧ prob.th.eval pk t m = prob.th.eval pk t mj)
+
+/-- The source-final-validity SM-DT-TCR advantage. -/
+noncomputable def Advantage [DecidableEq Tweak] [DecidableEq M] [DecidableEq Y]
+    {prob : Problem ι PkSeed Tweak M Y} (adv : Adversary prob) : ℝ≥0∞ :=
+  Pr[= true | Experiment adv]
+
+variable [DecidableEq Tweak] {prob : Problem ι PkSeed Tweak M Y} {pk : PkSeed}
+  {t : Tweak} {m : M} {st : State Tweak M}
+
+/-- Every target query is answered and recorded, including a query that poisons final validity. -/
+theorem challengeOracle_run :
+    (challengeOracle prob pk (t, m)).run st =
+      pure (prob.th.eval pk t m, st.recordTarget prob.numTargets Prod.fst (t, m)) := by
+  simp [challengeOracle]
+
+end TweakableHash.SM_DT_TCR_SourceFinalValidity

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -23,6 +23,8 @@ public import VCVioTest.PerfectMerkleTree
 public import VCVioTest.ProbabilityTactics
 public import VCVioTest.QueryHom
 public import VCVioTest.RoundByRound.OneRound
+public import VCVioTest.SMDTPREFinalValidity
+public import VCVioTest.SMDTTCRFinalValidity
 public import VCVioTest.SampleableType
 public import VCVioTest.Smoke
 public import VCVioTest.UniformOn

--- a/VCVioTest/SMDTPREFinalValidity.lean
+++ b/VCVioTest/SMDTPREFinalValidity.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPREFinalValidity
+
+/-!
+# Source-final-validity SM-DT-PRE canaries
+
+A valid inversion wins. Duplicate targets and target/collection clashes still receive their
+sampled image, remain in the histories, and poison the final result. The target cap is two so the
+duplicate-target canary isolates tweak distinctness from cap overflow.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SMDTPREFinalValidityTest
+
+inductive Seed
+  | only
+
+inductive Input
+  | only
+
+instance : SampleableType Seed where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+@[simp] lemma uniformSample_seed : ($ᵗ Seed : ProbComp Seed) = pure .only := rfl
+
+instance : SampleableType Input where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+@[simp] lemma uniformSample_input : ($ᵗ Input : ProbComp Input) = pure .only := rfl
+
+def hash : TweakableHash Seed Bool Bool Bool where
+  seedGen := $ᵗ Seed
+  eval _ _ _ := false
+
+def collection : TweakableHashCollection Unit Seed Bool Bool where
+  Msg _ := Bool
+  eval _ _ _ m := m
+
+def problem :
+    TweakableHash.SM_DT_PRE_SourceFinalValidity.Problem Unit Seed Bool Bool Input Bool where
+  th := hash
+  emb _ := false
+  emb_injective := fun _ _ _ => rfl
+  thColl := collection
+  numTargets := 2
+
+@[simp] lemma problem_seedGen : problem.th.seedGen = pure .only := rfl
+
+abbrev Specs := unifSpec +
+  (TweakableHash.SM_DT_PRE_SourceFinalValidity.challengeSpec Bool Bool +
+    TweakableHash.SourceFinalValidity.collectionSpec problem.thColl)
+
+def challenge (t : Bool) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inl t)))
+
+def collectionQuery (t : Bool) (m : problem.thColl.Msg ()) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inr ⟨(), t, m⟩)))
+
+def valid : TweakableHash.SM_DT_PRE_SourceFinalValidity.Adversary problem where
+  State := Bool
+  choose := challenge false
+  invert _ _ := pure (0, .only)
+
+def duplicateTarget : TweakableHash.SM_DT_PRE_SourceFinalValidity.Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← challenge false
+    let y₂ ← challenge false
+    return (y₁, y₂)
+  invert _ _ := pure (0, .only)
+
+def collectionClash : TweakableHash.SM_DT_PRE_SourceFinalValidity.Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← collectionQuery false true
+    let y₂ ← challenge false
+    return (y₁, y₂)
+  invert _ _ := pure (0, .only)
+
+private lemma run_valid :
+    (simulateQ (TweakableHash.SM_DT_PRE_SourceFinalValidity.oracles problem .only)
+      valid.choose).run .initial =
+      pure (false, ⟨[(false, .only)], [], true⟩) := by
+  rfl
+
+private lemma run_duplicateTarget :
+    (simulateQ (TweakableHash.SM_DT_PRE_SourceFinalValidity.oracles problem .only)
+      duplicateTarget.choose).run .initial =
+      pure ((false, false), ⟨[(false, .only), (false, .only)], [], false⟩) := by
+  rfl
+
+private lemma run_collectionClash :
+    (simulateQ (TweakableHash.SM_DT_PRE_SourceFinalValidity.oracles problem .only)
+      collectionClash.choose).run .initial =
+      pure ((true, false), ⟨[(false, .only)], [false], false⟩) := by
+  rfl
+
+private lemma experiment_valid :
+    TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment valid = pure true := by
+  simp only [TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment, problem_seedGen, pure_bind]
+  rw [run_valid]
+  rfl
+
+private lemma experiment_duplicateTarget :
+    TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment duplicateTarget = pure false := by
+  simp only [TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment, problem_seedGen, pure_bind]
+  rw [run_duplicateTarget]
+  rfl
+
+private lemma experiment_collectionClash :
+    TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment collectionClash = pure false := by
+  simp only [TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment, problem_seedGen, pure_bind]
+  rw [run_collectionClash]
+  rfl
+
+/-- Valid inversion wins, while answered-and-recorded duplicate and cross-oracle queries lose
+through final validity. -/
+theorem final_validity_branch_canary :
+    TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment valid = pure true ∧
+      TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment duplicateTarget = pure false ∧
+      TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment collectionClash = pure false :=
+  ⟨experiment_valid, experiment_duplicateTarget, experiment_collectionClash⟩
+
+end SMDTPREFinalValidityTest

--- a/VCVioTest/SMDTTCRFinalValidity.lean
+++ b/VCVioTest/SMDTTCRFinalValidity.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCRFinalValidity
+
+/-!
+# Source-final-validity SM-DT-TCR canaries
+
+These concrete games pin the source-final-predicate branch behavior. Both query orders across the
+challenge/collection boundary are answered and recorded but poison the final result. Repeated
+collection-only tweaks remain legal, while a repeated target tweak is invalid even though its
+second digest is returned.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SMDTTCRFinalValidityTest
+
+inductive Seed
+  | only
+
+instance : SampleableType Seed where
+  selectElem := pure .only
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq x y := by cases x; cases y; rfl
+
+@[simp] lemma uniformSample_seed : ($ᵗ Seed : ProbComp Seed) = pure .only := rfl
+
+def hash : TweakableHash Seed Bool Bool Bool where
+  seedGen := $ᵗ Seed
+  eval _ _ _ := false
+
+def collection : TweakableHashCollection Unit Seed Bool Bool where
+  Msg _ := Bool
+  eval _ _ _ m := m
+
+def problem : TweakableHash.SM_DT_TCR_SourceFinalValidity.Problem Unit Seed Bool Bool Bool where
+  th := hash
+  thColl := collection
+  numTargets := 2
+
+@[simp] lemma problem_seedGen : problem.th.seedGen = pure .only := rfl
+
+abbrev Specs := unifSpec +
+  (TweakableHash.SM_DT_TCR_SourceFinalValidity.challengeSpec Bool Bool Bool +
+    TweakableHash.SourceFinalValidity.collectionSpec problem.thColl)
+
+def challenge (t m : Bool) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inl (t, m))))
+
+def collectionQuery (t : Bool) (m : problem.thColl.Msg ()) : OracleComp Specs Bool :=
+  liftM (Specs.query (.inr (.inr ⟨(), t, m⟩)))
+
+def challengeOnly : TweakableHash.SM_DT_TCR_SourceFinalValidity.Adversary problem where
+  State := Unit
+  choose := challenge false false *> pure ()
+  forge _ _ := pure (0, true)
+
+def challengeThenCollection : TweakableHash.SM_DT_TCR_SourceFinalValidity.Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← challenge false false
+    let y₂ ← collectionQuery false true
+    return (y₁, y₂)
+  forge _ _ := pure (0, true)
+
+def collectionThenChallenge : TweakableHash.SM_DT_TCR_SourceFinalValidity.Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← collectionQuery false true
+    let y₂ ← challenge false false
+    return (y₁, y₂)
+  forge _ _ := pure (0, true)
+
+/-- Repeating a collection tweak is permitted; the subsequent fresh challenge remains valid. -/
+def repeatedCollection : TweakableHash.SM_DT_TCR_SourceFinalValidity.Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← collectionQuery false false
+    let y₂ ← collectionQuery false true
+    let _ ← challenge true false
+    return (y₁, y₂)
+  forge _ _ := pure (0, true)
+
+/-- A repeated target tweak is answered and recorded, then final validity rejects the forgery. -/
+def repeatedTarget : TweakableHash.SM_DT_TCR_SourceFinalValidity.Adversary problem where
+  State := Bool × Bool
+  choose := do
+    let y₁ ← challenge false false
+    let y₂ ← challenge false true
+    return (y₁, y₂)
+  forge _ _ := pure (0, true)
+
+private lemma run_challengeOnly :
+    (simulateQ (TweakableHash.SM_DT_TCR_SourceFinalValidity.oracles problem .only)
+      challengeOnly.choose).run .initial =
+      pure ((), ⟨[(false, false)], [], true⟩) := by
+  rfl
+
+private lemma run_challengeThenCollection :
+    (simulateQ (TweakableHash.SM_DT_TCR_SourceFinalValidity.oracles problem .only)
+      challengeThenCollection.choose).run .initial =
+      pure ((false, true), ⟨[(false, false)], [false], false⟩) := by
+  rfl
+
+private lemma run_collectionThenChallenge :
+    (simulateQ (TweakableHash.SM_DT_TCR_SourceFinalValidity.oracles problem .only)
+      collectionThenChallenge.choose).run .initial =
+      pure ((true, false), ⟨[(false, false)], [false], false⟩) := by
+  rfl
+
+private lemma run_repeatedCollection :
+    (simulateQ (TweakableHash.SM_DT_TCR_SourceFinalValidity.oracles problem .only)
+      repeatedCollection.choose).run .initial =
+      pure ((false, true), ⟨[(true, false)], [false, false], true⟩) := by
+  rfl
+
+private lemma run_repeatedTarget :
+    (simulateQ (TweakableHash.SM_DT_TCR_SourceFinalValidity.oracles problem .only)
+      repeatedTarget.choose).run .initial =
+      pure ((false, false), ⟨[(false, false), (false, true)], [], false⟩) := by
+  rfl
+
+private lemma experiment_challengeOnly :
+    TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment challengeOnly = pure true := by
+  simp only [TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment, problem_seedGen, pure_bind]
+  rw [run_challengeOnly]
+  rfl
+
+private lemma experiment_challengeThenCollection :
+    TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment challengeThenCollection =
+      pure false := by
+  simp only [TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment, problem_seedGen, pure_bind]
+  rw [run_challengeThenCollection]
+  rfl
+
+private lemma experiment_collectionThenChallenge :
+    TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment collectionThenChallenge =
+      pure false := by
+  simp only [TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment, problem_seedGen, pure_bind]
+  rw [run_collectionThenChallenge]
+  rfl
+
+private lemma experiment_repeatedCollection :
+    TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment repeatedCollection = pure true := by
+  simp only [TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment, problem_seedGen, pure_bind]
+  rw [run_repeatedCollection]
+  rfl
+
+private lemma experiment_repeatedTarget :
+    TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment repeatedTarget = pure false := by
+  simp only [TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment, problem_seedGen, pure_bind]
+  rw [run_repeatedTarget]
+  rfl
+
+/-- Both clash orders and a repeated target lose through final validity, while the legal control
+cases win. The run equalities also pin that invalid queries still return their real answers. -/
+theorem final_validity_branch_canary :
+    TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment challengeOnly = pure true ∧
+      TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment challengeThenCollection =
+        pure false ∧
+      TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment collectionThenChallenge =
+        pure false ∧
+      TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment repeatedCollection = pure true ∧
+      TweakableHash.SM_DT_TCR_SourceFinalValidity.Experiment repeatedTarget = pure false :=
+  ⟨experiment_challengeOnly, experiment_challengeThenCollection,
+    experiment_collectionThenChallenge, experiment_repeatedCollection, experiment_repeatedTarget⟩
+
+end SMDTTCRFinalValidityTest

--- a/VCVioTest/SMDTTCRFinalValidity.lean
+++ b/VCVioTest/SMDTTCRFinalValidity.lean
@@ -97,6 +97,16 @@ def repeatedTarget : TweakableHash.SM_DT_TCR_SourceFinalValidity.Adversary probl
     return (y₁, y₂)
   forge _ _ := pure (0, true)
 
+/-- A collection query after target duplication still returns its digest and is appended. -/
+def poisonThenCollection : TweakableHash.SM_DT_TCR_SourceFinalValidity.Adversary problem where
+  State := Bool × Bool × Bool
+  choose := do
+    let y₁ ← challenge false false
+    let y₂ ← challenge false true
+    let y₃ ← collectionQuery true true
+    return (y₁, y₂, y₃)
+  forge _ _ := pure (0, true)
+
 private lemma run_challengeOnly :
     (simulateQ (TweakableHash.SM_DT_TCR_SourceFinalValidity.oracles problem .only)
       challengeOnly.choose).run .initial =
@@ -125,6 +135,15 @@ private lemma run_repeatedTarget :
     (simulateQ (TweakableHash.SM_DT_TCR_SourceFinalValidity.oracles problem .only)
       repeatedTarget.choose).run .initial =
       pure ((false, false), ⟨[(false, false), (false, true)], [], false⟩) := by
+  rfl
+
+/-- Once poisoned, the monitor remains always-answering: the later collection digest and its tweak
+are both observable, while validity remains false. -/
+theorem poison_then_collection_history_canary :
+    (simulateQ (TweakableHash.SM_DT_TCR_SourceFinalValidity.oracles problem .only)
+      poisonThenCollection.choose).run .initial =
+      pure ((false, false, true),
+        ⟨[(false, false), (false, true)], [true], false⟩) := by
   rfl
 
 private lemma experiment_challengeOnly :


### PR DESCRIPTION
## Summary

This PR adds the generic source-final-validity monitor required by the SLH-DSA proof stack and instantiates it for the multi-target, single-function TCR and preimage games used by the hypertree reduction.

The key semantic choice is deliberately final-state based: target and collection queries are always answered and always recorded, while invalidity is sticky and checked only in the experiment's final win predicate. This matches the source game and avoids accidentally turning a final-validity condition into an aborting oracle.

### Exact diff metadata

- Base: `a9dd3bd2895d2ca8bbe02af480c1df7c3be64e24` (`main`)
- Head: `c0930e49f74580fc8c0c22fbbffd8496df38972a`
- Commits: 2
- Files changed: 8
- Diff: 821 insertions, 1 deletion
- Planning document: #592

## What changed

### Generic final-validity monitor

- Adds `SourceFinalValidity.State` with target history, collection-tweak history, and a sticky validity bit.
- Defines validity as the conjunction of:
  - the target-query cap,
  - pairwise-distinct target tweaks, and
  - disjoint target and collection tweak sets.
- Proves the Boolean monitor exactly corresponds to the declarative predicate.
- Proves target and collection updates preserve the monitor invariant.
- Exposes an unconditional collection-oracle run theorem: even a poisoned state still receives the hash answer and appends the query while remaining invalid.

### Final-validity TCR and PRE games

- Adds `SM_DT_TCR_SourceFinalValidity` with separated challenge and collection oracles, exact target counting, and final-state validity in the win condition.
- Adds `SM_DT_PRE_SourceFinalValidity` with sampled challenge inputs, the same final-validity discipline, and the preimage/inversion win predicate.
- Provides standalone constructors for using a single tweakable hash as the degenerate collection.
- Leaves the existing `SMDTTCR.lean` and `SMDTPRE.lean` rejection-on-arrival APIs untouched.

### Mutation-sensitive canaries and CI

- Covers both cross-oracle collision orders.
- Covers repeated target tweaks, target-cap overflow, repeated collection queries, and legal controls.
- Pins PRE inversion behavior.
- Pins the post-poison contract: a later collection query is answered and appended, and the validity bit stays false.
- Registers both test modules in the aggregate test root and hosted style-lint workflow, including targeted path triggers.

## File map

- `FinalValidity.lean`: reusable state, validity predicate, sticky monitor, invariant proofs, and collection oracle.
- `SMDTTCRFinalValidity.lean`: final-validity TCR problem, adversary, oracles, experiment, advantage, and challenge run theorem.
- `SMDTPREFinalValidity.lean`: final-validity PRE problem, adversary, oracles, experiment, advantage, and challenge run theorem.
- `VCVioTest/SMDTTCRFinalValidity.lean`: TCR branch, cross-oracle ordering, repetition, and post-poison canaries.
- `VCVioTest/SMDTPREFinalValidity.lean`: PRE validity and inversion canaries.
- `VCVio.lean`, `VCVioTest.lean`, `.github/workflows/linting.yml`: imports and permanent lint coverage.

## Validation

Validated locally at exact head `c0930e49f74580fc8c0c22fbbffd8496df38972a` on base `a9dd3bd2895d2ca8bbe02af480c1df7c3be64e24`:

- focused builds for all new library and test modules;
- focused and full text-based style lint;
- `./scripts/build-project.sh` (3,723 jobs);
- `./scripts/test-axiomsweep.sh`;
- `lake exe axiomsweep --check` (15,598 declarations across 495 modules; no new axiom or `sorry` taint);
- PMF/SPMF ceiling and PolyFun-boundary checks;
- Extern and Interop isolation checks;
- agent-documentation and generated-import checks;
- changed-file forbidden-token scan and `git diff --check`.

The independent Lean formalization gate reviewed and passed this exact head with no findings. Hosted CI was restarted by the base rewrite and is intentionally treated as pending until the new head's checks finish.

## Stack

This is an independent foundation PR from the SLH-DSA implementation track. The subsequent cryptographic-assumption PR is stacked on this branch; this PR itself targets `main`.

Planning issue/stack document: #592.
