### PR TITLE
feat(SLHDSA): model digest and hypertree positions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -88,4 +88,4 @@ jobs:
       # project deliberately defines no `lint-style` exe, so it does not link the
       # FFI backends). Pass the libraries explicitly for full coverage.
       - name: Run text-based style linters
-        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Params HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Scheme HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT
+        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Params HashSigTest.SLHDSA.Position HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Scheme HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT

--- a/HashSig.lean
+++ b/HashSig.lean
@@ -17,6 +17,7 @@ public import HashSig.SLHDSA.Fors
 public import HashSig.SLHDSA.Hypertree
 public import HashSig.SLHDSA.Oracle
 public import HashSig.SLHDSA.Params
+public import HashSig.SLHDSA.Position
 public import HashSig.SLHDSA.Primitives
 public import HashSig.SLHDSA.RandomOracle
 public import HashSig.SLHDSA.Scheme

--- a/HashSig/SLHDSA/Encoding.lean
+++ b/HashSig/SLHDSA/Encoding.lean
@@ -14,7 +14,7 @@ The pure conversion helpers of FIPS 205 §4.4: `toInt` (Algorithm 2, big-endian 
 integer), `toByte` (Algorithm 3, integer → big-endian byte string), and `base2b`
 (Algorithm 4, split a byte string into `outLen` big-endian `b`-bit digits, most significant
 first). These are used by WOTS+ (`b = lg_w`) and FORS (`b = a`) to derive digit/index vectors,
-and by the message-digest split (`Scheme.splitDigest`).
+and by the message-digest split (`Position.splitDigest`).
 
 ## References
 

--- a/HashSig/SLHDSA/Position.lean
+++ b/HashSig/SLHDSA/Position.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Address
+public import HashSig.SLHDSA.Encoding
+
+/-!
+# SLH-DSA digest and hypertree positions
+
+This module owns the positional data shared by FIPS 205 message-digest parsing, FORS, and the
+hypertree. `DigestParts` preserves all three outputs of the `H_msg` split. `LayerPosition` records
+the exact layer, reachable tree, and leaf bounds for validated parameters and implements the
+low-bits/high-bits transition between hypertree layers.
+
+## References
+
+- NIST FIPS 205, Section 4.1 and Algorithms 19–20 (message-digest decomposition)
+- NIST FIPS 205, Algorithms 12–13 (hypertree layer recurrence)
+-/
+
+@[expose] public section
+
+namespace SLHDSA
+
+/-! ## Exact message-digest decomposition -/
+
+/-- The FORS-message byte slice at the start of an `H_msg` digest. -/
+def digestMdBytes (p : Params) (digest : Bytes p.m) : Bytes p.digestBytes :=
+  (digest.extract 0 p.digestBytes).cast (by
+    simp [Params.m]
+    omega)
+
+/-- The byte slice encoding the lowest-layer tree index. -/
+def digestTreeBytes (p : Params) (digest : Bytes p.m) : Bytes p.treeIdxBytes :=
+  (digest.extract p.digestBytes (p.digestBytes + p.treeIdxBytes)).cast (by
+    simp [Params.m])
+
+/-- The final byte slice encoding the lowest-layer leaf index. -/
+def digestLeafBytes (p : Params) (digest : Bytes p.m) : Bytes p.leafIdxBytes :=
+  (digest.extract (p.digestBytes + p.treeIdxBytes)
+    (p.digestBytes + p.treeIdxBytes + p.leafIdxBytes)).cast (by
+      simp [Params.m])
+
+/-- The three outputs parsed from an SLH-DSA `H_msg` digest.
+
+The two indices are reduced to their FIPS-prescribed bit widths. Their bounds are intrinsic, so
+later algorithms cannot accidentally use high padding bits from the byte-aligned digest. -/
+structure DigestParts (p : Params) where
+  /-- The message passed to FORS. -/
+  md : Bytes p.digestBytes
+  /-- The tree at hypertree layer zero. -/
+  idxTree : Fin (2 ^ (p.h - p.hp))
+  /-- The leaf within that tree. -/
+  idxLeaf : Fin (2 ^ p.hp)
+deriving Repr, DecidableEq
+
+/-- Split an `H_msg` digest into `md`, `idxTree`, and `idxLeaf` as prescribed by FIPS 205. -/
+def splitDigest (p : Params) (digest : Bytes p.m) : DigestParts p where
+  md := digestMdBytes p digest
+  idxTree := ⟨toInt (digestTreeBytes p digest).toList % 2 ^ (p.h - p.hp),
+    Nat.mod_lt _ (by positivity)⟩
+  idxLeaf := ⟨toInt (digestLeafBytes p digest).toList % 2 ^ p.hp,
+    Nat.mod_lt _ (by positivity)⟩
+
+@[simp]
+theorem digestMdBytes_toList (p : Params) (digest : Bytes p.m) :
+    (digestMdBytes p digest).toList = digest.toList.take p.digestBytes := by
+  simp [digestMdBytes, Vector.toList_cast, Vector.toList_extract]
+
+@[simp]
+theorem digestTreeBytes_toList (p : Params) (digest : Bytes p.m) :
+    (digestTreeBytes p digest).toList =
+      (digest.toList.drop p.digestBytes).take p.treeIdxBytes := by
+  simp [digestTreeBytes, Vector.toList_cast, Vector.toList_extract]
+
+@[simp]
+theorem digestLeafBytes_toList (p : Params) (digest : Bytes p.m) :
+    (digestLeafBytes p digest).toList =
+      (digest.toList.drop (p.digestBytes + p.treeIdxBytes)).take p.leafIdxBytes := by
+  simp [digestLeafBytes, Vector.toList_cast, Vector.toList_extract]
+
+@[simp]
+theorem splitDigest_md_toList (p : Params) (digest : Bytes p.m) :
+    (splitDigest p digest).md.toList = digest.toList.take p.digestBytes := by
+  simp [splitDigest]
+
+@[simp]
+theorem splitDigest_idxTree_val (p : Params) (digest : Bytes p.m) :
+    (splitDigest p digest).idxTree.val =
+      toInt ((digest.toList.drop p.digestBytes).take p.treeIdxBytes) % 2 ^ (p.h - p.hp) := by
+  simp [splitDigest]
+
+@[simp]
+theorem splitDigest_idxLeaf_val (p : Params) (digest : Bytes p.m) :
+    (splitDigest p digest).idxLeaf.val =
+      toInt ((digest.toList.drop (p.digestBytes + p.treeIdxBytes)).take p.leafIdxBytes) %
+        2 ^ p.hp := by
+  simp [splitDigest]
+
+/-- For a valid one-layer parameter set, the digest's tree index is the unique element of
+`Fin 1`. -/
+theorem DigestParts.idxTree_eq_zero_of_d_eq_one {p : Params} (hp : p.Valid) (hd : p.d = 1)
+    (parts : DigestParts p) : parts.idxTree.val = 0 := by
+  have hh : p.h = p.hp := by
+    rw [hp.h_eq_layers, hd]
+    simp
+  have hexp : p.h - p.hp = 0 := by omega
+  have hbound : 2 ^ (p.h - p.hp) = 1 := by simp [hexp]
+  have hlt : parts.idxTree.val < 1 := lt_of_lt_of_eq parts.idxTree.isLt hbound
+  omega
+
+/-! ## Layer-indexed hypertree positions -/
+
+/-- Remaining tree-index bits at a hypertree layer.
+
+The normalized form `(d - (layer + 1)) * h'` avoids repeated transports through
+`h = d * h'` while retaining the exact FIPS reachability bound. -/
+def layerTreeHeight (p : ValidatedParams) (layer : ℕ) : ℕ :=
+  (p.params.d - (layer + 1)) * p.params.hp
+
+/-- A reachable tree and leaf at one layer of a validated SLH-DSA hypertree. -/
+structure LayerPosition (p : ValidatedParams) where
+  /-- Layer number, starting at zero. -/
+  layer : Fin p.params.d
+  /-- Tree index reachable at this layer. -/
+  tree : Fin (2 ^ layerTreeHeight p layer.val)
+  /-- Leaf index within the layer's XMSS tree. -/
+  leaf : Fin (2 ^ p.params.hp)
+deriving Repr, DecidableEq
+
+namespace LayerPosition
+
+/-- The layer-zero position parsed from an `H_msg` digest. -/
+def initial (p : ValidatedParams) (parts : DigestParts p.params) : LayerPosition p where
+  layer := ⟨0, p.valid.d_pos⟩
+  tree := ⟨parts.idxTree.val, by
+    simpa [layerTreeHeight, p.valid.h_eq_layers, Nat.sub_mul] using parts.idxTree.isLt⟩
+  leaf := parts.idxLeaf
+
+/-- Advance one hypertree layer: low `h'` bits select the next leaf and the remaining high bits
+select the next tree. -/
+def next {p : ValidatedParams} (pos : LayerPosition p)
+    (hnext : pos.layer.val + 1 < p.params.d) : LayerPosition p where
+  layer := ⟨pos.layer.val + 1, hnext⟩
+  tree := ⟨pos.tree.val / 2 ^ p.params.hp, by
+    have hlevels :
+        p.params.d - (pos.layer.val + 1) =
+          p.params.d - (pos.layer.val + 2) + 1 := by
+      omega
+    have hexp :
+        layerTreeHeight p pos.layer.val =
+          p.params.hp + layerTreeHeight p (pos.layer.val + 1) := by
+      unfold layerTreeHeight
+      rw [hlevels, Nat.add_mul]
+      simp only [one_mul, Nat.add_comm]
+      congr 2
+      omega
+    apply Nat.div_lt_of_lt_mul
+    calc
+      pos.tree.val < 2 ^ layerTreeHeight p pos.layer.val := pos.tree.isLt
+      _ = 2 ^ p.params.hp * 2 ^ layerTreeHeight p (pos.layer.val + 1) := by
+        rw [hexp, pow_add]⟩
+  leaf := ⟨pos.tree.val % 2 ^ p.params.hp, Nat.mod_lt _ (by positivity)⟩
+
+@[simp]
+theorem initial_layer_val (p : ValidatedParams) (parts : DigestParts p.params) :
+    (initial p parts).layer.val = 0 := rfl
+
+@[simp]
+theorem initial_tree_val (p : ValidatedParams) (parts : DigestParts p.params) :
+    (initial p parts).tree.val = parts.idxTree.val := rfl
+
+@[simp]
+theorem initial_leaf_val (p : ValidatedParams) (parts : DigestParts p.params) :
+    (initial p parts).leaf.val = parts.idxLeaf.val := rfl
+
+@[simp]
+theorem next_layer_val {p : ValidatedParams} (pos : LayerPosition p)
+    (hnext : pos.layer.val + 1 < p.params.d) :
+    (pos.next hnext).layer.val = pos.layer.val + 1 := rfl
+
+@[simp]
+theorem next_tree_val {p : ValidatedParams} (pos : LayerPosition p)
+    (hnext : pos.layer.val + 1 < p.params.d) :
+    (pos.next hnext).tree.val = pos.tree.val / 2 ^ p.params.hp := rfl
+
+@[simp]
+theorem next_leaf_val {p : ValidatedParams} (pos : LayerPosition p)
+    (hnext : pos.layer.val + 1 < p.params.d) :
+    (pos.next hnext).leaf.val = pos.tree.val % 2 ^ p.params.hp := rfl
+
+/-- The reachable tree index at the final layer is zero. -/
+theorem tree_eq_zero_of_isFinal {p : ValidatedParams} (pos : LayerPosition p)
+    (hfinal : pos.layer.val + 1 = p.params.d) : pos.tree.val = 0 := by
+  have hrem : p.params.d - (pos.layer.val + 1) = 0 := by omega
+  have hheight : layerTreeHeight p pos.layer.val = 0 := by
+    simp [layerTreeHeight, hrem]
+  have hbound : 2 ^ layerTreeHeight p pos.layer.val = 1 := by simp [hheight]
+  have hlt : pos.tree.val < 1 := lt_of_lt_of_eq pos.tree.isLt hbound
+  omega
+
+/-- The layer and tree fields of the base hash address for this position. Type-dependent words
+remain zero until the component algorithm selects its address type. -/
+def toAdrs {p : ValidatedParams} (pos : LayerPosition p) : Adrs :=
+  (Adrs.zero.setLayerAddress pos.layer.val).setTreeAddress pos.tree.val
+
+@[simp]
+theorem toAdrs_layer {p : ValidatedParams} (pos : LayerPosition p) :
+    pos.toAdrs.layer = pos.layer.val := rfl
+
+@[simp]
+theorem toAdrs_tree {p : ValidatedParams} (pos : LayerPosition p) :
+    pos.toAdrs.tree = pos.tree.val := rfl
+
+end LayerPosition
+
+namespace DigestParts
+
+/-- The FIPS Algorithm 19 FORS address, carrying both digest-derived indices. -/
+def forsAdrs {p : Params} (parts : DigestParts p) : Adrs :=
+  ((Adrs.zero.setTreeAddress parts.idxTree.val).setTypeAndClear .forsTree).setKeyPairAddress
+    parts.idxLeaf.val
+
+@[simp]
+theorem forsAdrs_layer {p : Params} (parts : DigestParts p) : parts.forsAdrs.layer = 0 := rfl
+
+@[simp]
+theorem forsAdrs_tree {p : Params} (parts : DigestParts p) :
+    parts.forsAdrs.tree = parts.idxTree.val := rfl
+
+@[simp]
+theorem forsAdrs_type {p : Params} (parts : DigestParts p) :
+    parts.forsAdrs.type = AddrType.forsTree.toCode := rfl
+
+@[simp]
+theorem forsAdrs_keyPair {p : Params} (parts : DigestParts p) :
+    parts.forsAdrs.getKeyPairAddress = parts.idxLeaf.val := rfl
+
+end DigestParts
+
+end SLHDSA

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -6,6 +6,7 @@ Authors: Nicolas Consigny
 
 module
 public import HashSig.SLHDSA.Hypertree
+public import HashSig.SLHDSA.Position
 
 /-!
 # SLH-DSA Scheme (FIPS 205 §9–10)
@@ -18,8 +19,7 @@ an explicit `HasQuery` operation:
 - `slhKeygenInternalM` / `slhSignInternalM` / `slhVerifyInternalM` (Algorithms 18–20),
 - `slhKeygenInternal` / `slhSignInternal` / `slhVerifyInternal`, the deterministic
   `PublicHash.impl` interpretations of those programs,
-- `splitDigest`, the message-digest split into `(md, idxLeaf)` (§9; for `d = 1` the tree index
-  is always `0`, so it is omitted), and
+- `splitDigest`, the typed message-digest split into `md`, `idxTree`, and `idxLeaf` (§9), and
 - `emptyContextMessage`, the FIPS 205 external-message encoding used by the canonical external
   scheme in `HashSig.SLHDSA.RandomOracle`.
 
@@ -71,25 +71,6 @@ structure SecretKeyCore (core : CorePrimitives p) where
 abbrev SignatureCore (p : Params) (core : CorePrimitives p) :=
   core.Y × ForsSigCore p core × HtSigCore p core
 
-/-! ### Message-digest split (FIPS 205 §9) -/
-
-/-- Split the message digest into the FORS message `md` and the hypertree leaf index `idxLeaf`
-(reduced mod `2^{h'}`). For `d = 1` the tree-index field is empty, so the tree index is `0` and
-omitted. -/
-def splitDigest (p : Params) (digest : Bytes p.m) : List Byte × ℕ :=
-  let bytes := digest.toList
-  (bytes.take p.digestBytes,
-    toInt ((bytes.drop (p.digestBytes + p.treeIdxBytes)).take p.leafIdxBytes) % 2 ^ p.hp)
-
-theorem splitDigest_snd_lt (p : Params) (digest : Bytes p.m) :
-    (splitDigest p digest).2 < 2 ^ p.hp := by
-  simp only [splitDigest]
-  exact Nat.mod_lt _ (by positivity)
-
-/-- The FORS base address keyed to the per-message hypertree leaf `idxLeaf` (FIPS 205 Alg 19). -/
-def forsAdrsOf (idxLeaf : ℕ) : Adrs :=
-  ((Adrs.zero.setTreeAddress 0).setTypeAndClear .forsTree).setKeyPairAddress idxLeaf
-
 /-! ### Canonical internal algorithms (FIPS 205 §9) -/
 
 /-- Canonical SLH-DSA internal key generation (FIPS 205 Algorithm 18). The public root is
@@ -110,12 +91,10 @@ def slhSignInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     m (SignatureCore p core) := do
   let R := core.PRFmsg sk.skPrf addrnd msg
   let digest ← PublicHash.hmsg core R sk.pkSeed sk.pkRoot msg
-  let idxLeaf := (splitDigest p digest).2
-  let md := (splitDigest p digest).1
-  let fAdrs := forsAdrsOf idxLeaf
-  let forsSig ← forsSignM core md sk.skSeed sk.pkSeed fAdrs
-  let forsPk ← forsPkFromSigM core forsSig md sk.pkSeed fAdrs
-  let htSig ← htSignM core forsPk sk.skSeed sk.pkSeed Adrs.zero 0 idxLeaf
+  let parts := splitDigest p digest
+  let forsSig ← forsSignM core parts.md.toList sk.skSeed sk.pkSeed parts.forsAdrs
+  let forsPk ← forsPkFromSigM core forsSig parts.md.toList sk.pkSeed parts.forsAdrs
+  let htSig ← htSignM core forsPk sk.skSeed sk.pkSeed Adrs.zero 0 parts.idxLeaf.val
   return (R, forsSig, htSig)
 
 /-- Canonical SLH-DSA internal verification (FIPS 205 Algorithm 20). Its public-hash schedule is
@@ -124,11 +103,9 @@ def slhVerifyInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
     (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) : m Bool := do
   let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
-  let idxLeaf := (splitDigest p digest).2
-  let md := (splitDigest p digest).1
-  let fAdrs := forsAdrsOf idxLeaf
-  let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
-  htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot
+  let parts := splitDigest p digest
+  let forsPk ← forsPkFromSigM core sig.2.1 parts.md.toList pk.pkSeed parts.forsAdrs
+  htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 parts.idxLeaf.val pk.pkRoot
 
 /-! ### Pure deterministic interpretations -/
 
@@ -280,15 +257,13 @@ theorem slhSignInternalM_isTotalQueryBound (core : CorePrimitives p)
   let R := core.PRFmsg sk.skPrf addrnd msg
   have hbound := isTotalQueryBound_bind
     (publicHash_hmsg_isTotalQueryBound_one core R sk.pkSeed sk.pkRoot msg) fun digest =>
-      let idxLeaf := (splitDigest p digest).2
-      let md := (splitDigest p digest).1
-      let fAdrs := forsAdrsOf idxLeaf
+      let parts := splitDigest p digest
       isTotalQueryBound_bind
         (forsSignM_then_forsPkFromSigM_isTotalQueryBound
-          core md sk.skSeed sk.pkSeed fAdrs) fun sigAndPk =>
+          core parts.md.toList sk.skSeed sk.pkSeed parts.forsAdrs) fun sigAndPk =>
             isTotalQueryBound_bind
               (htSignM_isTotalQueryBound_coarse core sigAndPk.2 sk.skSeed sk.pkSeed
-                Adrs.zero 0 idxLeaf) fun htSig =>
+                Adrs.zero 0 parts.idxLeaf.val) fun htSig =>
                   show IsTotalQueryBound
                     (pure (R, sigAndPk.1, htSig) :
                       OracleComp (publicHashSpec core) (SignatureCore p core)) 0 from trivial
@@ -324,11 +299,12 @@ theorem slhVerifyInternalM_isTotalQueryBound (core : CorePrimitives p) [Decidabl
       (slhVerifyInternalQueryBound p core sig) := by
   have hbound := isTotalQueryBound_bind
     (publicHash_hmsg_isTotalQueryBound_one core sig.1 pk.pkSeed pk.pkRoot msg) fun digest =>
+      let parts := splitDigest p digest
       isTotalQueryBound_bind
-        (forsPkFromSigM_isTotalQueryBound core sig.2.1 (splitDigest p digest).1 pk.pkSeed
-          (forsAdrsOf (splitDigest p digest).2)) fun forsPk =>
+        (forsPkFromSigM_isTotalQueryBound core sig.2.1 parts.md.toList pk.pkSeed
+          parts.forsAdrs) fun forsPk =>
             htVerifyM_isTotalQueryBound_coarse core forsPk sig.2.2 pk.pkSeed Adrs.zero 0
-              (splitDigest p digest).2 pk.pkRoot
+              parts.idxLeaf.val pk.pkRoot
   simpa [slhVerifyInternalM, slhVerifyInternalQueryBound, Nat.add_assoc] using hbound
 
 /-! ### Deterministic interpretations -/
@@ -405,7 +381,7 @@ theorem simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
     simulateQ_forsPkFromSigM_withPublicHash, simulateQ_htSignM_withPublicHash,
     simulateQ_htVerifyM_withPublicHash]
   exact htVerify_htSign (PublicHash.withPublicHash core answer) _ skSeed pkSeed Adrs.zero 0 _
-    (splitDigest_snd_lt p _)
+    (splitDigest p _).idxLeaf.isLt
 
 /-- **Deterministic correctness core**: an honestly generated signature verifies, for every
 choice of seeds, randomizer, and deterministic public-hash implementation. -/

--- a/HashSigTest/SLHDSA/Position.lean
+++ b/HashSigTest/SLHDSA/Position.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import HashSig.SLHDSA.Position
+
+/-!
+# SLH-DSA digest and position canaries
+
+Mutation-sensitive checks for digest byte boundaries, high-bit truncation, hypertree transitions,
+and address propagation. The expected values are independent of the implementation theorems.
+-/
+
+public section
+
+namespace SLHDSA.PositionTest
+
+open FipsParameterSet
+
+/-- A small valid three-layer profile with one digest byte for each parsed component. -/
+def threeLayerParams : Params :=
+  { n := 1, h := 12, d := 3, hp := 4, a := 8, k := 1, lgw := 1 }
+
+/-- The three-layer profile bundled with its arithmetic validity proof. -/
+def threeLayerValidated : ValidatedParams := ⟨threeLayerParams, by decide⟩
+
+/-- Digest bytes chosen so every parsed component and both masked high-bit boundaries differ. -/
+def threeLayerDigest : Bytes threeLayerParams.m :=
+  Vector.ofFn fun i => ([0xa5, 0xab, 0xfe] : List Byte).getD i.val 0
+
+/-- The exact typed result of parsing `a5 || ab || fe`: the final nibble masks `fe` to `e`. -/
+theorem threeLayerSplit :
+    let parts := splitDigest threeLayerParams threeLayerDigest
+    (parts.md.toList, parts.idxTree.val, parts.idxLeaf.val) = ([0xa5], 171, 14) := by
+  simp only [splitDigest_md_toList, splitDigest_idxTree_val, splitDigest_idxLeaf_val]
+  simp [threeLayerParams, threeLayerDigest, Params.digestBytes, Params.treeIdxBytes,
+    Params.leafIdxBytes, Params.m, toInt, Vector.toList_ofFn, List.ofFn, Fin.foldr,
+    Fin.foldr.loop]
+
+theorem threeLayerTree :
+    (splitDigest threeLayerParams threeLayerDigest).idxTree.val = 171 := by
+  exact congrArg (fun result => result.2.1) threeLayerSplit
+
+theorem threeLayerLeaf :
+    (splitDigest threeLayerParams threeLayerDigest).idxLeaf.val = 14 := by
+  exact congrArg (fun result => result.2.2) threeLayerSplit
+
+/-- The FORS address carries the digest-derived tree and leaf, not one-layer zero defaults. -/
+example : (splitDigest threeLayerParams threeLayerDigest).forsAdrs =
+    { layer := 0, tree := 171, type := 3, word1 := 14, word2 := 0, word3 := 0 } := by
+  unfold DigestParts.forsAdrs
+  rw [show (splitDigest threeLayerParams threeLayerDigest).idxTree.val = 171 from threeLayerTree]
+  rw [show (splitDigest threeLayerParams threeLayerDigest).idxLeaf.val = 14 from threeLayerLeaf]
+  rfl
+
+/-- Layer zero receives the digest's tree and leaf without swapping them. -/
+def position0 : LayerPosition threeLayerValidated :=
+  LayerPosition.initial threeLayerValidated (splitDigest threeLayerParams threeLayerDigest)
+
+theorem position0Values :
+    [position0.layer.val, position0.tree.val, position0.leaf.val] = [0, 171, 14] := by
+  change [0, (splitDigest threeLayerParams threeLayerDigest).idxTree.val,
+    (splitDigest threeLayerParams threeLayerDigest).idxLeaf.val] = [0, 171, 14]
+  rw [threeLayerTree, threeLayerLeaf]
+
+theorem position0Layer : position0.layer.val = 0 :=
+  congrArg (fun xs => xs[0]!) position0Values
+
+theorem position0Tree : position0.tree.val = 171 :=
+  congrArg (fun xs => xs[1]!) position0Values
+
+/-- The first real transition sends low four tree bits to the leaf and high bits to the tree. -/
+def position1 : LayerPosition threeLayerValidated := position0.next (by decide)
+
+theorem position1Layer : position1.layer.val = 1 := by
+  change position0.layer.val + 1 = 1
+  rw [position0Layer]
+
+theorem position1Tree : position1.tree.val = 10 := by
+  change position0.tree.val / 2 ^ threeLayerValidated.params.hp = 10
+  rw [position0Tree]
+  norm_num [threeLayerValidated, threeLayerParams]
+
+theorem position1Leaf : position1.leaf.val = 11 := by
+  change position0.tree.val % 2 ^ threeLayerValidated.params.hp = 11
+  rw [position0Tree]
+  norm_num [threeLayerValidated, threeLayerParams]
+
+theorem position1Values :
+    [position1.layer.val, position1.tree.val, position1.leaf.val] = [1, 10, 11] := by
+  simpa only [List.cons.injEq, List.nil_eq, and_true] using
+    And.intro position1Layer (And.intro position1Tree position1Leaf)
+
+example : position1.toAdrs =
+    { layer := 1, tree := 10, type := 0, word1 := 0, word2 := 0, word3 := 0 } := by
+  unfold LayerPosition.toAdrs
+  rw [show position1.tree.val = 10 from position1Tree]
+  rw [show position1.layer.val = 1 from position1Layer]
+  rfl
+
+/-- The second transition reaches the final layer with tree zero and the prior tree as leaf. -/
+def position2 : LayerPosition threeLayerValidated := position1.next (by decide)
+
+theorem position2Layer : position2.layer.val = 2 := by
+  change position1.layer.val + 1 = 2
+  rw [position1Layer]
+
+theorem position2Tree : position2.tree.val = 0 := by
+  change position1.tree.val / 2 ^ threeLayerValidated.params.hp = 0
+  rw [position1Tree]
+  norm_num [threeLayerValidated, threeLayerParams]
+
+theorem position2Leaf : position2.leaf.val = 10 := by
+  change position1.tree.val % 2 ^ threeLayerValidated.params.hp = 10
+  rw [position1Tree]
+  norm_num [threeLayerValidated, threeLayerParams]
+
+theorem position2Values :
+    [position2.layer.val, position2.tree.val, position2.leaf.val] = [2, 0, 10] := by
+  simpa only [List.cons.injEq, List.nil_eq, and_true] using
+    And.intro position2Layer (And.intro position2Tree position2Leaf)
+
+example : position2.tree.val = 0 := position2Tree
+
+/-- Increasing digest bytes make every slice boundary and big-endian conversion observable. -/
+def increasingDigest (p : Params) : Bytes p.m :=
+  Vector.ofFn fun i => UInt8.ofNat i.val
+
+/-- Summary of exact `md` extent and the two parsed indices for a named FIPS parameter set. -/
+def digestSummary (ps : FipsParameterSet) : List ℕ :=
+  let p := ps.params
+  let parts := splitDigest p (increasingDigest p)
+  [parts.md.toList.length,
+    (parts.md.toList.getD (p.digestBytes - 1) 0).toNat,
+    parts.idxTree.val,
+    parts.idxLeaf.val]
+
+/-- All six numerical shapes, in both families, use the exact byte offsets and bit masks. -/
+example : all.map digestSummary =
+  [[21, 20, 5935262955280923, 29], [25, 24, 1808788007904223008, 1],
+    [30, 29, 8478472156619556, 294], [33, 32, 2387509390608836392, 1],
+    [39, 38, 11021681357958189, 46], [40, 39, 2893890600475373103, 0],
+    [21, 20, 5935262955280923, 29], [25, 24, 1808788007904223008, 1],
+    [30, 29, 8478472156619556, 294], [33, 32, 2387509390608836392, 1],
+    [39, 38, 11021681357958189, 46], [40, 39, 2893890600475373103, 0]] := by
+  simp only [all, List.map_cons, List.map_nil, digestSummary, splitDigest_md_toList,
+    splitDigest_idxTree_val, splitDigest_idxLeaf_val]
+  norm_num [increasingDigest, FipsParameterSet.params, Params.digestBytes, Params.treeIdxBytes,
+    Params.leafIdxBytes, Params.m, toInt, Vector.toList_ofFn, List.ofFn, Fin.foldr,
+    Fin.foldr.loop]
+
+/-- An all-ones digest reaches the maximum tree and leaf after discarding byte-alignment padding. -/
+def truncationBoundaryCorrect (ps : FipsParameterSet) : Bool :=
+  let p := ps.params
+  let digest : Bytes p.m := Vector.replicate p.m 0xff
+  let parts := splitDigest p digest
+  parts.idxTree.val == 2 ^ (p.h - p.hp) - 1 &&
+    parts.idxLeaf.val == 2 ^ p.hp - 1
+
+example : all.all truncationBoundaryCorrect = true := by decide
+
+/-- The one-layer limited profile has an empty tree-index slice and therefore tree zero. -/
+example :
+    let digest : Bytes slhdsaSha2_128_24.m := Vector.replicate slhdsaSha2_128_24.m 0xff
+    (splitDigest slhdsaSha2_128_24 digest).idxTree.val = 0 := by
+  decide
+
+end SLHDSA.PositionTest

--- a/HashSigTest/SLHDSA/Position.lean
+++ b/HashSigTest/SLHDSA/Position.lean
@@ -140,7 +140,7 @@ def digestSummary (ps : FipsParameterSet) : List ℕ :=
     parts.idxLeaf.val]
 
 /-- All six numerical shapes, in both families, use the exact byte offsets and bit masks. -/
-example : all.map digestSummary =
+theorem allDigestSummaries : all.map digestSummary =
   [[21, 20, 5935262955280923, 29], [25, 24, 1808788007904223008, 1],
     [30, 29, 8478472156619556, 294], [33, 32, 2387509390608836392, 1],
     [39, 38, 11021681357958189, 46], [40, 39, 2893890600475373103, 0],
@@ -152,6 +152,119 @@ example : all.map digestSummary =
   norm_num [increasingDigest, FipsParameterSet.params, Params.digestBytes, Params.treeIdxBytes,
     Params.leafIdxBytes, Params.m, toInt, Vector.toList_ofFn, List.ofFn, Fin.foldr,
     Fin.foldr.loop]
+
+/-! ## Named FIPS hypertree trajectories -/
+
+/-- The layer-zero position obtained from a named FIPS parameter set's increasing-byte digest. -/
+private def fipsInitialPosition (ps : FipsParameterSet) : LayerPosition ps.validatedParams :=
+  LayerPosition.initial ps.validatedParams (splitDigest ps.params (increasingDigest ps.params))
+
+@[simp]
+private theorem fipsInitialPosition_layer (ps : FipsParameterSet) :
+    (fipsInitialPosition ps).layer.val = 0 := rfl
+
+@[simp]
+private theorem fipsInitialPosition_tree (ps : FipsParameterSet) :
+    (fipsInitialPosition ps).tree.val =
+      (splitDigest ps.params (increasingDigest ps.params)).idxTree.val := rfl
+
+@[simp]
+private theorem fipsInitialPosition_leaf (ps : FipsParameterSet) :
+    (fipsInitialPosition ps).leaf.val =
+      (splitDigest ps.params (increasingDigest ps.params)).idxLeaf.val := rfl
+
+/-- The first FIPS layer transition, which exists for every named parameter set. -/
+private def fipsFirstPosition (ps : FipsParameterSet) : LayerPosition ps.validatedParams :=
+  (fipsInitialPosition ps).next (by cases ps <;> decide)
+
+/-- Initial and first-transition position fields followed by their independently projected address
+layer and tree. -/
+private def fipsFirstTransitionSummary (ps : FipsParameterSet) : List ℕ :=
+  let initial := fipsInitialPosition ps
+  let next := fipsFirstPosition ps
+  [initial.layer.val, initial.tree.val, initial.leaf.val,
+    initial.toAdrs.layer, initial.toAdrs.tree,
+    next.layer.val, next.tree.val, next.leaf.val,
+    next.toAdrs.layer, next.toAdrs.tree]
+
+@[simp]
+private theorem fipsFirstTransitionSummary_eq (ps : FipsParameterSet) :
+    fipsFirstTransitionSummary ps =
+      let parts := splitDigest ps.params (increasingDigest ps.params)
+      [0, parts.idxTree.val, parts.idxLeaf.val, 0, parts.idxTree.val,
+        1, parts.idxTree.val / 2 ^ ps.params.hp,
+        parts.idxTree.val % 2 ^ ps.params.hp,
+        1, parts.idxTree.val / 2 ^ ps.params.hp] := by
+  rfl
+
+/-- Every approved small/fast shape and both hash families follow the first FIPS transition and
+propagate the resulting layer and tree into the address. -/
+example : all.map fipsFirstTransitionSummary =
+  [[0, 5935262955280923, 29, 0, 5935262955280923,
+      1, 11592310459533, 27, 1, 11592310459533],
+    [0, 1808788007904223008, 1, 0, 1808788007904223008,
+      1, 226098500988027876, 0, 1, 226098500988027876],
+    [0, 8478472156619556, 294, 0, 8478472156619556,
+      1, 16559515930897, 292, 1, 16559515930897],
+    [0, 2387509390608836392, 1, 0, 2387509390608836392,
+      1, 298438673826104549, 0, 1, 298438673826104549],
+    [0, 11021681357958189, 46, 0, 11021681357958189,
+      1, 43053442804524, 45, 1, 43053442804524],
+    [0, 2893890600475373103, 0, 0, 2893890600475373103,
+      1, 180868162529710818, 15, 1, 180868162529710818],
+    [0, 5935262955280923, 29, 0, 5935262955280923,
+      1, 11592310459533, 27, 1, 11592310459533],
+    [0, 1808788007904223008, 1, 0, 1808788007904223008,
+      1, 226098500988027876, 0, 1, 226098500988027876],
+    [0, 8478472156619556, 294, 0, 8478472156619556,
+      1, 16559515930897, 292, 1, 16559515930897],
+    [0, 2387509390608836392, 1, 0, 2387509390608836392,
+      1, 298438673826104549, 0, 1, 298438673826104549],
+    [0, 11021681357958189, 46, 0, 11021681357958189,
+      1, 43053442804524, 45, 1, 43053442804524],
+    [0, 2893890600475373103, 0, 0, 2893890600475373103,
+      1, 180868162529710818, 15, 1, 180868162529710818]] := by
+  simp only [all, List.map_cons, List.map_nil, fipsFirstTransitionSummary_eq,
+    splitDigest_idxTree_val, splitDigest_idxLeaf_val]
+  norm_num [increasingDigest, FipsParameterSet.params, Params.digestBytes, Params.treeIdxBytes,
+    Params.leafIdxBytes, Params.m, toInt, Vector.toList_ofFn, List.ofFn, Fin.foldr,
+    Fin.foldr.loop]
+
+/-- Compact layer/tree/leaf view used to pin a complete named FIPS trajectory. -/
+private def positionSummary {p : ValidatedParams} (pos : LayerPosition p) : List ℕ :=
+  [pos.layer.val, pos.tree.val, pos.leaf.val]
+
+private def sha2_128sPosition0 :
+    LayerPosition (.SLHDSA_SHA2_128s : FipsParameterSet).validatedParams :=
+  fipsInitialPosition .SLHDSA_SHA2_128s
+
+private def sha2_128sPosition1 := sha2_128sPosition0.next (by decide)
+private def sha2_128sPosition2 := sha2_128sPosition1.next (by decide)
+private def sha2_128sPosition3 := sha2_128sPosition2.next (by decide)
+private def sha2_128sPosition4 := sha2_128sPosition3.next (by decide)
+private def sha2_128sPosition5 := sha2_128sPosition4.next (by decide)
+private def sha2_128sPosition6 := sha2_128sPosition5.next (by decide)
+
+@[simp]
+private theorem sha2_128s_hp :
+    (.SLHDSA_SHA2_128s : FipsParameterSet).validatedParams.params.hp = 9 := rfl
+
+/-- A full seven-layer approved small trajectory reaches the final zero tree without changing
+layer order or swapping the high- and low-bit components. -/
+example :
+    [sha2_128sPosition0, sha2_128sPosition1, sha2_128sPosition2, sha2_128sPosition3,
+      sha2_128sPosition4, sha2_128sPosition5, sha2_128sPosition6].map positionSummary =
+    [[0, 5935262955280923, 29], [1, 11592310459533, 27], [2, 22641231366, 141],
+      [3, 44221155, 6], [4, 86369, 227], [5, 168, 353], [6, 0, 168]] := by
+  simp only [List.map_cons, List.map_nil, positionSummary, sha2_128sPosition6,
+    sha2_128sPosition5, sha2_128sPosition4, sha2_128sPosition3, sha2_128sPosition2,
+    sha2_128sPosition1, sha2_128sPosition0, LayerPosition.next_layer_val,
+    LayerPosition.next_tree_val, LayerPosition.next_leaf_val, fipsInitialPosition_layer,
+    fipsInitialPosition_tree, fipsInitialPosition_leaf, splitDigest_idxTree_val,
+    splitDigest_idxLeaf_val, sha2_128s_hp]
+  norm_num [increasingDigest, FipsParameterSet.validatedParams, FipsParameterSet.params,
+    Params.digestBytes, Params.treeIdxBytes, Params.leafIdxBytes, Params.m, toInt,
+    Vector.toList_ofFn, List.ofFn, Fin.foldr, Fin.foldr.loop]
 
 /-- An all-ones digest reaches the maximum tree and leaf after discarding byte-alignment padding. -/
 def truncationBoundaryCorrect (ps : FipsParameterSet) : Bool :=

--- a/HashSigTest/SLHDSA/Scheme.lean
+++ b/HashSigTest/SLHDSA/Scheme.lean
@@ -31,12 +31,11 @@ example (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
       OracleComp (publicHashSpec core) (SignatureCore p core)) = (do
         let R := core.PRFmsg sk.skPrf addrnd msg
         let digest ← PublicHash.hmsg core R sk.pkSeed sk.pkRoot msg
-        let idxLeaf := (splitDigest p digest).2
-        let md := (splitDigest p digest).1
-        let fAdrs := forsAdrsOf idxLeaf
-        let forsSig ← forsSignM core md sk.skSeed sk.pkSeed fAdrs
-        let forsPk ← forsPkFromSigM core forsSig md sk.pkSeed fAdrs
-        let htSig ← htSignM core forsPk sk.skSeed sk.pkSeed Adrs.zero 0 idxLeaf
+        let parts := splitDigest p digest
+        let forsSig ← forsSignM core parts.md.toList sk.skSeed sk.pkSeed parts.forsAdrs
+        let forsPk ←
+          forsPkFromSigM core forsSig parts.md.toList sk.pkSeed parts.forsAdrs
+        let htSig ← htSignM core forsPk sk.skSeed sk.pkSeed Adrs.zero 0 parts.idxLeaf.val
         return (R, forsSig, htSig)) := by
   rfl
 
@@ -45,11 +44,9 @@ example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
     (pk : PublicKeyCore core) :
     (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool) = (do
       let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
-      let idxLeaf := (splitDigest p digest).2
-      let md := (splitDigest p digest).1
-      let fAdrs := forsAdrsOf idxLeaf
-      let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
-      htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot) := by
+      let parts := splitDigest p digest
+      let forsPk ← forsPkFromSigM core sig.2.1 parts.md.toList pk.pkSeed parts.forsAdrs
+      htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 parts.idxLeaf.val pk.pkRoot) := by
   rfl
 
 end SLHDSA.SchemeTest


### PR DESCRIPTION
## Summary

This stacked PR removes the positional part of the historical `d = 1` restriction. It gives the FIPS 205 `H_msg` output an exact typed decomposition into `md`, `idxTree`, and `idxLeaf`, then models the reachable tree/leaf position at every hypertree layer.

The new types make padding-bit truncation, layer bounds, and the low-bits/high-bits recurrence explicit. They also provide canonical address construction so downstream FORS, XMSS, hypertree, and full-scheme PRs can share one positional API.

## What changed

### Typed digest decomposition

- Adds exact byte slices for the FORS message, tree index, and leaf index.
- Adds `DigestParts`, with indices intrinsically bounded as `Fin (2^(h-h'))` and `Fin (2^h')`.
- Defines the FIPS big-endian conversion and modulo truncation for byte-alignment padding.
- Proves exact slice/list and parsed-value theorems.
- Retains an explicit theorem that valid `d = 1` profiles have tree index zero.

### Reachable hypertree positions

- Adds `LayerPosition` for validated parameters, bundling:
  - a layer in `Fin d`,
  - a tree index bounded by the remaining tree bits, and
  - a leaf index bounded by `2^h'`.
- Defines the initial position from `DigestParts`.
- Defines the FIPS transition: low `h'` tree bits become the next leaf and the remaining high bits become the next tree.
- Proves the exact layer/tree/leaf recurrence and that the final reachable tree is zero.
- Adds canonical layer/tree address projection and a FORS address carrying the digest-derived tree and leaf.

### Scheme migration within this slice

- Migrates SLH-DSA sign/verify and query-bound proofs to the structured digest split.
- Propagates the actual digest-derived tree and leaf into the FORS address.
- Deliberately retains the current one-layer hypertree call (`tree = 0`) because the existing key generation and HT implementation are still one-layer. General HT traversal and complete scheme wiring belong to the later G4/G5 PRs; changing only this call here would break the current generic correctness theorem.

### Mutation-sensitive evidence

- Pins a synthetic three-layer `171 -> (tree 10, leaf 11) -> (tree 0, leaf 10)` trajectory and address propagation.
- Pins exact increasing-byte digest summaries for all 12 approved FIPS parameter sets.
- Pins all-ones truncation at the maximum legal tree and leaf for every named set.
- Pins hard-coded initial and first-transition positions and addresses for all 12 named sets.
- Pins the complete seven-layer SHA2-128s trajectory, including final tree zero.
- Pins the `d = 1` empty-tree-index boundary.

## File map

- `HashSig/SLHDSA/Position.lean`: digest decomposition, typed positions, recurrence theorems, and address construction.
- `HashSig/SLHDSA/Scheme.lean`: structured split and FORS-address consumer migration.
- `HashSigTest/SLHDSA/Position.lean`: synthetic, all-parameter, truncation, named-transition, and full-trajectory canaries.
- `HashSigTest/SLHDSA/Scheme.lean`: updated sign/verify schedule canaries.
- `HashSig/SLHDSA/Encoding.lean`, `HashSig.lean`, `.github/workflows/linting.yml`: ownership documentation, imports, and permanent lint coverage.

## Validation

Validated at:

- stacked base: `0caf09ca831ba0686db549b596ddfeb121de69ac`
- head: `be823fbb6745e95412efe2bf49e0e46055953413`
- unique diff: 7 files, `+558/-54`

Passing checks:

- focused Position/Scheme library and test builds (`2696` jobs)
- focused Position test build (`2652` jobs)
- `lake build HashSig HashSigTest` (`2734` jobs)
- full non-test repository build (`9346` jobs)
- targeted style lint
- import regeneration with no residual changes
- axiomsweep fixture matrix and full check (`15,707` declarations / `494` modules; no new taint)
- extern and interop isolation checks
- PMF boundary ceiling, report, and ratchet (`1923 -> 1923`)
- agent/generated-documentation checks
- changed-file trust scan and `git diff --check`

The independent Lean formalization gate reviewed the exact FIPS decomposition, dependent bounds, recurrence and reachability statements, address propagation, consumer migration, scope deferrals, all-12 named evidence, and trust/integration surfaces at the exact OIDs above.

## Stack

- Base PR: #593
- This PR must merge after #593.
- No later general-hypertree or full-scheme work is included here.
