### PR TITLE
ci: validate merge queue groups

### DIFF
--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -2,6 +2,8 @@ name: Agent Docs
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/interop-isolation.yml
+++ b/.github/workflows/interop-isolation.yml
@@ -13,6 +13,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,6 +18,10 @@ on:
       - "lakefile.lean"
       - "scripts/nolints-style.txt"
       - ".github/workflows/linting.yml"
+  # Merge-queue refs must run independently of PR path filters: the group can
+  # contain changes from several pull requests.
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

- run build, lint, agent-doc, and interop checks for GitHub merge-queue groups
- keep pull-request-only timing and comment steps guarded
- run merge-group linting without PR path filters because a group can contain multiple pull requests

## Validation

- `python3 scripts/check-agent-docs.py`
- `python3 scripts/extract-doc-fragments.py --check`
- `bash scripts/check-interop-isolation.sh`
- `bash scripts/check-extern-isolation.sh`
- workflow YAML parse
- `git diff --check`

This bootstraps merge-queue support; the queue rule will be enabled only after this PR lands.