### PR TITLE
feat(SignatureAlg): add generic strong-unforgeability games

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,6 +12,7 @@ on:
       - "VCVioTest/SMDTDSPR.lean"
       - "VCVioTest/SMDTOpenPRE.lean"
       - "VCVioTest/SMDTUDC.lean"
+      - "VCVioTest/CryptoFoundations/SignatureAlg.lean"
       - "Extern/**/*.lean"
       - "LatticeCrypto/**/*.lean"
       - "HashSig.lean"
@@ -39,6 +40,7 @@ on:
       - "VCVioTest/SMDTDSPR.lean"
       - "VCVioTest/SMDTOpenPRE.lean"
       - "VCVioTest/SMDTUDC.lean"
+      - "VCVioTest/CryptoFoundations/SignatureAlg.lean"
       - "Extern/**/*.lean"
       - "LatticeCrypto/**/*.lean"
       - "HashSig.lean"
@@ -104,6 +106,7 @@ jobs:
           lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets
           Interop VCVioTest.SMDTPREFinalValidity VCVioTest.SMDTTCRFinalValidity
           VCVioTest.ITSR VCVioTest.SMDTDSPR VCVioTest.SMDTOpenPRE VCVioTest.SMDTUDC
+          VCVioTest.CryptoFoundations.SignatureAlg
           HashSigTest.SLHDSA.Params HashSigTest.SLHDSA.Position HashSigTest.SLHDSA.Oracle
           HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors
           HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Scheme HashSigTest.SLHDSA.Sha2KAT

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -309,17 +309,15 @@ but its final pair is fresh when that exact `(message, signature)` pair was neve
 structure strongUnforgeableAdv (_sigAlg : SignatureAlg (OracleComp spec) M PK SK S) where
   main (pk : PK) : OracleComp (spec + (M →ₒ S)) (M × S)
 
-/-- Strong unforgeability under chosen-message attack. The signing oracle logs every successful
-returned `(message, signature)` pair. The adversary succeeds exactly when its final pair verifies
-and that pair does not occur in the returned-pair log. In particular, a different valid signature
-for a previously signed message remains an eligible strong forgery. -/
-noncomputable def strongUnforgeableExp
+/-- The computation underlying strong unforgeability under chosen-message attack. The signing
+oracle logs every successful returned `(message, signature)` pair. The adversary succeeds exactly
+when its final pair verifies and that pair does not occur in the returned-pair log. -/
+noncomputable def strongUnforgeableGame
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
-    (runtime : ProbCompRuntime (OracleComp spec))
-    (adv : strongUnforgeableAdv sigAlg) :=
+    (adv : strongUnforgeableAdv sigAlg) : OracleComp spec Bool :=
   letI : DecidableEq M := Classical.decEq M
   letI : DecidableEq S := Classical.decEq S
-  runtime.evalSPMF do
+  do
     let (pk, sk) ← sigAlg.keygen
     let impl : QueryImpl (spec + (M →ₒ S))
         (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
@@ -332,13 +330,32 @@ noncomputable def strongUnforgeableExp
     let verified ← sigAlg.verify pk msg σ
     return !signingLogContains log msg σ && verified
 
+/-- The canonical measure-valued SUF-CMA experiment. The explicit `SPMF.toMeasure` application
+is the compatibility boundary from the runtime's finite evaluator to VCVio's primary measure API. -/
+noncomputable def strongUnforgeableExp
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) : MeasureTheory.Measure Bool :=
+  (runtime.evalSPMF (strongUnforgeableGame adv)).toMeasure
+
+omit [DecidableEq M] [DecidableEq S] in
+/-- On a singleton event, the measure-valued SUF experiment agrees with the legacy executable
+point-probability reading. -/
+lemma strongUnforgeableExp_apply_singleton
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec)) (adv : strongUnforgeableAdv sigAlg) (b : Bool) :
+    strongUnforgeableExp runtime adv {b} =
+      Pr[= b | runtime.evalSPMF (strongUnforgeableGame adv)] := by
+  rw [strongUnforgeableExp, SPMF.toMeasure_apply_singleton]
+  rfl
+
 /-- The SUF-CMA success probability: the probability of outputting a valid pair not previously
 returned by the signing oracle. -/
 noncomputable def strongUnforgeableAdv.advantage
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec))
     (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
-  Pr[= true | strongUnforgeableExp runtime adv]
+  strongUnforgeableExp runtime adv {true}
 
 /-- Forget pair freshness and regard a strong-unforgeability adversary as an ordinary
 EUF-CMA adversary.  The oracle interface and adversary program are unchanged. -/
@@ -347,17 +364,16 @@ def strongUnforgeableAdv.toUnforgeableAdv
     (adv : strongUnforgeableAdv sigAlg) : unforgeableAdv sigAlg where
   main := adv.main
 
-/-- The extra event separating SUF-CMA from EUF-CMA: the adversary returns a valid, new
-signature for a message that it did submit to the signing oracle.  This event is intentionally
-defined without assigning it to a cryptographic assumption; doing so is scheme-specific (for
-example, it may require signature binding or a rerandomization argument). -/
-noncomputable def sameMessageStrongUnforgeableExp
+/-- The computation for the extra event separating SUF-CMA from EUF-CMA: the adversary returns a
+valid, new signature for a message that it did submit to the signing oracle. This event is
+intentionally defined without assigning it to a cryptographic assumption; doing so is
+scheme-specific (for example, it may require signature binding or a rerandomization argument). -/
+noncomputable def sameMessageStrongUnforgeableGame
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
-    (runtime : ProbCompRuntime (OracleComp spec))
-    (adv : strongUnforgeableAdv sigAlg) :=
+    (adv : strongUnforgeableAdv sigAlg) : OracleComp spec Bool :=
   letI : DecidableEq M := Classical.decEq M
   letI : DecidableEq S := Classical.decEq S
-  runtime.evalSPMF do
+  do
     let (pk, sk) ← sigAlg.keygen
     let impl : QueryImpl (spec + (M →ₒ S))
         (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
@@ -370,13 +386,31 @@ noncomputable def sameMessageStrongUnforgeableExp
     let verified ← sigAlg.verify pk msg σ
     return log.wasQueried msg && !signingLogContains log msg σ && verified
 
+/-- The canonical measure-valued same-message, new-signature experiment. -/
+noncomputable def sameMessageStrongUnforgeableExp
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) : MeasureTheory.Measure Bool :=
+  (runtime.evalSPMF (sameMessageStrongUnforgeableGame adv)).toMeasure
+
+omit [DecidableEq M] [DecidableEq S] in
+/-- On a singleton event, the measure-valued same-message experiment agrees with the legacy
+executable point-probability reading. -/
+lemma sameMessageStrongUnforgeableExp_apply_singleton
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec)) (adv : strongUnforgeableAdv sigAlg) (b : Bool) :
+    sameMessageStrongUnforgeableExp runtime adv {b} =
+      Pr[= b | runtime.evalSPMF (sameMessageStrongUnforgeableGame adv)] := by
+  rw [sameMessageStrongUnforgeableExp, SPMF.toMeasure_apply_singleton]
+  rfl
+
 /-- Probability of the same-message, new-signature event in the strong-unforgeability
 experiment. -/
 noncomputable def strongUnforgeableAdv.sameMessageAdvantage
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec))
     (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
-  Pr[= true | sameMessageStrongUnforgeableExp runtime adv]
+  sameMessageStrongUnforgeableExp runtime adv {true}
 
 /-- Quantitative scheme property needed in addition to EUF-CMA for strong unforgeability: every
 adversary has at most `ε` probability of returning a new valid signature for a message previously
@@ -403,9 +437,10 @@ lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
       adv.toUnforgeableAdv.advantage runtime + adv.sameMessageAdvantage runtime := by
   let : DecidableEq M := Classical.decEq M
   let : DecidableEq S := Classical.decEq S
-  unfold strongUnforgeableAdv.advantage strongUnforgeableExp
+  unfold strongUnforgeableAdv.advantage strongUnforgeableExp strongUnforgeableGame
     unforgeableAdv.advantage unforgeableExp
     strongUnforgeableAdv.sameMessageAdvantage sameMessageStrongUnforgeableExp
+    sameMessageStrongUnforgeableGame
   set joint : OracleComp spec (M × S × QueryLog (M →ₒ S) × Bool) := do
     let (pk, sk) ← sigAlg.keygen
     let impl : QueryImpl (spec + (M →ₒ S))
@@ -470,7 +505,16 @@ lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
     rw [← h_pull]
     congr 1
     simp only [hjoint_def, monad_norm]
-  rw [hSuf, hEuf, hSame, ← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput,
+  rw [hSuf, hEuf, hSame, SPMF.toMeasure_apply_singleton,
+    SPMF.toMeasure_apply_singleton]
+  change Pr[= true | (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+      !signingLogContains t.2.2.1 t.1 t.2.1 && t.2.2.2) <$> runtime.evalSPMF joint] ≤
+    Pr[= true | (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+      !t.2.2.1.wasQueried t.1 && t.2.2.2) <$> runtime.evalSPMF joint] +
+    Pr[= true | (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+      t.2.2.1.wasQueried t.1 && !signingLogContains t.2.2.1 t.1 t.2.1 && t.2.2.2) <$>
+        runtime.evalSPMF joint]
+  rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput,
     ← probEvent_eq_eq_probOutput, probEvent_map, probEvent_map, probEvent_map]
   exact (probEvent_mono'' fun t h => by
     by_cases hm : t.2.2.1.wasQueried t.1 = true <;> simp_all).trans

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -340,6 +340,135 @@ noncomputable def strongUnforgeableAdv.advantage
     (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
   Pr[= true | strongUnforgeableExp runtime adv]
 
+/-- Forget pair freshness and regard a strong-unforgeability adversary as an ordinary
+EUF-CMA adversary.  The oracle interface and adversary program are unchanged. -/
+def strongUnforgeableAdv.toUnforgeableAdv
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (adv : strongUnforgeableAdv sigAlg) : unforgeableAdv sigAlg where
+  main := adv.main
+
+/-- The extra event separating SUF-CMA from EUF-CMA: the adversary returns a valid, new
+signature for a message that it did submit to the signing oracle.  This event is intentionally
+defined without assigning it to a cryptographic assumption; doing so is scheme-specific (for
+example, it may require signature binding or a rerandomization argument). -/
+noncomputable def sameMessageStrongUnforgeableExp
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) : SPMF Bool :=
+  letI : DecidableEq M := Classical.decEq M
+  letI : DecidableEq S := Classical.decEq S
+  runtime.evalSPMF do
+    let (pk, sk) ← sigAlg.keygen
+    let impl : QueryImpl (spec + (M →ₒ S))
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+      (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+        sigAlg.signingOracle pk sk
+    let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+      simulateQ impl (adv.main pk)
+    let ((msg, σ), log) ← simAdv.run
+    let verified ← sigAlg.verify pk msg σ
+    return log.wasQueried msg && !signingLogContains log msg σ && verified
+
+/-- Probability of the same-message, new-signature event in the strong-unforgeability
+experiment. -/
+noncomputable def strongUnforgeableAdv.sameMessageAdvantage
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
+  Pr[= true | sameMessageStrongUnforgeableExp runtime adv]
+
+omit [DecidableEq M] [DecidableEq S] in
+/-- **Generic SUF-to-EUF partition.** Every strong forgery either uses a message never queried
+to the signing oracle (an ordinary EUF-CMA forgery) or is a new valid signature for a previously
+queried message.  Consequently SUF-CMA is EUF-CMA plus precisely the latter, scheme-specific
+same-message event.
+
+The `h_pull` hypothesis is the same runtime-factoring law used by the EUF freshness lemma above.
+It is satisfied by the standard state-oracle runtimes used by VCVio. -/
+lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h_pull : ∀ {α β : Type} (f : α → β) (mx : OracleComp spec α),
+      runtime.evalSPMF (mx >>= fun x => pure (f x)) = f <$> runtime.evalSPMF mx)
+    (adv : strongUnforgeableAdv sigAlg) :
+    adv.advantage runtime ≤
+      adv.toUnforgeableAdv.advantage runtime + adv.sameMessageAdvantage runtime := by
+  let : DecidableEq M := Classical.decEq M
+  let : DecidableEq S := Classical.decEq S
+  unfold strongUnforgeableAdv.advantage strongUnforgeableExp
+    unforgeableAdv.advantage unforgeableExp
+    strongUnforgeableAdv.sameMessageAdvantage sameMessageStrongUnforgeableExp
+  set joint : OracleComp spec (M × S × QueryLog (M →ₒ S) × Bool) := do
+    let (pk, sk) ← sigAlg.keygen
+    let impl : QueryImpl (spec + (M →ₒ S))
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+      (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+        sigAlg.signingOracle pk sk
+    let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+      simulateQ impl (adv.main pk)
+    let ((msg, σ), log) ← simAdv.run
+    let verified ← sigAlg.verify pk msg σ
+    pure (msg, σ, log, verified) with hjoint_def
+  have hSuf : (runtime.evalSPMF do
+        let (pk, sk) ← sigAlg.keygen
+        let impl : QueryImpl (spec + (M →ₒ S))
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+          (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+            sigAlg.signingOracle pk sk
+        let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+          simulateQ impl (adv.main pk)
+        let ((msg, σ), log) ← simAdv.run
+        let verified ← sigAlg.verify pk msg σ
+        pure (!signingLogContains log msg σ && verified)) =
+      (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+        !signingLogContains t.2.2.1 t.1 t.2.1 && t.2.2.2) <$> runtime.evalSPMF joint := by
+    rw [← h_pull]
+    congr 1
+    simp only [hjoint_def, monad_norm]
+  have hEuf : (runtime.evalSPMF do
+        let (pk, sk) ← sigAlg.keygen
+        let impl : QueryImpl (spec + (M →ₒ S))
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+          (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+            sigAlg.signingOracle pk sk
+        let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+          simulateQ impl (adv.toUnforgeableAdv.main pk)
+        let ((msg, σ), log) ← simAdv.run
+        let verified ← sigAlg.verify pk msg σ
+        pure (!log.wasQueried msg && verified)) =
+      (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+        !t.2.2.1.wasQueried t.1 && t.2.2.2) <$> runtime.evalSPMF joint := by
+    rw [← h_pull]
+    congr 1
+    simp only [strongUnforgeableAdv.toUnforgeableAdv, hjoint_def, monad_norm]
+  have hSame : (runtime.evalSPMF do
+        let (pk, sk) ← sigAlg.keygen
+        let impl : QueryImpl (spec + (M →ₒ S))
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+          (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+            (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+            sigAlg.signingOracle pk sk
+        let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+          simulateQ impl (adv.main pk)
+        let ((msg, σ), log) ← simAdv.run
+        let verified ← sigAlg.verify pk msg σ
+        pure (log.wasQueried msg && !signingLogContains log msg σ && verified)) =
+      (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
+        t.2.2.1.wasQueried t.1 &&
+          !signingLogContains t.2.2.1 t.1 t.2.1 && t.2.2.2) <$> runtime.evalSPMF joint := by
+    rw [← h_pull]
+    congr 1
+    simp only [hjoint_def, monad_norm]
+  rw [hSuf, hEuf, hSame, ← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput,
+    ← probEvent_eq_eq_probOutput, probEvent_map, probEvent_map, probEvent_map]
+  exact (probEvent_mono'' fun t h => by
+    by_cases hm : t.2.2.1.wasQueried t.1 = true <;> simp_all).trans
+      (probEvent_or_le (runtime.evalSPMF joint) _ _)
+
 end strongUnforgeable
 
 section eufNma

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -169,7 +169,7 @@ the adversary successfully forged a signature. The ambient oracle family is forw
 the signing oracle is logged, and the final check requires both signature validity and that the
 forged message was never submitted to the signing oracle. -/
 noncomputable def unforgeableExp {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
-    (runtime : ProbCompRuntime (OracleComp spec)) (adv : unforgeableAdv sigAlg) : SPMF Bool :=
+    (runtime : ProbCompRuntime (OracleComp spec)) (adv : unforgeableAdv sigAlg) :=
   letI : DecidableEq M := Classical.decEq M
   letI : DecidableEq S := Classical.decEq S
   runtime.evalSPMF do
@@ -199,7 +199,7 @@ signature; the bound `adv.advantage ≤ Pr[unforgeableExpNoFresh ⇒ true]` (see
 `unforgeableAdv.advantage_le_unforgeableExpNoFresh`) is the first game-hop
 in standard CMA-to-NMA reductions. -/
 noncomputable def unforgeableExpNoFresh {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
-    (runtime : ProbCompRuntime (OracleComp spec)) (adv : unforgeableAdv sigAlg) : SPMF Bool :=
+    (runtime : ProbCompRuntime (OracleComp spec)) (adv : unforgeableAdv sigAlg) :=
   letI : DecidableEq M := Classical.decEq M
   letI : DecidableEq S := Classical.decEq S
   runtime.evalSPMF do
@@ -303,6 +303,22 @@ lemma signingLogContains_singleton_self (msg : M) (σ : S) :
     signingLogContains ([⟨msg, σ⟩] : QueryLog (M →ₒ S)) msg σ = true := by
   simp [signingLogContains]
 
+/-- Exact returned-pair membership implies ordinary message membership in the same signing log. -/
+lemma wasQueried_eq_true_of_signingLogContains_eq_true
+    (log : QueryLog (M →ₒ S)) (msg : M) (σ : S)
+    (h : signingLogContains log msg σ = true) : log.wasQueried msg = true := by
+  rw [QueryLog.wasQueried_eq_decide_mem_map_fst, decide_eq_true_eq]
+  rw [signingLogContains, decide_eq_true_eq] at h
+  exact List.mem_map.mpr ⟨⟨msg, σ⟩, h, rfl⟩
+
+omit [DecidableEq M] [DecidableEq S] in
+/-- The runtime's compatibility measure agrees with its executable point probability on a
+singleton. This is the local bridge used by the measure-valued security experiments below. -/
+private lemma compatibilityMeasure_apply_singleton
+    (dist : SPMF Bool) (b : Bool) : dist.toMeasure {b} = Pr[= b | dist] := by
+  rw [SPMF.toMeasure_apply_singleton]
+  rfl
+
 /-- A SUF-CMA (strong unforgeability under chosen-message attack) adversary. As in EUF-CMA it
 receives the public key and has access to the scheme's ambient oracles plus the signing oracle,
 but its final pair is fresh when that exact `(message, signature)` pair was never returned. -/
@@ -339,15 +355,15 @@ noncomputable def strongUnforgeableExp
   (runtime.evalSPMF (strongUnforgeableGame adv)).toMeasure
 
 omit [DecidableEq M] [DecidableEq S] in
-/-- On a singleton event, the measure-valued SUF experiment agrees with the legacy executable
+/-- On a singleton event, the measure-valued SUF experiment agrees with the executable
 point-probability reading. -/
 lemma strongUnforgeableExp_apply_singleton
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec)) (adv : strongUnforgeableAdv sigAlg) (b : Bool) :
     strongUnforgeableExp runtime adv {b} =
       Pr[= b | runtime.evalSPMF (strongUnforgeableGame adv)] := by
-  rw [strongUnforgeableExp, SPMF.toMeasure_apply_singleton]
-  rfl
+  exact compatibilityMeasure_apply_singleton
+    (runtime.evalSPMF (strongUnforgeableGame adv)) b
 
 /-- The SUF-CMA success probability: the probability of outputting a valid pair not previously
 returned by the signing oracle. -/
@@ -394,15 +410,15 @@ noncomputable def sameMessageStrongUnforgeableExp
   (runtime.evalSPMF (sameMessageStrongUnforgeableGame adv)).toMeasure
 
 omit [DecidableEq M] [DecidableEq S] in
-/-- On a singleton event, the measure-valued same-message experiment agrees with the legacy
+/-- On a singleton event, the measure-valued same-message experiment agrees with the
 executable point-probability reading. -/
 lemma sameMessageStrongUnforgeableExp_apply_singleton
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec)) (adv : strongUnforgeableAdv sigAlg) (b : Bool) :
     sameMessageStrongUnforgeableExp runtime adv {b} =
       Pr[= b | runtime.evalSPMF (sameMessageStrongUnforgeableGame adv)] := by
-  rw [sameMessageStrongUnforgeableExp, SPMF.toMeasure_apply_singleton]
-  rfl
+  exact compatibilityMeasure_apply_singleton
+    (runtime.evalSPMF (sameMessageStrongUnforgeableGame adv)) b
 
 /-- Probability of the same-message, new-signature event in the strong-unforgeability
 experiment. -/
@@ -420,20 +436,20 @@ def SameMessageBinding (sigAlg : SignatureAlg (OracleComp spec) M PK SK S)
   ∀ adv : strongUnforgeableAdv sigAlg, adv.sameMessageAdvantage runtime ≤ ε
 
 omit [DecidableEq M] [DecidableEq S] in
-/-- **Generic SUF-to-EUF partition.** Every strong forgery either uses a message never queried
+/-- **Exact generic SUF-to-EUF partition.** Every strong forgery either uses a message never queried
 to the signing oracle (an ordinary EUF-CMA forgery) or is a new valid signature for a previously
-queried message.  Consequently SUF-CMA is EUF-CMA plus precisely the latter, scheme-specific
-same-message event.
+queried message. These events are disjoint and exhaustive inside the exact-pair-fresh success
+event, so SUF-CMA equals EUF-CMA plus precisely the latter, scheme-specific same-message event.
 
 The `h_pull` hypothesis is the same runtime-factoring law used by the EUF freshness lemma above.
 It is satisfied by the standard state-oracle runtimes used by VCVio. -/
-lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
+lemma strongUnforgeableAdv.advantage_eq_euf_add_sameMessage
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec))
     (h_pull : ∀ {α β : Type} (f : α → β) (mx : OracleComp spec α),
       runtime.evalSPMF (mx >>= fun x => pure (f x)) = f <$> runtime.evalSPMF mx)
     (adv : strongUnforgeableAdv sigAlg) :
-    adv.advantage runtime ≤
+    adv.advantage runtime =
       adv.toUnforgeableAdv.advantage runtime + adv.sameMessageAdvantage runtime := by
   let : DecidableEq M := Classical.decEq M
   let : DecidableEq S := Classical.decEq S
@@ -505,10 +521,10 @@ lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
     rw [← h_pull]
     congr 1
     simp only [hjoint_def, monad_norm]
-  rw [hSuf, hEuf, hSame, SPMF.toMeasure_apply_singleton,
-    SPMF.toMeasure_apply_singleton]
+  rw [hSuf, hEuf, hSame, compatibilityMeasure_apply_singleton,
+    compatibilityMeasure_apply_singleton]
   change Pr[= true | (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
-      !signingLogContains t.2.2.1 t.1 t.2.1 && t.2.2.2) <$> runtime.evalSPMF joint] ≤
+      !signingLogContains t.2.2.1 t.1 t.2.1 && t.2.2.2) <$> runtime.evalSPMF joint] =
     Pr[= true | (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
       !t.2.2.1.wasQueried t.1 && t.2.2.2) <$> runtime.evalSPMF joint] +
     Pr[= true | (fun t : M × S × QueryLog (M →ₒ S) × Bool =>
@@ -516,9 +532,27 @@ lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
         runtime.evalSPMF joint]
   rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput,
     ← probEvent_eq_eq_probOutput, probEvent_map, probEvent_map, probEvent_map]
-  exact (probEvent_mono'' fun t h => by
-    by_cases hm : t.2.2.1.wasQueried t.1 = true <;> simp_all).trans
-      (probEvent_or_le (runtime.evalSPMF joint) _ _)
+  simp only [probEvent_eq_tsum_ite, ← ENNReal.tsum_add]
+  refine tsum_congr fun t => ?_
+  by_cases hm : t.2.2.1.wasQueried t.1 = true
+  · cases hp : signingLogContains t.2.2.1 t.1 t.2.1 <;>
+      cases hv : t.2.2.2 <;> simp_all
+  · cases hp : signingLogContains t.2.2.1 t.1 t.2.1
+    · cases hv : t.2.2.2 <;> simp_all
+    · exact (hm (wasQueried_eq_true_of_signingLogContains_eq_true
+        t.2.2.1 t.1 t.2.1 hp)).elim
+
+omit [DecidableEq M] [DecidableEq S] in
+/-- Convenient inequality corollary of the exact SUF-to-EUF partition. -/
+lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h_pull : ∀ {α β : Type} (f : α → β) (mx : OracleComp spec α),
+      runtime.evalSPMF (mx >>= fun x => pure (f x)) = f <$> runtime.evalSPMF mx)
+    (adv : strongUnforgeableAdv sigAlg) :
+    adv.advantage runtime ≤
+      adv.toUnforgeableAdv.advantage runtime + adv.sameMessageAdvantage runtime :=
+  (adv.advantage_eq_euf_add_sameMessage runtime h_pull).le
 
 omit [DecidableEq M] [DecidableEq S] in
 /-- SUF-CMA from EUF-CMA plus a quantitative same-message binding property. -/
@@ -529,9 +563,9 @@ lemma strongUnforgeableAdv.advantage_le_euf_add_of_sameMessageBinding
       runtime.evalSPMF (mx >>= fun x => pure (f x)) = f <$> runtime.evalSPMF mx)
     {ε : ℝ≥0∞} (hbinding : sigAlg.SameMessageBinding runtime ε)
     (adv : strongUnforgeableAdv sigAlg) :
-    adv.advantage runtime ≤ adv.toUnforgeableAdv.advantage runtime + ε :=
-  (adv.advantage_le_euf_add_sameMessage runtime h_pull).trans
-    (add_le_add le_rfl (hbinding adv))
+    adv.advantage runtime ≤ adv.toUnforgeableAdv.advantage runtime + ε := by
+  rw [adv.advantage_eq_euf_add_sameMessage runtime h_pull]
+  exact add_le_add le_rfl (hbinding adv)
 
 end strongUnforgeable
 
@@ -551,7 +585,7 @@ structure eufNmaAdv (_sigAlg : SignatureAlg (OracleComp spec) M PK SK S) where
 /-- The EUF-NMA experiment: generate a key pair, give the public key to the adversary
 (with no signing oracle), and check whether the adversary produced a valid forgery. -/
 def eufNmaExp {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
-    (runtime : ProbCompRuntime (OracleComp spec)) (adv : eufNmaAdv sigAlg) : SPMF Bool :=
+    (runtime : ProbCompRuntime (OracleComp spec)) (adv : eufNmaAdv sigAlg) :=
   runtime.evalSPMF do
     let (pk, _) ← sigAlg.keygen
     let (msg, σ) ← adv.main pk
@@ -584,7 +618,7 @@ structure managedRoNmaAdv (sigAlg : SignatureAlg (OracleComp spec) M PK SK S) wh
 and a `QueryCache`, then verify the forgery through `withCacheOverlay` so that programmed
 entries take priority over the real oracle. -/
 def managedRoNmaExp {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
-    (runtime : ProbCompRuntime (OracleComp spec)) (adv : managedRoNmaAdv sigAlg) : SPMF Bool :=
+    (runtime : ProbCompRuntime (OracleComp spec)) (adv : managedRoNmaAdv sigAlg) :=
   runtime.evalSPMF do
     let (pk, _) ← sigAlg.keygen
     let ((msg, σ), cache) ← adv.main pk

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -354,7 +354,7 @@ example, it may require signature binding or a rerandomization argument). -/
 noncomputable def sameMessageStrongUnforgeableExp
     {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec))
-    (adv : strongUnforgeableAdv sigAlg) : SPMF Bool :=
+    (adv : strongUnforgeableAdv sigAlg) :=
   letI : DecidableEq M := Classical.decEq M
   letI : DecidableEq S := Classical.decEq S
   runtime.evalSPMF do

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -378,6 +378,13 @@ noncomputable def strongUnforgeableAdv.sameMessageAdvantage
     (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
   Pr[= true | sameMessageStrongUnforgeableExp runtime adv]
 
+/-- Quantitative scheme property needed in addition to EUF-CMA for strong unforgeability: every
+adversary has at most `ε` probability of returning a new valid signature for a message previously
+submitted to the signing oracle. -/
+def SameMessageBinding (sigAlg : SignatureAlg (OracleComp spec) M PK SK S)
+    (runtime : ProbCompRuntime (OracleComp spec)) (ε : ℝ≥0∞) : Prop :=
+  ∀ adv : strongUnforgeableAdv sigAlg, adv.sameMessageAdvantage runtime ≤ ε
+
 omit [DecidableEq M] [DecidableEq S] in
 /-- **Generic SUF-to-EUF partition.** Every strong forgery either uses a message never queried
 to the signing oracle (an ordinary EUF-CMA forgery) or is a new valid signature for a previously
@@ -468,6 +475,19 @@ lemma strongUnforgeableAdv.advantage_le_euf_add_sameMessage
   exact (probEvent_mono'' fun t h => by
     by_cases hm : t.2.2.1.wasQueried t.1 = true <;> simp_all).trans
       (probEvent_or_le (runtime.evalSPMF joint) _ _)
+
+omit [DecidableEq M] [DecidableEq S] in
+/-- SUF-CMA from EUF-CMA plus a quantitative same-message binding property. -/
+lemma strongUnforgeableAdv.advantage_le_euf_add_of_sameMessageBinding
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h_pull : ∀ {α β : Type} (f : α → β) (mx : OracleComp spec α),
+      runtime.evalSPMF (mx >>= fun x => pure (f x)) = f <$> runtime.evalSPMF mx)
+    {ε : ℝ≥0∞} (hbinding : sigAlg.SameMessageBinding runtime ε)
+    (adv : strongUnforgeableAdv sigAlg) :
+    adv.advantage runtime ≤ adv.toUnforgeableAdv.advantage runtime + ε :=
+  (adv.advantage_le_euf_add_sameMessage runtime h_pull).trans
+    (add_le_add le_rfl (hbinding adv))
 
 end strongUnforgeable
 

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -27,8 +27,9 @@ and signature space `S`.
 * `SignatureAlg`: a signature scheme as a `keygen`/`sign`/`verify` triple in a monad `m`.
 * `SignatureAlg.Complete`: completeness up to an error `δ`, with `PerfectlyComplete` the `δ = 0`
   case.
-* `SignatureAlg.unforgeableExp`, `eufNmaExp`, `managedRoNmaExp`: the EUF-CMA, EUF-NMA, and
-  managed-random-oracle NMA security experiments, with the corresponding adversary advantages.
+* `SignatureAlg.unforgeableExp`, `strongUnforgeableExp`, `eufNmaExp`, `managedRoNmaExp`: the
+  EUF-CMA, SUF-CMA, EUF-NMA, and managed-random-oracle NMA security experiments, with the
+  corresponding adversary advantages.
 -/
 
 @[expose] public section
@@ -55,9 +56,9 @@ variable {m : Type → Type v} [Monad m] {M PK SK S : Type}
 /-- The signing oracle for `sigAlg` under public key `pk` and secret key `sk`: the
 `QueryImpl` that answers each queried message by running `sigAlg.sign pk sk` on it.
 
-Every produced signature is recorded in a `WriterT (QueryLog (M →ₒ S))` writer layer, so an
-experiment running an adversary against this oracle can later read off which messages were
-signed and check the freshness of a forged message. -/
+Every successful response is recorded as its exact `(message, signature)` pair in a
+`WriterT (QueryLog (M →ₒ S))` writer layer. EUF-CMA projects this trace to queried messages;
+SUF-CMA checks whether the exact final pair occurs in it. -/
 def signingOracle (sigAlg : SignatureAlg m M PK SK S) (pk : PK) (sk : SK) :
     QueryImpl (M →ₒ S) (WriterT (QueryLog (M →ₒ S)) m) :=
   QueryImpl.withLogging (sigAlg.sign pk sk)
@@ -281,6 +282,65 @@ lemma unforgeableAdv.advantage_le_unforgeableExpNoFresh
   exact probEvent_mono fun _ _ => Bool.and_elim_right
 
 end unforgeable
+
+section strongUnforgeable
+
+variable {ι : Type u} {spec : OracleSpec ι} {M PK SK S : Type}
+  [DecidableEq M] [DecidableEq S]
+
+/-- Whether the signing-oracle trace contains the exact returned pair `(msg, σ)`. Unlike
+`QueryLog.wasQueried`, this predicate distinguishes two signatures returned for the same message. -/
+def signingLogContains (log : QueryLog (M →ₒ S)) (msg : M) (σ : S) : Bool :=
+  decide (⟨msg, σ⟩ ∈ log)
+
+@[simp]
+lemma signingLogContains_nil (msg : M) (σ : S) :
+    signingLogContains ([] : QueryLog (M →ₒ S)) msg σ = false := by
+  simp [signingLogContains]
+
+@[simp]
+lemma signingLogContains_singleton_self (msg : M) (σ : S) :
+    signingLogContains ([⟨msg, σ⟩] : QueryLog (M →ₒ S)) msg σ = true := by
+  simp [signingLogContains]
+
+/-- A SUF-CMA (strong unforgeability under chosen-message attack) adversary. As in EUF-CMA it
+receives the public key and has access to the scheme's ambient oracles plus the signing oracle,
+but its final pair is fresh when that exact `(message, signature)` pair was never returned. -/
+structure strongUnforgeableAdv (_sigAlg : SignatureAlg (OracleComp spec) M PK SK S) where
+  main (pk : PK) : OracleComp (spec + (M →ₒ S)) (M × S)
+
+/-- Strong unforgeability under chosen-message attack. The signing oracle logs every successful
+returned `(message, signature)` pair. The adversary succeeds exactly when its final pair verifies
+and that pair does not occur in the returned-pair log. In particular, a different valid signature
+for a previously signed message remains an eligible strong forgery. -/
+noncomputable def strongUnforgeableExp
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) :=
+  letI : DecidableEq M := Classical.decEq M
+  letI : DecidableEq S := Classical.decEq S
+  runtime.evalSPMF do
+    let (pk, sk) ← sigAlg.keygen
+    let impl : QueryImpl (spec + (M →ₒ S))
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
+      (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
+        (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
+        sigAlg.signingOracle pk sk
+    let simAdv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=
+      simulateQ impl (adv.main pk)
+    let ((msg, σ), log) ← simAdv.run
+    let verified ← sigAlg.verify pk msg σ
+    return !signingLogContains log msg σ && verified
+
+/-- The SUF-CMA success probability: the probability of outputting a valid pair not previously
+returned by the signing oracle. -/
+noncomputable def strongUnforgeableAdv.advantage
+    {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (adv : strongUnforgeableAdv sigAlg) : ℝ≥0∞ :=
+  Pr[= true | strongUnforgeableExp runtime adv]
+
+end strongUnforgeable
 
 section eufNma
 

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -312,7 +312,7 @@ lemma wasQueried_eq_true_of_signingLogContains_eq_true
   exact List.mem_map.mpr ⟨⟨msg, σ⟩, h, rfl⟩
 
 omit [DecidableEq M] [DecidableEq S] in
-/-- The runtime's compatibility measure agrees with its executable point probability on a
+/-- An `SPMF`'s compatibility measure agrees with its executable point probability on a
 singleton. This is the local bridge used by the measure-valued security experiments below. -/
 private lemma compatibilityMeasure_apply_singleton
     (dist : SPMF Bool) (b : Bool) : dist.toMeasure {b} = Pr[= b | dist] := by
@@ -430,7 +430,15 @@ noncomputable def strongUnforgeableAdv.sameMessageAdvantage
 
 /-- Quantitative scheme property needed in addition to EUF-CMA for strong unforgeability: every
 adversary has at most `ε` probability of returning a new valid signature for a message previously
-submitted to the signing oracle. -/
+submitted to the signing oracle.
+
+This quantifies over *all* adversaries with no query or time bound, so it is an
+information-theoretic property. It is satisfiable with small `ε` only for schemes whose valid
+signatures are (statistically close to) unique per message, such as unique-signature schemes.
+For schemes where an unbounded adversary can find a second valid signature — hash-based schemes
+like SLH-DSA included — no `ε < 1` can hold, and quantitative results should instead consume the
+per-adversary partition `strongUnforgeableAdv.advantage_eq_euf_add_sameMessage` directly,
+bounding the same-message term for the specific reduction adversary at hand. -/
 def SameMessageBinding (sigAlg : SignatureAlg (OracleComp spec) M PK SK S)
     (runtime : ProbCompRuntime (OracleComp spec)) (ε : ℝ≥0∞) : Prop :=
   ∀ adv : strongUnforgeableAdv sigAlg, adv.sameMessageAdvantage runtime ≤ ε

--- a/VCVio/OracleComp/ProbCompLift.lean
+++ b/VCVio/OracleComp/ProbCompLift.lean
@@ -8,6 +8,7 @@ module
 public import VCVio.OracleComp.ProbComp
 public import VCVio.EvalDist.Defs.Semantics
 public import PolyFun.Control.Monad.Hom
+import VCVio.EvalDist.Monad.Map
 
 /-!
 # Bundled Lifts from `ProbComp`
@@ -86,5 +87,16 @@ def liftProbComp (runtime : ProbCompRuntime m) : ProbComp →ᵐ m :=
 noncomputable def probComp : ProbCompRuntime ProbComp where
   toSPMFSemantics := SPMFSemantics.ofMonadLift ProbComp
   toProbCompLift := ProbCompLift.id
+
+/-- The canonical `ProbComp` runtime satisfies the pure-return factoring law: `evalSPMF`
+commutes with binding a pure function. Security decompositions that couple several
+experiments through one joint execution (e.g. the exact SUF-CMA partition in
+`VCVio.CryptoFoundations.SignatureAlg`) take exactly this equation as their pull-through
+hypothesis, so consumers instantiating them at `ProbCompRuntime.probComp` can use this
+lemma directly. -/
+lemma probComp_evalSPMF_bind_pure {α β : Type} (f : α → β) (mx : ProbComp α) :
+    probComp.evalSPMF (mx >>= fun x => pure (f x)) = f <$> probComp.evalSPMF mx := by
+  change _root_.evalSPMF (mx >>= fun x => pure (f x)) = f <$> _root_.evalSPMF mx
+  rw [bind_pure_comp, evalSPMF_map]
 
 end ProbCompRuntime

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -5,6 +5,7 @@ public import VCVioTest.CryptoFoundations.ComplexityAdapters
 public import VCVioTest.CryptoFoundations.ComplexityTactics
 public import VCVioTest.CryptoFoundations.ComputationalComplexitySoundness
 public import VCVioTest.CryptoFoundations.OracleClosure
+public import VCVioTest.CryptoFoundations.SignatureAlg
 public import VCVioTest.CryptoFoundations.SymmEncAlgMeasure
 public import VCVioTest.ForkMeasure
 public import VCVioTest.Forking.WithoutReplacement

--- a/VCVioTest/CryptoFoundations/SignatureAlg.lean
+++ b/VCVioTest/CryptoFoundations/SignatureAlg.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.SignatureAlg
+
+/-!
+# Signature security-game canaries
+
+Executable symbolic canaries for the generic SUF-CMA endpoint. The toy scheme deliberately has
+two valid signatures for each message, while honest signing returns only one of them. This makes
+the distinction between message freshness and exact returned-pair freshness observable.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SignatureAlgTest
+
+/-- The toy signature records the message in its first bit and has an ignored rerandomization
+bit. Both values of the second bit verify. -/
+abbrev ToySignature := Bool × Bool
+
+/-- A deterministic scheme with two valid signatures per message. Honest signing uses
+rerandomization bit `false`. -/
+def twoSignatureAlg : SignatureAlg ProbComp Bool Unit Unit ToySignature where
+  keygen := pure ((), ())
+  sign _ _ msg := pure (msg, false)
+  verify _ msg σ := pure (σ.1 == msg)
+
+/-- Query one signature and replay the exact pair. -/
+def replayAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
+  main _ := do
+    let σ ← (unifSpec + (Bool →ₒ ToySignature)).query (Sum.inr false)
+    return (false, σ)
+
+/-- Query a signature, then flip its ignored rerandomization bit. -/
+def rerandomizeAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
+  main _ := do
+    let _ ← (unifSpec + (Bool →ₒ ToySignature)).query (Sum.inr false)
+    return (false, (false, true))
+
+/-- Forge directly on a fresh message without calling the signing oracle. -/
+def freshMessageAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
+  main _ := pure (true, (true, true))
+
+/-- Replaying an exact signing-oracle response loses SUF-CMA. -/
+example :
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp replayAdv = pure false := by
+  simp [SignatureAlg.strongUnforgeableExp, replayAdv, twoSignatureAlg,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- A different valid signature on an already queried message is an eligible strong forgery. -/
+example :
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp rerandomizeAdv = pure true := by
+  simp [SignatureAlg.strongUnforgeableExp, rerandomizeAdv, twoSignatureAlg,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- A valid signature on a fresh message wins exactly as in the ordinary unforgeability game. -/
+example :
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp freshMessageAdv = pure true := by
+  simp [SignatureAlg.strongUnforgeableExp, freshMessageAdv, twoSignatureAlg,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- The ENNReal advantage endpoint assigns zero to replay and one to the two valid fresh-pair
+forgeries in this deterministic scheme. -/
+example : replayAdv.advantage ProbCompRuntime.probComp = 0 ∧
+    rerandomizeAdv.advantage ProbCompRuntime.probComp = 1 ∧
+    freshMessageAdv.advantage ProbCompRuntime.probComp = 1 := by
+  simp [SignatureAlg.strongUnforgeableAdv.advantage,
+    SignatureAlg.strongUnforgeableExp, replayAdv, rerandomizeAdv, freshMessageAdv,
+    twoSignatureAlg, SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+end SignatureAlgTest

--- a/VCVioTest/CryptoFoundations/SignatureAlg.lean
+++ b/VCVioTest/CryptoFoundations/SignatureAlg.lean
@@ -79,4 +79,20 @@ example : replayAdv.advantage ProbCompRuntime.probComp = 0 ∧
     twoSignatureAlg, SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
+/-- The SUF partition is exact on the two qualitatively different forgery branches: rerandomizing
+an already signed message contributes only to the same-message term, while a fresh-message
+forgery contributes only to EUF. -/
+example :
+    rerandomizeAdv.toUnforgeableAdv.advantage ProbCompRuntime.probComp = 0 ∧
+      rerandomizeAdv.sameMessageAdvantage ProbCompRuntime.probComp = 1 ∧
+      freshMessageAdv.toUnforgeableAdv.advantage ProbCompRuntime.probComp = 1 ∧
+      freshMessageAdv.sameMessageAdvantage ProbCompRuntime.probComp = 0 := by
+  simp [SignatureAlg.unforgeableAdv.advantage, SignatureAlg.unforgeableExp,
+    SignatureAlg.strongUnforgeableAdv.sameMessageAdvantage,
+    SignatureAlg.sameMessageStrongUnforgeableExp,
+    SignatureAlg.strongUnforgeableAdv.toUnforgeableAdv,
+    rerandomizeAdv, freshMessageAdv, twoSignatureAlg, SignatureAlg.signingOracle,
+    SignatureAlg.signingLogContains, QueryLog.wasQueried,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
 end SignatureAlgTest

--- a/VCVioTest/CryptoFoundations/SignatureAlg.lean
+++ b/VCVioTest/CryptoFoundations/SignatureAlg.lean
@@ -142,21 +142,14 @@ example :
     SignatureAlg.signingLogContains, QueryLog.wasQueried,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
-/-- The canonical plain-probability runtime satisfies the pure-return factoring law required by
-the generic joint-execution partition. -/
-private lemma probComp_evalSPMF_bind_pure
-    {α β : Type} (f : α → β) (mx : ProbComp α) :
-    ProbCompRuntime.probComp.evalSPMF (mx >>= fun x => pure (f x)) =
-      f <$> ProbCompRuntime.probComp.evalSPMF mx := by
-  change evalSPMF (mx >>= fun x => pure (f x)) = f <$> evalSPMF mx
-  rw [bind_pure_comp, evalSPMF_map]
-
-/-- Direct executable-runtime consumer of the public exact SUF partition. -/
+/-- Direct executable-runtime consumer of the public exact SUF partition, discharging the
+pull-through hypothesis with the library-level `ProbCompRuntime.probComp_evalSPMF_bind_pure`. -/
 example (adv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg) :
     adv.advantage ProbCompRuntime.probComp =
       adv.toUnforgeableAdv.advantage ProbCompRuntime.probComp +
         adv.sameMessageAdvantage ProbCompRuntime.probComp :=
-  adv.advantage_eq_euf_add_sameMessage ProbCompRuntime.probComp probComp_evalSPMF_bind_pure
+  adv.advantage_eq_euf_add_sameMessage ProbCompRuntime.probComp
+    ProbCompRuntime.probComp_evalSPMF_bind_pure
 
 /-- The toy scheme satisfies the vacuous unit upper bound for the same-message residual. -/
 private lemma twoSignatureBinding :
@@ -172,6 +165,6 @@ example (adv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg) :
     adv.advantage ProbCompRuntime.probComp ≤
       adv.toUnforgeableAdv.advantage ProbCompRuntime.probComp + 1 :=
   adv.advantage_le_euf_add_of_sameMessageBinding ProbCompRuntime.probComp
-    probComp_evalSPMF_bind_pure twoSignatureBinding
+    ProbCompRuntime.probComp_evalSPMF_bind_pure twoSignatureBinding
 
 end SignatureAlgTest

--- a/VCVioTest/CryptoFoundations/SignatureAlg.lean
+++ b/VCVioTest/CryptoFoundations/SignatureAlg.lean
@@ -50,22 +50,25 @@ def freshMessageAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
 
 /-- Replaying an exact signing-oracle response loses SUF-CMA. -/
 example :
-    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp replayAdv = pure false := by
-  simp [SignatureAlg.strongUnforgeableExp, replayAdv, twoSignatureAlg,
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp replayAdv {true} = 0 := by
+  simp [SignatureAlg.strongUnforgeableExp, SignatureAlg.strongUnforgeableGame,
+    replayAdv, twoSignatureAlg,
     SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
 /-- A different valid signature on an already queried message is an eligible strong forgery. -/
 example :
-    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp rerandomizeAdv = pure true := by
-  simp [SignatureAlg.strongUnforgeableExp, rerandomizeAdv, twoSignatureAlg,
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp rerandomizeAdv {true} = 1 := by
+  simp [SignatureAlg.strongUnforgeableExp, SignatureAlg.strongUnforgeableGame,
+    rerandomizeAdv, twoSignatureAlg,
     SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
 /-- A valid signature on a fresh message wins exactly as in the ordinary unforgeability game. -/
 example :
-    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp freshMessageAdv = pure true := by
-  simp [SignatureAlg.strongUnforgeableExp, freshMessageAdv, twoSignatureAlg,
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp freshMessageAdv {true} = 1 := by
+  simp [SignatureAlg.strongUnforgeableExp, SignatureAlg.strongUnforgeableGame,
+    freshMessageAdv, twoSignatureAlg,
     SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
@@ -75,8 +78,20 @@ example : replayAdv.advantage ProbCompRuntime.probComp = 0 ∧
     rerandomizeAdv.advantage ProbCompRuntime.probComp = 1 ∧
     freshMessageAdv.advantage ProbCompRuntime.probComp = 1 := by
   simp [SignatureAlg.strongUnforgeableAdv.advantage,
-    SignatureAlg.strongUnforgeableExp, replayAdv, rerandomizeAdv, freshMessageAdv,
+    SignatureAlg.strongUnforgeableExp, SignatureAlg.strongUnforgeableGame,
+    replayAdv, rerandomizeAdv, freshMessageAdv,
     twoSignatureAlg, SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- Exact replay is excluded from the same-message residual as well as from SUF itself. This
+pins exact-pair freshness independently in the residual experiment and its advantage endpoint. -/
+example :
+    SignatureAlg.sameMessageStrongUnforgeableExp ProbCompRuntime.probComp replayAdv {true} = 0 ∧
+      replayAdv.sameMessageAdvantage ProbCompRuntime.probComp = 0 := by
+  simp [SignatureAlg.strongUnforgeableAdv.sameMessageAdvantage,
+    SignatureAlg.sameMessageStrongUnforgeableExp, replayAdv, twoSignatureAlg,
+    SignatureAlg.sameMessageStrongUnforgeableGame,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
 /-- The SUF partition is exact on the two qualitatively different forgery branches: rerandomizing
@@ -90,6 +105,7 @@ example :
   simp [SignatureAlg.unforgeableAdv.advantage, SignatureAlg.unforgeableExp,
     SignatureAlg.strongUnforgeableAdv.sameMessageAdvantage,
     SignatureAlg.sameMessageStrongUnforgeableExp,
+    SignatureAlg.sameMessageStrongUnforgeableGame,
     SignatureAlg.strongUnforgeableAdv.toUnforgeableAdv,
     rerandomizeAdv, freshMessageAdv, twoSignatureAlg, SignatureAlg.signingOracle,
     SignatureAlg.signingLogContains, QueryLog.wasQueried,

--- a/VCVioTest/CryptoFoundations/SignatureAlg.lean
+++ b/VCVioTest/CryptoFoundations/SignatureAlg.lean
@@ -48,6 +48,17 @@ def rerandomizeAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
 def freshMessageAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
   main _ := pure (true, (true, true))
 
+/-- Return a fresh-message pair whose signature encodes the wrong message. -/
+def invalidFreshMessageAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
+  main _ := pure (true, (false, true))
+
+/-- Query one message, then return a fresh pair for that message whose signature encodes the
+other message. This reaches the same-message branch but must still fail verification. -/
+def invalidSameMessageAdv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg where
+  main _ := do
+    let _ ← (unifSpec + (Bool →ₒ ToySignature)).query (Sum.inr false)
+    return (false, (true, true))
+
 /-- Replaying an exact signing-oracle response loses SUF-CMA. -/
 example :
     SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp replayAdv {true} = 0 := by
@@ -83,6 +94,15 @@ example : replayAdv.advantage ProbCompRuntime.probComp = 0 ∧
     twoSignatureAlg, SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
+/-- Exact-pair freshness alone is insufficient: an invalid fresh-message signature loses. -/
+example :
+    SignatureAlg.strongUnforgeableExp ProbCompRuntime.probComp
+        invalidFreshMessageAdv {true} = 0 := by
+  simp [SignatureAlg.strongUnforgeableExp, SignatureAlg.strongUnforgeableGame,
+    invalidFreshMessageAdv, twoSignatureAlg,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
 /-- Exact replay is excluded from the same-message residual as well as from SUF itself. This
 pins exact-pair freshness independently in the residual experiment and its advantage endpoint. -/
 example :
@@ -91,6 +111,17 @@ example :
   simp [SignatureAlg.strongUnforgeableAdv.sameMessageAdvantage,
     SignatureAlg.sameMessageStrongUnforgeableExp, replayAdv, twoSignatureAlg,
     SignatureAlg.sameMessageStrongUnforgeableGame,
+    SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
+    ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- The same-message residual requires verification: a new but invalid pair has probability
+zero even after the message was submitted to the signing oracle. -/
+example :
+    SignatureAlg.sameMessageStrongUnforgeableExp ProbCompRuntime.probComp
+        invalidSameMessageAdv {true} = 0 := by
+  simp [SignatureAlg.sameMessageStrongUnforgeableExp,
+    SignatureAlg.sameMessageStrongUnforgeableGame,
+    invalidSameMessageAdv, twoSignatureAlg,
     SignatureAlg.signingOracle, SignatureAlg.signingLogContains,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
 
@@ -110,5 +141,37 @@ example :
     rerandomizeAdv, freshMessageAdv, twoSignatureAlg, SignatureAlg.signingOracle,
     SignatureAlg.signingLogContains, QueryLog.wasQueried,
     ProbCompRuntime.evalSPMF, ProbCompRuntime.probComp]
+
+/-- The canonical plain-probability runtime satisfies the pure-return factoring law required by
+the generic joint-execution partition. -/
+private lemma probComp_evalSPMF_bind_pure
+    {α β : Type} (f : α → β) (mx : ProbComp α) :
+    ProbCompRuntime.probComp.evalSPMF (mx >>= fun x => pure (f x)) =
+      f <$> ProbCompRuntime.probComp.evalSPMF mx := by
+  change evalSPMF (mx >>= fun x => pure (f x)) = f <$> evalSPMF mx
+  rw [bind_pure_comp, evalSPMF_map]
+
+/-- Direct executable-runtime consumer of the public exact SUF partition. -/
+example (adv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg) :
+    adv.advantage ProbCompRuntime.probComp =
+      adv.toUnforgeableAdv.advantage ProbCompRuntime.probComp +
+        adv.sameMessageAdvantage ProbCompRuntime.probComp :=
+  adv.advantage_eq_euf_add_sameMessage ProbCompRuntime.probComp probComp_evalSPMF_bind_pure
+
+/-- The toy scheme satisfies the vacuous unit upper bound for the same-message residual. -/
+private lemma twoSignatureBinding :
+    twoSignatureAlg.SameMessageBinding ProbCompRuntime.probComp 1 := by
+  intro adv
+  unfold SignatureAlg.strongUnforgeableAdv.sameMessageAdvantage
+    SignatureAlg.sameMessageStrongUnforgeableExp
+  exact (MeasureTheory.measure_mono (Set.subset_univ {true})).trans
+    (SPMF.toMeasure_apply_univ_le_one _)
+
+/-- Direct consumer of the quantitative `SameMessageBinding` packaging. -/
+example (adv : SignatureAlg.strongUnforgeableAdv twoSignatureAlg) :
+    adv.advantage ProbCompRuntime.probComp ≤
+      adv.toUnforgeableAdv.advantage ProbCompRuntime.probComp + 1 :=
+  adv.advantage_le_euf_add_of_sameMessageBinding ProbCompRuntime.probComp
+    probComp_evalSPMF_bind_pure twoSignatureBinding
 
 end SignatureAlgTest

--- a/scripts/pmf_boundary_baseline.tsv
+++ b/scripts/pmf_boundary_baseline.tsv
@@ -39,7 +39,7 @@ VCVio/CryptoFoundations/KeyEncapMech.lean	3
 VCVio/CryptoFoundations/MacAlg.lean	1
 VCVio/CryptoFoundations/SecExp.lean	18
 VCVio/CryptoFoundations/SeededFork.lean	1
-VCVio/CryptoFoundations/SignatureAlg.lean	9
+VCVio/CryptoFoundations/SignatureAlg.lean	5
 VCVio/CryptoFoundations/SymmEncAlg.lean	13
 VCVio/CryptoFoundations/SymmEncAlg/MeasureCompatibility.lean	4
 VCVio/EvalDist/BitVec.lean	2

--- a/scripts/pmf_boundary_baseline.tsv
+++ b/scripts/pmf_boundary_baseline.tsv
@@ -39,7 +39,7 @@ VCVio/CryptoFoundations/KeyEncapMech.lean	3
 VCVio/CryptoFoundations/MacAlg.lean	1
 VCVio/CryptoFoundations/SecExp.lean	18
 VCVio/CryptoFoundations/SeededFork.lean	1
-VCVio/CryptoFoundations/SignatureAlg.lean	5
+VCVio/CryptoFoundations/SignatureAlg.lean	9
 VCVio/CryptoFoundations/SymmEncAlg.lean	13
 VCVio/CryptoFoundations/SymmEncAlg/MeasureCompatibility.lean	4
 VCVio/EvalDist/BitVec.lean	2


### PR DESCRIPTION
## Summary

This draft lands CF3 from the SLH-DSA FIPS 205 plan: a generic `SignatureAlg` strong-unforgeability surface with exact returned-pair freshness, measure-valued SUF-CMA and same-message experiments, and an exact quantitative partition

```text
SUF advantage = EUF advantage + same-message/new-signature advantage.
```

The implementation is scheme-independent. It contains no SLH-DSA target enumeration, construction code, or hash assumption.

Normative plan: [`docs/design/slh-dsa-fips205-generalization.md`](https://github.com/Verified-zkEVM/VCVio/blob/main/docs/design/slh-dsa-fips205-generalization.md).

### Exact diff metadata

- Base branch: `main`
- Base commit / merge-base: `c82bfa9fa9111d3eedb9db765bfda7da85f1b134`
- Head commit: `5939f893c08ecc90add4c798a71080dc4b2d0a0d`
- Commits: 8
- Files changed: 4
- Diff: 477 insertions, 9 deletions
- Status: draft; local exact-head gate passed, hosted checks pending

## Motivation

EUF-CMA excludes every forgery on a message previously sent to the signing oracle. SUF-CMA instead excludes only an exact `(message, signature)` pair returned by that oracle, so a different valid signature for a previously signed message is still a strong forgery.

This distinction is generic and belongs in `SignatureAlg`, below any SLH-DSA-specific security proof. Giving it one canonical owner API prevents downstream schemes from defining subtly different trace-freshness experiments and makes the residual security obligation explicit.

## Change overview

### Exact-pair trace freshness

`signingLogContains log msg σ` checks whether the dependent signing-oracle log contains the exact returned pair. The new provenance lemma proves that exact-pair membership implies ordinary queried-message membership.

### Canonical games and advantages

The PR adds:

- `strongUnforgeableAdv`;
- `strongUnforgeableGame` and the measure-valued `strongUnforgeableExp`;
- `sameMessageStrongUnforgeableGame` and its measure-valued experiment;
- ENNReal SUF and same-message advantages;
- `strongUnforgeableAdv.toUnforgeableAdv`; and
- `SameMessageBinding`, the generic quantitative package for the residual event.

The executable finite evaluator is confined to a local singleton-compatibility bridge. The public experiments remain measure-valued, and the explicit PMF/SPMF source surface in `SignatureAlg.lean` decreases from 5 occurrences to 3; the repository total decreases from 1,923 to 1,921.

### Exact partition theorem

`strongUnforgeableAdv.advantage_eq_euf_add_sameMessage` factors all three events through one joint key-generation/adversary/verification execution. It proves the new-message and same-message branches are disjoint and exhaustive inside exact-pair-fresh success. The inequality form remains available as a corollary, and `advantage_le_euf_add_of_sameMessageBinding` consumes the equality.

### Mutation-sensitive canaries

The toy scheme has two valid signatures per message, making the semantic branches observable:

| Adversary behavior | SUF | EUF | Same-message residual |
| --- | ---: | ---: | ---: |
| Replay exact oracle response | 0 | — | 0 |
| Rerandomize a valid signature on a queried message | 1 | 0 | 1 |
| Forge a valid signature on a fresh message | 1 | 1 | 0 |
| Return an invalid signature on a fresh message | 0 | — | — |
| Return a new but invalid signature on a queried message | — | — | 0 |

The test module also directly instantiates the public exact-partition theorem and `SameMessageBinding` wrapper with `ProbCompRuntime.probComp`.

## Donor and downstream relation

This is the clean CF3 owner slice reconstructed from the reviewed donor stack `7068fd993e35748822d07bba922fe70fe2953cd9..a68b161766edc94464d0c73b3a7eabd435e829df` after CF1 and CF2 were squash-merged. The donor's first six semantic patches are patch-identical; the final lint patch was rebuilt over the current `main` workflow entries, and this branch adds the exact partition and verification canaries requested by independent review.

Draft [#597](https://github.com/Verified-zkEVM/VCVio/pull/597) is a downstream SLH-DSA construction/security consumer. It does not modify `SignatureAlg`; after this generic owner API merges, #597 can consume these games and keep its scheme-specific SUF residual in `HashSig/SLHDSA`.

## API and trust impact

- Existing EUF-CMA game behavior is unchanged.
- Four existing compatibility-distribution return types are inferred rather than written explicitly; their elaborated types do not change.
- No `sorry`, `admit`, `stop`, `unsafe`, custom axiom, or `native_decide` is added.
- No imports from `Extern` or `Interop` enter proof/test libraries.
- No SLH-DSA, lattice, FFI, or concrete-hash source is modified.

## Validation

All commands below passed on exact head `5939f893c08ecc90add4c798a71080dc4b2d0a0d`:

- `lake build VCVio.CryptoFoundations.SignatureAlg VCVioTest.CryptoFoundations.SignatureAlg` (2,678 jobs);
- `./scripts/build-project.sh` (3,733 jobs plus repository lint);
- the exact `.github/workflows/linting.yml` lint target set, including `VCVioTest.CryptoFoundations.SignatureAlg`;
- `./scripts/test-axiomsweep.sh`;
- `lake exe axiomsweep --check` (15,865 declarations across 501 modules; no new axiom or `sorryAx` taint);
- `lake exe mk_all --lib VCVio --module --check`;
- `lake exe mk_all --lib VCVioTest --module --check`;
- `./scripts/update-lib.sh` (no update required);
- `./scripts/check-pmf-boundary.sh --ratchet c82bfa9fa9111d3eedb9db765bfda7da85f1b134` (per-file 5→3; repository 1,923→1,921);
- Interop, Extern, and optional-complexity-backend isolation checks;
- agent-documentation and generated-document-fragment checks;
- `git diff --check`; and
- changed-line trust-token and generic-owner isolation scans.

An independent Lean-formalization gate reviewed the exact local head and reported no findings. Any head, base, or diff mutation invalidates that gate.

## Explicit deferrals

This PR does not add:

- an SLH-DSA-specific same-message binding argument;
- SLH-DSA target enumeration or hash assumptions;
- construction-to-game program couplings or probability reductions;
- resource/query transformations for a concrete security theorem; or
- a general-`d` EUF-CMA or SUF-CMA theorem.

Those remain downstream responsibilities, including the scheme-specific work tracked in #597 and the later security slices in the FIPS 205 plan.

## Reviewer map

Suggested order:

1. `VCVio/CryptoFoundations/SignatureAlg.lean`: trace predicate, games, and measure endpoints;
2. the shared-joint-execution exact partition and its inequality/binding corollaries;
3. `VCVioTest/CryptoFoundations/SignatureAlg.lean`: replay, rerandomization, fresh-message, invalid-signature, and public-consumer canaries;
4. umbrella import and lint workflow registration.
