### PR TITLE
feat(SLHDSA): make signature shapes intrinsic

### DIFF
--- a/HashSig/SLHDSA/Concrete/Instance.lean
+++ b/HashSig/SLHDSA/Concrete/Instance.lean
@@ -124,28 +124,32 @@ def shaPrimitives : Primitives slhdsaSha2_128_24 where
   Hmsg := shaHmsg
   yToBytes := fun y => y
 
+/-- The supported reduced SHA2-128-24 compatibility profile has one hypertree layer. -/
+theorem shaParams_d_eq_one : slhdsaSha2_128_24.d = 1 := rfl
+
 /-! ### Fixed-width signature decoding (FIPS 205 Fig 17 wire format) -/
 
 /-- Decode the 3856-byte signature `R ‖ SIG_FORS ‖ SIG_HT` (FORS: `k` trees of
 `sk(16) ‖ auth(a×16)`; HT: WOTS `len×16` then XMSS auth `h'×16`). -/
 def decodeSignature (ba : ByteArray) : SignatureCore slhdsaSha2_128_24 shaPrimitives.core :=
   let R : Bytes 16 := baSliceToB16 ba 0
-  let fors : Vector (Bytes 16 × List (Bytes 16)) 6 :=
+  let fors : ForsSigCore slhdsaSha2_128_24 shaPrimitives.core :=
     Vector.ofFn fun i : Fin 6 =>
       let base := 16 + i.val * 400
-      (baSliceToB16 ba base,
-        (List.range 24).map fun j => baSliceToB16 ba (base + 16 + j * 16))
+      { sk := baSliceToB16 ba base
+        auth := Vector.ofFn fun j : Fin 24 => baSliceToB16 ba (base + 16 + j.val * 16) }
   let wots : Vector (Bytes 16) 68 :=
     Vector.ofFn fun i : Fin 68 => baSliceToB16 ba (2416 + i.val * 16)
-  let xmssAuth : List (Bytes 16) :=
-    (List.range 22).map fun j => baSliceToB16 ba (2416 + 1088 + j * 16)
-  (R, fors, (wots, xmssAuth))
+  let xmssAuth : Vector (Bytes 16) 22 :=
+    Vector.ofFn fun j : Fin 22 => baSliceToB16 ba (2416 + 1088 + j.val * 16)
+  let xmss : XmssSigCore slhdsaSha2_128_24 shaPrimitives.core := ⟨wots, xmssAuth⟩
+  ⟨R, fors, HtSigCore.singleLayer shaParams_d_eq_one xmss⟩
 
 /-- Concrete FIPS 205 external verification of a decoded signature against
 `(pkSeed, pkRoot, message)`. -/
 def verifyBytes (pkSeed pkRoot : Bytes 16) (msg : List Byte) (sigBytes : ByteArray) : Bool :=
   letI : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16))
-  slhVerifyInternal shaPrimitives (emptyContextMessage msg)
+  slhVerifyInternal shaParams_d_eq_one shaPrimitives (emptyContextMessage msg)
     (decodeSignature sigBytes) ⟨pkSeed, pkRoot⟩
 
 /-- Verification against the internal `M'` interface. This entry point supports reference vectors
@@ -154,7 +158,7 @@ context encoding a second time. -/
 def verifyInternalBytes (pkSeed pkRoot : Bytes 16) (msg : List Byte)
     (sigBytes : ByteArray) : Bool :=
   letI : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16))
-  slhVerifyInternal shaPrimitives msg (decodeSignature sigBytes) ⟨pkSeed, pkRoot⟩
+  slhVerifyInternal shaParams_d_eq_one shaPrimitives msg (decodeSignature sigBytes) ⟨pkSeed, pkRoot⟩
 
 /-! ### Completeness transfers to the concrete bundle
 
@@ -171,7 +175,8 @@ instance : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16
 definitional concrete-function interpretation of the canonical oracle-parametric scheme to the
 exact primitive bundle exercised by `verifyBytes`. -/
 theorem shaPrimitives_perfectlyComplete :
-    (slhdsaConcreteAlg shaPrimitives).PerfectlyComplete ProbCompRuntime.probComp :=
-  slhdsaConcreteAlg_perfectlyComplete shaPrimitives
+    (slhdsaConcreteAlg shaParams_d_eq_one shaPrimitives).PerfectlyComplete
+      ProbCompRuntime.probComp :=
+  slhdsaConcreteAlg_perfectlyComplete shaParams_d_eq_one shaPrimitives
 
 end SLHDSA.Concrete

--- a/HashSig/SLHDSA/Fors.lean
+++ b/HashSig/SLHDSA/Fors.lean
@@ -118,9 +118,9 @@ def forsPkGenWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     forsRootWith core hash nodeHash sk pk adrs i.val
   compress (forsPkAdrs adrs) roots.toList
 
-/-- Low-level callback-parametric FORS signing. `authPathM` evaluates only sibling subtrees, so
-the selected leaf is revealed but never hashed by signing. Trees are processed in increasing
-order. -/
+/-- Low-level callback-parametric FORS signing. `intrinsicAuthPathM` evaluates only sibling
+subtrees, so the selected leaf is revealed but never hashed by signing. Trees are processed in
+increasing order. -/
 def forsSignWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     (hash : Adrs → core.Y → m core.Y)
     (nodeHash : Adrs → core.Y → core.Y → m core.Y)
@@ -465,37 +465,6 @@ private theorem isTotalQueryBound_ofFnM {ι α : Type} {spec : OracleSpec ι} {k
       simpa using isTotalQueryBound_bind (n₂ := 0) (h (Fin.last k))
         (fun a => show IsTotalQueryBound (pure (xs.push a) : OracleComp spec _) 0 from trivial)
 
-/-- Compose `Vector.ofFnM` with a continuation whose bound depends on an invariant satisfied by
-every generated entry.  The entry hypothesis is deliberately a refined bind rule rather than a
-plain query bound: it lets structured producers such as `authPathM` carry their path-length fact
-into the final continuation without claiming that arbitrary oracle outputs satisfy it. -/
-private theorem isTotalQueryBound_ofFnM_bind_of_forall
-    {ι α β : Type} {spec : OracleSpec ι} {k : ℕ}
-    (g : Fin k → OracleComp spec α) (P : α → Prop) (budget : Fin k → ℕ)
-    (hentry : ∀ i (rest : α → OracleComp spec β) (restBudget : ℕ),
-      (∀ x, P x → IsTotalQueryBound (rest x) restBudget) →
-      IsTotalQueryBound (g i >>= rest) (budget i + restBudget))
-    (rest : Vector α k → OracleComp spec β) (restBudget : ℕ)
-    (hrest : ∀ xs, (∀ i : Fin k, P xs[i.val]) → IsTotalQueryBound (rest xs) restBudget) :
-    IsTotalQueryBound (Vector.ofFnM g >>= rest) ((∑ i, budget i) + restBudget) := by
-  induction k generalizing restBudget with
-  | zero =>
-      rw [Vector.ofFnM_zero]
-      simpa using hrest #v[] (fun i => Fin.elim0 i)
-  | succ k ih =>
-      rw [Vector.ofFnM_succ, bind_assoc, Fin.sum_univ_castSucc]
-      have hprefix := ih
-        (g := fun i => g i.castSucc) (budget := fun i => budget i.castSucc)
-        (rest := fun xs => g (Fin.last k) >>= fun x => rest (xs.push x))
-        (restBudget := budget (Fin.last k) + restBudget)
-        (fun i rest' restBudget' h => hentry i.castSucc rest' restBudget' h)
-        (fun xs hxs => hentry (Fin.last k) (fun x => rest (xs.push x)) restBudget
-          (fun x hx => hrest (xs.push x) (fun i => by
-            refine Fin.lastCases ?_ (fun j => ?_) i
-            · simpa using hx
-            · simpa using hxs j)))
-      simpa [Nat.add_assoc] using hprefix
-
 private theorem publicHash_f_isTotalQueryBound_one (core : CorePrimitives p)
     (pk : core.PkSeed) (adrs : Adrs) (x : core.Y) :
     IsTotalQueryBound
@@ -630,16 +599,6 @@ theorem forsPkFromSigM_isTotalQueryBound (core : CorePrimitives p)
       simpa [idx, Nat.add_comm] using hbound)
   simpa using isTotalQueryBound_bind hroots fun roots =>
     publicHash_tl_isTotalQueryBound_one core pk (forsPkAdrs adrs) roots.toList
-
-/-- For a FIPS-shaped signature with `a` authentication nodes per tree, recovery has structural
-upper bound `k * (a + 1) + 1`: one `F` and `a` `H` calls per tree, then `T_k`. The constant is
-the exact callback count; `IsTotalQueryBound` exposes it through the library's upper-bound API. -/
-theorem forsPkFromSigM_isTotalQueryBound_fips (core : CorePrimitives p)
-    (sig : ForsSigCore p core) (md : List Byte) (pk : core.PkSeed) (adrs : Adrs) :
-    IsTotalQueryBound
-      (forsPkFromSigM core sig md pk adrs : OracleComp (publicHashSpec core) core.Y)
-      (p.k * (p.a + 1) + 1) :=
-  forsPkFromSigM_isTotalQueryBound core sig md pk adrs
 
 /-- Honest FORS signing followed by recovery stays within the full signing-and-recovery
 schedule.  Signing computes only sibling subtrees; every generated authentication path has

--- a/HashSig/SLHDSA/Fors.lean
+++ b/HashSig/SLHDSA/Fors.lean
@@ -94,9 +94,18 @@ def forsRootWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
 def forsPkAdrs (adrs : Adrs) : Adrs :=
   (adrs.setTypeAndClear .forsRoots).setKeyPairAddress adrs.getKeyPairAddress
 
-/-- A FORS signature over an implementation-independent context. -/
+/-- One intrinsically shaped FORS tree signature: a revealed secret value and exactly `a`
+authentication nodes. -/
+structure ForsTreeSigCore (p : Params) (core : CorePrimitives p) where
+  /-- Secret value selected by the message digest. -/
+  sk : core.Y
+  /-- The `a` sibling nodes, from the leaf level upward. -/
+  auth : Vector core.Y p.a
+
+/-- A FORS signature contains exactly one intrinsically shaped tree signature for each of the
+`k` trees. -/
 abbrev ForsSigCore (p : Params) (core : CorePrimitives p) :=
-  Vector (core.Y × List core.Y) p.k
+  Vector (ForsTreeSigCore p core) p.k
 
 /-- Low-level callback-parametric FORS public-key generation. Roots are computed in increasing
 tree order and compressed only after every root is available. -/
@@ -119,9 +128,9 @@ def forsSignWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     (adrs : Adrs) : m (ForsSigCore p core) :=
   Vector.ofFnM fun i : Fin p.k => do
     let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-    let path ← PerfectMerkleTree.authPathM (forsLeafWith core hash sk pk adrs)
+    let path ← PerfectMerkleTree.intrinsicAuthPathM (forsLeafWith core hash sk pk adrs)
       (forsNodeHashWith nodeHash adrs) idx p.a
-    return (forsSkGenCore core sk pk adrs idx, path)
+    return ⟨forsSkGenCore core sk pk adrs idx, path⟩
 
 /-- Low-level callback-parametric FORS recovery. Each tree first hashes the revealed secret,
 then climbs its authentication path; recovered roots are compressed in increasing tree order. -/
@@ -132,8 +141,8 @@ def forsPkFromSigWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     (sig : ForsSigCore p core) (md : List Byte) (adrs : Adrs) : m core.Y := do
   let roots ← Vector.ofFnM fun i : Fin p.k => do
     let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-    let leaf ← hash (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
-    PerfectMerkleTree.climbM (forsNodeHashWith nodeHash adrs) idx leaf (sig[i.val]).2
+    let leaf ← hash (forsNodeAdrs adrs 0 idx) (sig[i.val]).sk
+    PerfectMerkleTree.climbM (forsNodeHashWith nodeHash adrs) idx leaf (sig[i.val]).auth.toList
   compress (forsPkAdrs adrs) roots.toList
 
 /-! ### Canonical oracle programs -/
@@ -302,7 +311,7 @@ theorem forsSignWith_natural {m n : Type → Type*} [Monad m] [LawfulMonad m]
       forsSignWith core hashn nodeHashn md sk pk adrs := by
   apply monadHom_ofFnM F
   intro i
-  simp [PerfectMerkleTree.authPathM_natural F _ _ _ _
+  simp [PerfectMerkleTree.intrinsicAuthPathM_natural F _ _ _ _
     (fun t => forsLeafWith_natural F core hashm hashn hhash sk pk adrs t)
     (fun z t l r => forsNodeHashWith_natural F nodeHashm nodeHashn hnode adrs z t l r)]
 
@@ -323,12 +332,14 @@ theorem forsPkFromSigWith_natural {m n : Type → Type*} [Monad m] [LawfulMonad 
       forsPkFromSigWith core hashn nodeHashn compressn sig md adrs := by
   have hroots : F (Vector.ofFnM fun i : Fin p.k => do
       let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-      let leaf ← hashm (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
-      PerfectMerkleTree.climbM (forsNodeHashWith nodeHashm adrs) idx leaf (sig[i.val]).2) =
+      let leaf ← hashm (forsNodeAdrs adrs 0 idx) (sig[i.val]).sk
+      PerfectMerkleTree.climbM (forsNodeHashWith nodeHashm adrs) idx leaf
+        (sig[i.val]).auth.toList) =
       (Vector.ofFnM fun i : Fin p.k => do
         let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-        let leaf ← hashn (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
-        PerfectMerkleTree.climbM (forsNodeHashWith nodeHashn adrs) idx leaf (sig[i.val]).2) := by
+        let leaf ← hashn (forsNodeAdrs adrs 0 idx) (sig[i.val]).sk
+        PerfectMerkleTree.climbM (forsNodeHashWith nodeHashn adrs) idx leaf
+          (sig[i.val]).auth.toList) := by
     apply monadHom_ofFnM F
     intro i
     rw [F.mmap_bind, hhash]
@@ -558,21 +569,21 @@ theorem forsSignM_isTotalQueryBound (core : CorePrimitives p) (md : List Byte)
     (fun i : Fin p.k =>
       (do
         let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-        let path ← PerfectMerkleTree.authPathM
+        let path ← PerfectMerkleTree.intrinsicAuthPathM
           (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
           (forsNodeHashWith (PublicHash.h core pk) adrs) idx p.a
-        return (forsSkGenCore core sk pk adrs idx, path) :
-          OracleComp (publicHashSpec core) (core.Y × List core.Y)))
+        return ForsTreeSigCore.mk (forsSkGenCore core sk pk adrs idx) path :
+          OracleComp (publicHashSpec core) (ForsTreeSigCore p core)))
     (fun _ => (2 ^ p.a - 1) + (2 ^ p.a - p.a - 1))
     (fun i => by
       have hpath : IsTotalQueryBound
-          (PerfectMerkleTree.authPathM
+          (PerfectMerkleTree.intrinsicAuthPathM
             (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
             (forsNodeHashWith (PublicHash.h core pk) adrs)
             (i.val * 2 ^ p.a + forsIdx p md i.val) p.a :
-            OracleComp (publicHashSpec core) (List core.Y))
+            OracleComp (publicHashSpec core) (Vector core.Y p.a))
           ((2 ^ p.a - 1) + (2 ^ p.a - p.a - 1)) := by
-        simpa using PerfectMerkleTree.isTotalQueryBound_authPathM
+        simpa using PerfectMerkleTree.isTotalQueryBound_intrinsicAuthPathM
           (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
           (forsNodeHashWith (PublicHash.h core pk) adrs) 1 1
           (i.val * 2 ^ p.a + forsIdx p md i.val) p.a
@@ -580,8 +591,8 @@ theorem forsSignM_isTotalQueryBound (core : CorePrimitives p) (md : List Byte)
           (fun z t l r => publicHash_h_isTotalQueryBound_one core pk _ l r)
       exact isTotalQueryBound_bind (n₂ := 0) hpath
         (fun path => show IsTotalQueryBound
-          (pure (forsSkGenCore core sk pk adrs
-            (i.val * 2 ^ p.a + forsIdx p md i.val), path) :
+          (pure (ForsTreeSigCore.mk (forsSkGenCore core sk pk adrs
+            (i.val * 2 ^ p.a + forsIdx p md i.val)) path) :
             OracleComp (publicHashSpec core) _) 0 from trivial))
   simpa [forsSignM, forsSignWith] using hpaths
 
@@ -591,47 +602,44 @@ theorem forsPkFromSigM_isTotalQueryBound (core : CorePrimitives p)
     (sig : ForsSigCore p core) (md : List Byte) (pk : core.PkSeed) (adrs : Adrs) :
     IsTotalQueryBound
       (forsPkFromSigM core sig md pk adrs : OracleComp (publicHashSpec core) core.Y)
-      ((∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig[j.val]).2.length) i) + 1) := by
+      (p.k * (p.a + 1) + 1) := by
+  change IsTotalQueryBound (do
+    let roots ← Vector.ofFnM fun i : Fin p.k => do
+      let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+      let leaf ← PublicHash.f core pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).sk
+      PerfectMerkleTree.climbM (forsNodeHashWith (PublicHash.h core pk) adrs)
+        idx leaf (sig[i.val]).auth.toList
+    PublicHash.tl core pk (forsPkAdrs adrs) roots.toList) _
   have hroots := isTotalQueryBound_ofFnM
     (fun i : Fin p.k =>
       (do
         let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-        let leaf ← PublicHash.f core pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
+        let leaf ← PublicHash.f core pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).sk
         PerfectMerkleTree.climbM (forsNodeHashWith (PublicHash.h core pk) adrs)
-          idx leaf (sig[i.val]).2 : OracleComp (publicHashSpec core) core.Y))
-    (fun i => 1 + (sig[i.val]).2.length)
-    (fun i => isTotalQueryBound_bind
-      (publicHash_f_isTotalQueryBound_one core pk _ _)
-      (fun leaf => by
-        simpa using PerfectMerkleTree.isTotalQueryBound_climbM
-          (forsNodeHashWith (PublicHash.h core pk) adrs) 1
-          (i.val * 2 ^ p.a + forsIdx p md i.val) leaf (sig[i.val]).2
-          (fun z t l r => publicHash_h_isTotalQueryBound_one core pk _ l r)))
-  exact isTotalQueryBound_bind hroots fun roots =>
+          idx leaf (sig[i.val]).auth.toList : OracleComp (publicHashSpec core) core.Y))
+    (fun _ => p.a + 1)
+    (fun i => by
+      let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+      have hbound := isTotalQueryBound_bind
+        (publicHash_f_isTotalQueryBound_one core pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).sk)
+        (fun leaf => by
+          simpa using PerfectMerkleTree.isTotalQueryBound_climbM
+            (forsNodeHashWith (PublicHash.h core pk) adrs) 1
+            idx leaf (sig[i.val]).auth.toList
+            (fun z t l r => publicHash_h_isTotalQueryBound_one core pk _ l r))
+      simpa [idx, Nat.add_comm] using hbound)
+  simpa using isTotalQueryBound_bind hroots fun roots =>
     publicHash_tl_isTotalQueryBound_one core pk (forsPkAdrs adrs) roots.toList
 
 /-- For a FIPS-shaped signature with `a` authentication nodes per tree, recovery has structural
 upper bound `k * (a + 1) + 1`: one `F` and `a` `H` calls per tree, then `T_k`. The constant is
 the exact callback count; `IsTotalQueryBound` exposes it through the library's upper-bound API. -/
 theorem forsPkFromSigM_isTotalQueryBound_fips (core : CorePrimitives p)
-    (sig : ForsSigCore p core) (md : List Byte) (pk : core.PkSeed) (adrs : Adrs)
-    (hlen : ∀ i : Fin p.k, (sig[i.val]).2.length = p.a) :
+    (sig : ForsSigCore p core) (md : List Byte) (pk : core.PkSeed) (adrs : Adrs) :
     IsTotalQueryBound
       (forsPkFromSigM core sig md pk adrs : OracleComp (publicHashSpec core) core.Y)
-      (p.k * (p.a + 1) + 1) := by
-  have h := forsPkFromSigM_isTotalQueryBound core sig md pk adrs
-  have hsum : (∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig[j.val]).2.length) i) =
-      p.k * (p.a + 1) := by
-    calc
-      (∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig[j.val]).2.length) i) =
-          ∑ _ : Fin p.k, (p.a + 1) := by
-        apply Finset.sum_congr rfl
-        intro i _
-        change 1 + (sig[i.val]).2.length = p.a + 1
-        rw [hlen i]
-        omega
-      _ = p.k * (p.a + 1) := by simp
-  simpa [hsum] using h
+      (p.k * (p.a + 1) + 1) :=
+  forsPkFromSigM_isTotalQueryBound core sig md pk adrs
 
 /-- Honest FORS signing followed by recovery stays within the full signing-and-recovery
 schedule.  Signing computes only sibling subtrees; every generated authentication path has
@@ -650,43 +658,13 @@ theorem forsSignM_then_forsPkFromSigM_isTotalQueryBound (core : CorePrimitives p
         OracleComp (publicHashSpec core) (ForsSigCore p core × core.Y))
       (p.k * ((2 ^ p.a - 1) + (2 ^ p.a - p.a - 1)) +
         (p.k * (p.a + 1) + 1)) := by
-  let entryBudget := (2 ^ p.a - 1) + (2 ^ p.a - p.a - 1)
-  let recoveryBudget := p.k * (p.a + 1) + 1
-  let entries : Fin p.k → OracleComp (publicHashSpec core) (core.Y × List core.Y) :=
-    fun i => do
-      let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-      let path ← PerfectMerkleTree.authPathM
-        (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
-        (forsNodeHashWith (PublicHash.h core pk) adrs) idx p.a
-      return (forsSkGenCore core sk pk adrs idx, path)
-  have hentries : ∀ i (rest : core.Y × List core.Y →
-      OracleComp (publicHashSpec core) (ForsSigCore p core × core.Y)) (restBudget : ℕ),
-      (∀ x, x.2.length = p.a → IsTotalQueryBound (rest x) restBudget) →
-      IsTotalQueryBound (entries i >>= rest) (entryBudget + restBudget) := by
-    intro i rest restBudget hrest
-    simp only [entries, bind_assoc, pure_bind]
-    simpa [entryBudget] using
-      (PerfectMerkleTree.isTotalQueryBound_authPathM_bind
-        (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
-        (forsNodeHashWith (PublicHash.h core pk) adrs) 1 1
-        (i.val * 2 ^ p.a + forsIdx p md i.val) p.a restBudget
-        (fun t => publicHash_f_isTotalQueryBound_one core pk _ _)
-        (fun z t l r => publicHash_h_isTotalQueryBound_one core pk _ l r)
-        (fun path => rest (forsSkGenCore core sk pk adrs
-          (i.val * 2 ^ p.a + forsIdx p md i.val), path))
-        (fun path hlength => hrest _ hlength))
-  have hbound := isTotalQueryBound_ofFnM_bind_of_forall entries
-    (fun x => x.2.length = p.a) (fun _ => entryBudget) hentries
-    (fun sig => do
-      let forsPk ← forsPkFromSigM core sig md pk adrs
-      return (sig, forsPk)) recoveryBudget
-    (fun sig hlength => by
-      simpa using isTotalQueryBound_bind (n₂ := 0)
-        (forsPkFromSigM_isTotalQueryBound_fips core sig md pk adrs hlength)
+  exact isTotalQueryBound_bind
+    (forsSignM_isTotalQueryBound core md sk pk adrs) fun sig =>
+      isTotalQueryBound_bind (n₂ := 0)
+        (forsPkFromSigM_isTotalQueryBound core sig md pk adrs)
         (fun forsPk => show IsTotalQueryBound
           (pure (sig, forsPk) :
-            OracleComp (publicHashSpec core) (ForsSigCore p core × core.Y)) 0 from trivial))
-  simpa [forsSignM, forsSignWith, entries, entryBudget, recoveryBudget] using hbound
+            OracleComp (publicHashSpec core) (ForsSigCore p core × core.Y)) 0 from trivial)
 
 /-! ### Pure API equations -/
 
@@ -733,23 +711,23 @@ private theorem simulateQ_ofFnM {ι α : Type} {spec : OracleSpec ι} {k : ℕ}
     (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
     forsSign prims md sk pk adrs = Vector.ofFn fun i : Fin p.k =>
       let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-      (forsSkGenCore prims.core sk pk adrs idx,
-        PerfectMerkleTree.authPath (forsLeaf prims sk pk adrs)
+      ForsTreeSigCore.mk (forsSkGenCore prims.core sk pk adrs idx)
+        (PerfectMerkleTree.intrinsicAuthPath (forsLeaf prims sk pk adrs)
           (forsNodeHash prims pk adrs) idx p.a) := by
   unfold forsSign forsSignM forsSignWith
   rw [simulateQ_ofFnM]
   apply Vector.ext
   intro i hi
   simp only [Vector.getElem_ofFn, simulateQ_bind, simulateQ_pure,
-    PerfectMerkleTree.simulateQ_authPathM]
+    PerfectMerkleTree.simulateQ_intrinsicAuthPathM]
   rfl
 
 /-- Every authentication path produced by honest FORS signing has the FIPS-prescribed length
 `a`. -/
 @[simp] theorem forsSign_authPath_length (prims : Primitives p) (md : List Byte)
     (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (i : Fin p.k) :
-    ((forsSign prims md sk pk adrs)[i.val]).2.length = p.a := by
-  simp [forsSign_eq_ofFn, PerfectMerkleTree.authPath_length]
+    ((forsSign prims md sk pk adrs)[i.val]).auth.toList.length = p.a := by
+  simp
 
 @[simp] theorem forsPkFromSig_eq_tl (prims : Primitives p) (sig : ForsSigCore p prims.core)
     (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs) :
@@ -757,7 +735,8 @@ private theorem simulateQ_ofFnM {ι α : Type} {spec : OracleSpec ι} {k : ℕ}
       (Vector.ofFn (fun i : Fin p.k =>
         let idx := i.val * 2 ^ p.a + forsIdx p md i.val
         PerfectMerkleTree.climb (forsNodeHash prims pk adrs) idx
-          (prims.F pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1) (sig[i.val]).2)).toList := by
+          (prims.F pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).sk)
+          (sig[i.val]).auth.toList)).toList := by
   simp only [forsPkFromSig, forsPkFromSigM, forsPkFromSigWith, simulateQ_bind,
     simulateQ_ofFnM, PublicHash.tl, PublicHash.f, simulateQ_HasQuery_query,
     PublicHash.impl]
@@ -882,6 +861,7 @@ theorem forsPkFromSig_forsSign (prims : Primitives p) (md : List Byte) (sk : pri
   have key := PerfectMerkleTree.climb_authPath (forsLeaf prims sk pk adrs)
     (forsNodeHash prims pk adrs) (i * 2 ^ p.a + forsIdx p md i) p.a
   rw [ht] at key
+  rw [PerfectMerkleTree.intrinsicAuthPath_toList]
   simpa only [forsLeaf_eq_f, forsRoot_eq_merkleRoot] using key
 
 /-- Extensional FORS completeness for every fixed total public-hash answer table.

--- a/HashSig/SLHDSA/Hypertree.lean
+++ b/HashSig/SLHDSA/Hypertree.lean
@@ -13,10 +13,9 @@ public import HashSig.SLHDSA.Fors
 Hypertree signatures are represented canonically as exactly `d` intrinsically shaped XMSS
 signatures.  The executable algorithms here are explicit single-layer wrappers requiring a proof
 that `d = 1`.  For the SLH-DSA-SHA2-128-24 parameter set, Algorithms 12–13 then collapse to one
-XMSS layer. The `*M`
-algorithms in this file depend
-only on `CorePrimitives` and issue every public hash through `HasQuery`. The established pure API
-is defined as the literal `simulateQ` interpretation of those programs.
+XMSS layer. The `*M` algorithms in this file depend only on `CorePrimitives` and issue every
+public hash through `HasQuery`. The established pure API is defined as the literal `simulateQ`
+interpretation of those programs.
 
 The `*With` definitions expose the thin callback-parametric composition with XMSS. The
 `htPkFromSigM` recovery function is the computational core of verification; keeping it visible

--- a/HashSig/SLHDSA/Hypertree.lean
+++ b/HashSig/SLHDSA/Hypertree.lean
@@ -10,8 +10,11 @@ public import HashSig.SLHDSA.Fors
 /-!
 # Hypertree (FIPS 205 §7)
 
-For the SLH-DSA-SHA2-128-24 parameter set `d = 1`, the hypertree is a single XMSS tree and
-Algorithms 12–13 collapse to one XMSS layer. The canonical `*M` algorithms in this file depend
+Hypertree signatures are represented canonically as exactly `d` intrinsically shaped XMSS
+signatures.  The executable algorithms here are explicit single-layer wrappers requiring a proof
+that `d = 1`.  For the SLH-DSA-SHA2-128-24 parameter set, Algorithms 12–13 then collapse to one
+XMSS layer. The `*M`
+algorithms in this file depend
 only on `CorePrimitives` and issue every public hash through `HasQuery`. The established pure API
 is defined as the literal `simulateQ` interpretation of those programs.
 
@@ -20,8 +23,7 @@ The `*With` definitions expose the thin callback-parametric composition with XMS
 makes the exact extractor- and reduction-facing computation inspectable before the final Boolean
 comparison in `htVerifyM`.
 
-The general `d > 1` hypertree (each layer WOTS-signs the root of the layer below; needed by the
-C13 parameter set) remains a separate generalization.
+No multi-layer signature is synthesized by duplicating that one layer.
 
 ## References
 
@@ -37,8 +39,48 @@ open OracleComp
 
 variable {p : Params}
 
-/-- A hypertree signature for `d = 1`: one XMSS signature of the FORS public key. -/
-abbrev HtSigCore (p : Params) (core : CorePrimitives p) := XmssSig p core
+/-- A hypertree signature contains exactly one intrinsically shaped XMSS signature per layer. -/
+abbrev HtSigCore (p : Params) (core : CorePrimitives p) := Vector (XmssSigCore p core) p.d
+
+namespace HtSigCore
+
+variable {core : CorePrimitives p}
+
+/-- Package the only XMSS signature of a proven single-layer parameter set. -/
+def singleLayer (_hd : p.d = 1) (sig : XmssSigCore p core) : HtSigCore p core :=
+  Vector.ofFn fun _ => sig
+
+/-- Project the only XMSS signature of a proven single-layer parameter set. -/
+def getSingleLayer (hd : p.d = 1) (sig : HtSigCore p core) : XmssSigCore p core :=
+  sig[0]'(by omega)
+
+@[simp]
+theorem getSingleLayer_singleLayer (hd : p.d = 1) (sig : XmssSigCore p core) :
+    getSingleLayer hd (singleLayer hd sig) = sig := by
+  simp [getSingleLayer, singleLayer]
+
+/-- Every intrinsically shaped hypertree signature of a proven single-layer parameter set is
+the canonical singleton wrapper of its only XMSS signature. -/
+@[simp]
+theorem singleLayer_getSingleLayer (hd : p.d = 1) (sig : HtSigCore p core) :
+    singleLayer hd (getSingleLayer hd sig) = sig := by
+  let zero : Fin p.d := ⟨0, by omega⟩
+  apply Vector.ext
+  intro i hi
+  have hizero : i = zero.val := by omega
+  subst i
+  simp [singleLayer, getSingleLayer, zero]
+
+/-- Intrinsically shaped hypertree signatures at depth one are equivalent to one XMSS
+signature.  This is the compatibility boundary used by the reduced-profile algorithms; it does
+not define behavior for a multi-layer signature. -/
+def singleLayerEquiv (hd : p.d = 1) : HtSigCore p core ≃ XmssSigCore p core where
+  toFun := getSingleLayer hd
+  invFun := singleLayer hd
+  left_inv := singleLayer_getSingleLayer hd
+  right_inv := getSingleLayer_singleLayer hd
+
+end HtSigCore
 
 /-- Address of the single hypertree layer (layer `0`, tree `idxTree`). -/
 def htAdrs (adrs : Adrs) (idxTree : ℕ) : Adrs :=
@@ -47,16 +89,17 @@ def htAdrs (adrs : Adrs) (idxTree : ℕ) : Adrs :=
 /-! ### Low-level callback-parametric helpers -/
 
 /-- Callback-parametric hypertree signing for `d = 1`. -/
-def htSignWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+def htSignWith (core : CorePrimitives p) (hd : p.d = 1) {m : Type → Type*} [Monad m]
     (hash : Adrs → core.Y → m core.Y)
     (compress : Adrs → List core.Y → m core.Y)
     (nodeHash : Adrs → core.Y → core.Y → m core.Y)
     (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
-    (adrs : Adrs) (idxTree idxLeaf : ℕ) : m (HtSigCore p core) :=
-  xmssSignWith core hash compress nodeHash msg sk pk (htAdrs adrs idxTree) idxLeaf
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) : m (HtSigCore p core) := do
+  let sig ← xmssSignWith core hash compress nodeHash msg sk pk (htAdrs adrs idxTree) idxLeaf
+  return HtSigCore.singleLayer hd sig
 
 /-- Callback-parametric hypertree root generation for `d = 1`. -/
-def htRootWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+def htRootWith (core : CorePrimitives p) (_hd : p.d = 1) {m : Type → Type*} [Monad m]
     (hash : Adrs → core.Y → m core.Y)
     (compress : Adrs → List core.Y → m core.Y)
     (nodeHash : Adrs → core.Y → core.Y → m core.Y)
@@ -64,141 +107,158 @@ def htRootWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
   xmssRootWith core hash compress nodeHash sk pk (htAdrs adrs idxTree)
 
 /-- Callback-parametric recovery of the root authenticated by a `d = 1` hypertree signature. -/
-def htPkFromSigWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+def htPkFromSigWith (core : CorePrimitives p) (hd : p.d = 1) {m : Type → Type*} [Monad m]
     (hash : Adrs → core.Y → m core.Y)
     (compress : Adrs → List core.Y → m core.Y)
     (nodeHash : Adrs → core.Y → core.Y → m core.Y)
     (msg : core.Y) (sig : HtSigCore p core) (adrs : Adrs)
     (idxTree idxLeaf : ℕ) : m core.Y :=
-  xmssPkFromSigWith core hash compress nodeHash idxLeaf sig msg (htAdrs adrs idxTree)
+  xmssPkFromSigWith core hash compress nodeHash idxLeaf (HtSigCore.getSingleLayer hd sig) msg
+    (htAdrs adrs idxTree)
 
 /-! ### Canonical explicit-public-hash programs -/
 
 /-- Canonical explicit-public-hash hypertree signing for `d = 1`. -/
-def htSignM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+def htSignM (core : CorePrimitives p) (hd : p.d = 1) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m]
     (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) : m (HtSigCore p core) :=
-  htSignWith core (PublicHash.f core pk) (PublicHash.tl core pk)
+  htSignWith core hd (PublicHash.f core pk) (PublicHash.tl core pk)
     (PublicHash.h core pk) msg sk pk adrs idxTree idxLeaf
 
 /-- Canonical explicit-public-hash hypertree root generation for `d = 1`. -/
-def htRootM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+def htRootM (core : CorePrimitives p) (hd : p.d = 1) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m]
     (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) : m core.Y :=
-  htRootWith core (PublicHash.f core pk) (PublicHash.tl core pk)
+  htRootWith core hd (PublicHash.f core pk) (PublicHash.tl core pk)
     (PublicHash.h core pk) sk pk adrs idxTree
 
 /-- Canonical explicit-public-hash recovery of the root authenticated by a hypertree signature. -/
-def htPkFromSigM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+def htPkFromSigM (core : CorePrimitives p) (hd : p.d = 1) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m]
     (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) : m core.Y :=
-  htPkFromSigWith core (PublicHash.f core pk) (PublicHash.tl core pk)
+  htPkFromSigWith core hd (PublicHash.f core pk) (PublicHash.tl core pk)
     (PublicHash.h core pk) msg sig adrs idxTree idxLeaf
 
 /-- Canonical explicit-public-hash hypertree verification. The only non-oracle step is the final
 comparison with the claimed root. -/
-def htVerifyM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+def htVerifyM (core : CorePrimitives p) (hd : p.d = 1) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
     (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) : m Bool := do
-  let recovered ← htPkFromSigM core msg sig pk adrs idxTree idxLeaf
+  let recovered ← htPkFromSigM core hd msg sig pk adrs idxTree idxLeaf
   return decide (recovered = pkRoot)
 
 /-! ### Naturality -/
 
 /-- Query-preserving monad morphisms commute with `d = 1` hypertree signing. -/
-theorem htSignM_natural (core : CorePrimitives p)
+theorem htSignM_natural (core : CorePrimitives p) (hd : p.d = 1)
     {m n : Type → Type*} [Monad m] [LawfulMonad m]
     [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
     [HasQuery (publicHashSpec core) n]
     (F : HasQuery.QueryHom (publicHashSpec core) m n)
     (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) :
-    F.toMonadHom (htSignM core msg sk pk adrs idxTree idxLeaf) =
-      htSignM core msg sk pk adrs idxTree idxLeaf := by
-  exact xmssSignM_natural core F msg sk pk (htAdrs adrs idxTree) idxLeaf
+    F.toMonadHom (htSignM core hd msg sk pk adrs idxTree idxLeaf) =
+      htSignM core hd msg sk pk adrs idxTree idxLeaf := by
+  change F.toMonadHom (do
+    let sig ← xmssSignM core msg sk pk (htAdrs adrs idxTree) idxLeaf
+    return HtSigCore.singleLayer hd sig) = (do
+      let sig ← xmssSignM core msg sk pk (htAdrs adrs idxTree) idxLeaf
+      return HtSigCore.singleLayer hd sig)
+  rw [F.mmap_bind, xmssSignM_natural core F]
+  simp
 
 /-- Query-preserving monad morphisms commute with `d = 1` hypertree root generation. -/
-theorem htRootM_natural (core : CorePrimitives p)
+theorem htRootM_natural (core : CorePrimitives p) (hd : p.d = 1)
     {m n : Type → Type*} [Monad m] [LawfulMonad m]
     [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
     [HasQuery (publicHashSpec core) n]
     (F : HasQuery.QueryHom (publicHashSpec core) m n)
     (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
-    F.toMonadHom (htRootM core sk pk adrs idxTree) =
-      htRootM core sk pk adrs idxTree := by
+    F.toMonadHom (htRootM core hd sk pk adrs idxTree) =
+      htRootM core hd sk pk adrs idxTree := by
   exact xmssRootM_natural core F sk pk (htAdrs adrs idxTree)
 
 /-- Query-preserving monad morphisms commute with `d = 1` hypertree root recovery. -/
-theorem htPkFromSigM_natural (core : CorePrimitives p)
+theorem htPkFromSigM_natural (core : CorePrimitives p) (hd : p.d = 1)
     {m n : Type → Type*} [Monad m] [LawfulMonad m]
     [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
     [HasQuery (publicHashSpec core) n]
     (F : HasQuery.QueryHom (publicHashSpec core) m n)
     (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) :
-    F.toMonadHom (htPkFromSigM core msg sig pk adrs idxTree idxLeaf) =
-      htPkFromSigM core msg sig pk adrs idxTree idxLeaf := by
-  exact xmssPkFromSigM_natural core F idxLeaf sig msg pk (htAdrs adrs idxTree)
+    F.toMonadHom (htPkFromSigM core hd msg sig pk adrs idxTree idxLeaf) =
+      htPkFromSigM core hd msg sig pk adrs idxTree idxLeaf := by
+  exact xmssPkFromSigM_natural core F idxLeaf (HtSigCore.getSingleLayer hd sig) msg pk
+    (htAdrs adrs idxTree)
 
 /-- Query-preserving monad morphisms commute with `d = 1` hypertree verification, including
 the pure final comparison after oracle-parametric root recovery. -/
-theorem htVerifyM_natural (core : CorePrimitives p)
+theorem htVerifyM_natural (core : CorePrimitives p) (hd : p.d = 1)
     {m n : Type → Type*} [Monad m] [LawfulMonad m]
     [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
     [HasQuery (publicHashSpec core) n] [DecidableEq core.Y]
     (F : HasQuery.QueryHom (publicHashSpec core) m n)
     (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
-    F.toMonadHom (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot) =
-      htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot := by
-  simp [htVerifyM, htPkFromSigM_natural core F]
+    F.toMonadHom (htVerifyM core hd msg sig pk adrs idxTree idxLeaf pkRoot) =
+      htVerifyM core hd msg sig pk adrs idxTree idxLeaf pkRoot := by
+  simp [htVerifyM, htPkFromSigM_natural core hd F]
 
 /-! ### Structural query bounds -/
 
 /-- The single-layer hypertree root has exactly the inherited XMSS structural upper bound. -/
-theorem htRootM_isTotalQueryBound (core : CorePrimitives p)
+theorem htRootM_isTotalQueryBound (core : CorePrimitives p) (hd : p.d = 1)
     (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
     IsTotalQueryBound
-      (htRootM core sk pk adrs idxTree : OracleComp (publicHashSpec core) core.Y)
+      (htRootM core hd sk pk adrs idxTree : OracleComp (publicHashSpec core) core.Y)
       (xmssNodeQueryBound p p.hp) :=
   xmssRootM_isTotalQueryBound core sk pk (htAdrs adrs idxTree)
 
 /-- Hypertree signing inherits the XMSS authentication-path and WOTS+ chain budget. -/
-theorem htSignM_isTotalQueryBound (core : CorePrimitives p)
+theorem htSignM_isTotalQueryBound (core : CorePrimitives p) (hd : p.d = 1)
     (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) :
     IsTotalQueryBound
-      (htSignM core msg sk pk adrs idxTree idxLeaf :
+      (htSignM core hd msg sk pk adrs idxTree idxLeaf :
         OracleComp (publicHashSpec core) (HtSigCore p core))
       ((∑ i : Fin p.len, chainStepsCore core msg i.val) +
         xmssAuthPathQueryBound p p.hp) :=
-  xmssSignM_isTotalQueryBound core msg sk pk (htAdrs adrs idxTree) idxLeaf
+by
+  change IsTotalQueryBound (do
+    let sig ← xmssSignM core msg sk pk (htAdrs adrs idxTree) idxLeaf
+    return HtSigCore.singleLayer hd sig) _
+  simpa using isTotalQueryBound_bind (n₂ := 0)
+    (xmssSignM_isTotalQueryBound core msg sk pk (htAdrs adrs idxTree) idxLeaf)
+    (fun sig => show IsTotalQueryBound
+      (pure (HtSigCore.singleLayer hd sig) : OracleComp (publicHashSpec core) _) 0 from trivial)
 
 /-- Hypertree root recovery inherits the complementary WOTS+ and supplied-path budget. -/
-theorem htPkFromSigM_isTotalQueryBound (core : CorePrimitives p)
+theorem htPkFromSigM_isTotalQueryBound (core : CorePrimitives p) (hd : p.d = 1)
     (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) :
     IsTotalQueryBound
-      (htPkFromSigM core msg sig pk adrs idxTree idxLeaf :
+      (htPkFromSigM core hd msg sig pk adrs idxTree idxLeaf :
         OracleComp (publicHashSpec core) core.Y)
       ((∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) +
-        1 + sig.2.length) :=
-  xmssPkFromSigM_isTotalQueryBound core idxLeaf sig msg pk (htAdrs adrs idxTree)
+        1 + p.hp) :=
+  xmssPkFromSigM_isTotalQueryBound core idxLeaf (HtSigCore.getSingleLayer hd sig) msg pk
+    (htAdrs adrs idxTree)
 
 /-- The final Boolean comparison adds no oracle query to the inherited recovery budget. -/
-theorem htVerifyM_isTotalQueryBound (core : CorePrimitives p) [DecidableEq core.Y]
+theorem htVerifyM_isTotalQueryBound (core : CorePrimitives p) (hd : p.d = 1)
+    [DecidableEq core.Y]
     (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
     IsTotalQueryBound
-      (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+      (htVerifyM core hd msg sig pk adrs idxTree idxLeaf pkRoot :
         OracleComp (publicHashSpec core) Bool)
       ((∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) +
-        1 + sig.2.length) := by
+        1 + p.hp) := by
   have hbound := isTotalQueryBound_bind
-    (htPkFromSigM_isTotalQueryBound core msg sig pk adrs idxTree idxLeaf) fun recovered =>
+    (htPkFromSigM_isTotalQueryBound core hd msg sig pk adrs idxTree idxLeaf) fun recovered =>
       show IsTotalQueryBound
         (pure (decide (recovered = pkRoot)) : OracleComp (publicHashSpec core) Bool) 0 from trivial
   simpa [htVerifyM] using hbound
@@ -206,141 +266,158 @@ theorem htVerifyM_isTotalQueryBound (core : CorePrimitives p) [DecidableEq core.
 /-! ### Pure deterministic interpretations -/
 
 /-- Pure hypertree signing is the deterministic interpretation of `htSignM`. -/
-def htSign (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
+def htSign (prims : Primitives p) (hd : p.d = 1) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) : HtSigCore p prims.core :=
   simulateQ (PublicHash.impl prims)
-    (htSignM prims.core msg sk pk adrs idxTree idxLeaf :
+    (htSignM prims.core hd msg sk pk adrs idxTree idxLeaf :
       OracleComp (publicHashSpec prims.core) (HtSigCore p prims.core))
 
 /-- Pure hypertree root generation is the deterministic interpretation of `htRootM`. -/
-def htRoot (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+def htRoot (prims : Primitives p) (hd : p.d = 1) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs)
     (idxTree : ℕ) : prims.Y :=
   simulateQ (PublicHash.impl prims)
-    (htRootM prims.core sk pk adrs idxTree :
+    (htRootM prims.core hd sk pk adrs idxTree :
       OracleComp (publicHashSpec prims.core) prims.Y)
 
 /-- Pure recovery is the deterministic interpretation of `htPkFromSigM`. -/
-def htPkFromSig (prims : Primitives p) (msg : prims.Y) (sig : HtSigCore p prims.core)
+def htPkFromSig (prims : Primitives p) (hd : p.d = 1) (msg : prims.Y)
+    (sig : HtSigCore p prims.core)
     (pk : prims.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) : prims.Y :=
   simulateQ (PublicHash.impl prims)
-    (htPkFromSigM prims.core msg sig pk adrs idxTree idxLeaf :
+    (htPkFromSigM prims.core hd msg sig pk adrs idxTree idxLeaf :
       OracleComp (publicHashSpec prims.core) prims.Y)
 
 /-- Pure verification is the deterministic interpretation of `htVerifyM`. -/
-def htVerify (prims : Primitives p) [DecidableEq prims.Y] (msg : prims.Y)
+def htVerify (prims : Primitives p) (hd : p.d = 1) [DecidableEq prims.Y] (msg : prims.Y)
     (sig : HtSigCore p prims.core) (pk : prims.PkSeed) (adrs : Adrs)
     (idxTree idxLeaf : ℕ) (pkRoot : prims.Y) : Bool :=
   simulateQ (PublicHash.impl prims)
-    (htVerifyM prims.core msg sig pk adrs idxTree idxLeaf pkRoot :
+    (htVerifyM prims.core hd msg sig pk adrs idxTree idxLeaf pkRoot :
       OracleComp (publicHashSpec prims.core) Bool)
 
 /-! ### Pure API equations -/
 
 @[simp]
-theorem htSign_eq_xmssSign (prims : Primitives p) (msg : prims.Y)
+theorem htSign_eq_xmssSign (prims : Primitives p) (hd : p.d = 1) (msg : prims.Y)
     (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) :
-    htSign prims msg sk pk adrs idxTree idxLeaf =
-      xmssSign prims msg sk pk (htAdrs adrs idxTree) idxLeaf := by
+    htSign prims hd msg sk pk adrs idxTree idxLeaf =
+      HtSigCore.singleLayer hd (xmssSign prims msg sk pk (htAdrs adrs idxTree) idxLeaf) := by
+  unfold htSign htSignM htSignWith
+  simp only [simulateQ_bind, simulateQ_pure]
+  change (do
+    let x ← simulateQ (PublicHash.impl prims)
+      (xmssSignM prims.core msg sk pk (htAdrs adrs idxTree) idxLeaf)
+    pure (HtSigCore.singleLayer hd x)) = _
+  rw [simulateQ_xmssSignM]
+  simp
   rfl
 
 @[simp]
-theorem htRoot_eq_xmssRoot (prims : Primitives p) (sk : prims.SkSeed)
+theorem htRoot_eq_xmssRoot (prims : Primitives p) (hd : p.d = 1) (sk : prims.SkSeed)
     (pk : prims.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
-    htRoot prims sk pk adrs idxTree = xmssRoot prims sk pk (htAdrs adrs idxTree) := by
+    htRoot prims hd sk pk adrs idxTree = xmssRoot prims sk pk (htAdrs adrs idxTree) := by
   rfl
 
 @[simp]
-theorem htPkFromSig_eq_xmssPkFromSig (prims : Primitives p) (msg : prims.Y)
+theorem htPkFromSig_eq_xmssPkFromSig (prims : Primitives p) (hd : p.d = 1) (msg : prims.Y)
     (sig : HtSigCore p prims.core) (pk : prims.PkSeed) (adrs : Adrs)
     (idxTree idxLeaf : ℕ) :
-    htPkFromSig prims msg sig pk adrs idxTree idxLeaf =
-      xmssPkFromSig prims idxLeaf sig msg pk (htAdrs adrs idxTree) := by
+    htPkFromSig prims hd msg sig pk adrs idxTree idxLeaf =
+      xmssPkFromSig prims idxLeaf (HtSigCore.getSingleLayer hd sig) msg pk
+        (htAdrs adrs idxTree) := by
   rfl
 
 @[simp]
-theorem htVerify_eq_decide (prims : Primitives p) [DecidableEq prims.Y]
+theorem htVerify_eq_decide (prims : Primitives p) (hd : p.d = 1) [DecidableEq prims.Y]
     (msg : prims.Y) (sig : HtSigCore p prims.core) (pk : prims.PkSeed) (adrs : Adrs)
     (idxTree idxLeaf : ℕ) (pkRoot : prims.Y) :
-    htVerify prims msg sig pk adrs idxTree idxLeaf pkRoot =
-      decide (xmssPkFromSig prims idxLeaf sig msg pk (htAdrs adrs idxTree) = pkRoot) := by
+    htVerify prims hd msg sig pk adrs idxTree idxLeaf pkRoot =
+      decide (xmssPkFromSig prims idxLeaf (HtSigCore.getSingleLayer hd sig) msg pk
+        (htAdrs adrs idxTree) = pkRoot) := by
   unfold htVerify htVerifyM
   simp only [simulateQ_bind, simulateQ_pure]
   change decide
     (simulateQ (PublicHash.impl prims)
-      (xmssPkFromSigM prims.core idxLeaf sig msg pk (htAdrs adrs idxTree)) = pkRoot) = _
+      (xmssPkFromSigM prims.core idxLeaf (HtSigCore.getSingleLayer hd sig) msg pk
+        (htAdrs adrs idxTree)) = pkRoot) = _
   rw [simulateQ_xmssPkFromSigM]
 
 /-! ### Deterministic interpretations -/
 
 @[simp]
-theorem simulateQ_htSignM_withPublicHash (core : CorePrimitives p)
+theorem simulateQ_htSignM_withPublicHash (core : CorePrimitives p) (hd : p.d = 1)
     (answer : QueryImpl (publicHashSpec core) Id)
     (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) :
     simulateQ answer
-        (htSignM core msg sk pk adrs idxTree idxLeaf :
+        (htSignM core hd msg sk pk adrs idxTree idxLeaf :
           OracleComp (publicHashSpec core) (HtSigCore p core)) =
-      htSign (PublicHash.withPublicHash core answer) msg sk pk adrs idxTree idxLeaf := by
+      htSign (PublicHash.withPublicHash core answer) hd msg sk pk adrs idxTree idxLeaf := by
   simp [htSign, PublicHash.impl_withPublicHash]
 
 @[simp]
-theorem simulateQ_htRootM_withPublicHash (core : CorePrimitives p)
+theorem simulateQ_htRootM_withPublicHash (core : CorePrimitives p) (hd : p.d = 1)
     (answer : QueryImpl (publicHashSpec core) Id)
     (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
     simulateQ answer
-        (htRootM core sk pk adrs idxTree : OracleComp (publicHashSpec core) core.Y) =
-      htRoot (PublicHash.withPublicHash core answer) sk pk adrs idxTree := by
+        (htRootM core hd sk pk adrs idxTree : OracleComp (publicHashSpec core) core.Y) =
+      htRoot (PublicHash.withPublicHash core answer) hd sk pk adrs idxTree := by
   simp [htRoot, PublicHash.impl_withPublicHash]
 
 @[simp]
-theorem simulateQ_htPkFromSigM_withPublicHash (core : CorePrimitives p)
+theorem simulateQ_htPkFromSigM_withPublicHash (core : CorePrimitives p) (hd : p.d = 1)
     (answer : QueryImpl (publicHashSpec core) Id)
     (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) :
     simulateQ answer
-        (htPkFromSigM core msg sig pk adrs idxTree idxLeaf :
+        (htPkFromSigM core hd msg sig pk adrs idxTree idxLeaf :
           OracleComp (publicHashSpec core) core.Y) =
-      htPkFromSig (PublicHash.withPublicHash core answer) msg sig pk adrs idxTree idxLeaf := by
+      htPkFromSig (PublicHash.withPublicHash core answer) hd msg sig pk adrs idxTree idxLeaf := by
   simp [htPkFromSig, PublicHash.impl_withPublicHash]
 
 @[simp]
-theorem simulateQ_htVerifyM_withPublicHash (core : CorePrimitives p)
+theorem simulateQ_htVerifyM_withPublicHash (core : CorePrimitives p) (hd : p.d = 1)
     (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
     (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
     simulateQ answer
-        (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+        (htVerifyM core hd msg sig pk adrs idxTree idxLeaf pkRoot :
           OracleComp (publicHashSpec core) Bool) =
-      htVerify (PublicHash.withPublicHash core answer) msg sig pk adrs idxTree idxLeaf pkRoot := by
+      htVerify (PublicHash.withPublicHash core answer) hd msg sig pk adrs idxTree idxLeaf
+        pkRoot := by
   simp [htVerify, PublicHash.impl_withPublicHash]
 
 /-! ### Correctness -/
 
 /-- Hypertree correctness for `d = 1`: verification of an honest signature against the
 key-generation root succeeds. -/
-theorem htVerify_htSign (prims : Primitives p) [DecidableEq prims.Y] (msg : prims.Y)
+theorem htVerify_htSign (prims : Primitives p) (hd : p.d = 1) [DecidableEq prims.Y]
+    (msg : prims.Y)
     (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ)
     (hidx : idxLeaf < 2 ^ p.hp) :
-    htVerify prims msg (htSign prims msg sk pk adrs idxTree idxLeaf) pk adrs idxTree idxLeaf
-        (htRoot prims sk pk adrs idxTree) = true := by
-  rw [htVerify_eq_decide, htSign_eq_xmssSign, htRoot_eq_xmssRoot,
+    htVerify prims hd msg (htSign prims hd msg sk pk adrs idxTree idxLeaf) pk adrs
+        idxTree idxLeaf (htRoot prims hd sk pk adrs idxTree) = true := by
+  rw [htVerify_eq_decide, htSign_eq_xmssSign, HtSigCore.getSingleLayer_singleLayer,
+    htRoot_eq_xmssRoot,
     xmssPkFromSig_xmssSign prims msg sk pk (htAdrs adrs idxTree) idxLeaf hidx]
   simp
 
 /-- Fixed-answer completeness of the canonical hypertree programs. Signing, recovery, and root
 generation are interpreted by one shared deterministic public-hash answer function. This theorem
 does not install a lazy random-oracle cache; that experiment-level interpretation is separate. -/
-theorem simulateQ_htVerifyM_htSignM_withPublicHash (core : CorePrimitives p)
+theorem simulateQ_htVerifyM_htSignM_withPublicHash (core : CorePrimitives p) (hd : p.d = 1)
     (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
     (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) (hidx : idxLeaf < 2 ^ p.hp) :
     simulateQ answer (do
-      let sig ← htSignM core msg sk pk adrs idxTree idxLeaf
-      let root ← htRootM core sk pk adrs idxTree
-      htVerifyM core msg sig pk adrs idxTree idxLeaf root) = true := by
-  simp only [simulateQ_bind, simulateQ_htSignM_withPublicHash,
-    simulateQ_htRootM_withPublicHash, simulateQ_htVerifyM_withPublicHash]
-  exact htVerify_htSign (PublicHash.withPublicHash core answer)
+      let sig ← htSignM core hd msg sk pk adrs idxTree idxLeaf
+      let root ← htRootM core hd sk pk adrs idxTree
+      htVerifyM core hd msg sig pk adrs idxTree idxLeaf root) = true := by
+  simp only [simulateQ_bind, simulateQ_htSignM_withPublicHash core hd,
+    simulateQ_htRootM_withPublicHash core hd, simulateQ_htVerifyM_withPublicHash core hd]
+  exact htVerify_htSign (PublicHash.withPublicHash core answer) hd
     msg sk pk adrs idxTree idxLeaf hidx
 
 end SLHDSA

--- a/HashSig/SLHDSA/RandomOracle.lean
+++ b/HashSig/SLHDSA/RandomOracle.lean
@@ -34,6 +34,7 @@ open OracleComp OracleSpec
 namespace SLHDSA
 
 variable {p : Params}
+variable (hd : p.d = 1)
 
 /-! ### Canonical external algorithms -/
 
@@ -46,7 +47,7 @@ def slhKeygenM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
   let skSeed ← (monadLift ($ᵗ core.SkSeed) : m core.SkSeed)
   let skPrf ← (monadLift ($ᵗ core.SkPrf) : m core.SkPrf)
   let pkSeed ← (monadLift ($ᵗ core.PkSeed) : m core.PkSeed)
-  slhKeygenInternalM core skSeed skPrf pkSeed
+  slhKeygenInternalM hd core skSeed skPrf pkSeed
 
 /-- External hedged signing for the empty-context API: sample `addrnd`, encode the external
 message, then run the canonical internal explicit-query signer. -/
@@ -55,13 +56,13 @@ def slhSignM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     [SampleableType core.Y] (sk : SecretKeyCore core) (msg : List Byte) :
     m (SignatureCore p core) := do
   let addrnd ← (monadLift ($ᵗ core.Y) : m core.Y)
-  slhSignInternalM core (emptyContextMessage msg) sk addrnd
+  slhSignInternalM hd core (emptyContextMessage msg) sk addrnd
 
 /-- External empty-context verification via the canonical internal explicit-query verifier. -/
 def slhVerifyM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
     (pk : PublicKeyCore core) (msg : List Byte) (sig : SignatureCore p core) : m Bool :=
-  slhVerifyInternalM core (emptyContextMessage msg) sig pk
+  slhVerifyInternalM hd core (emptyContextMessage msg) sig pk
 
 /-- The single canonical oracle-parametric signature scheme for the current `d = 1` SLH-DSA
 formalization. Its algorithms are generic over the public-randomness lift and the public-hash
@@ -73,9 +74,9 @@ def slhdsaAlg (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     [SampleableType core.PkSeed] [SampleableType core.Y] [DecidableEq core.Y] :
     SignatureAlg m (List Byte) (PublicKeyCore core) (SecretKeyCore core)
       (SignatureCore p core) where
-  keygen := slhKeygenM core
-  sign _pk sk msg := slhSignM core sk msg
-  verify pk msg sig := slhVerifyM core pk msg sig
+  keygen := slhKeygenM hd core
+  sign _pk sk msg := slhSignM hd core sk msg
+  verify pk msg sig := slhVerifyM hd core pk msg sig
 
 /-! ### Deterministic public-hash specialization -/
 
@@ -88,22 +89,22 @@ def slhdsaConcreteAlg (prims : Primitives p)
     SignatureAlg ProbComp (List Byte) (PublicKeyCore prims.core) (SecretKeyCore prims.core)
       (SignatureCore p prims.core) :=
   SignatureAlg.map (simulateQ' (unifFwdAnswerImpl (PublicHash.impl prims)))
-    (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec prims.core)) prims.core)
+    (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec prims.core)) hd prims.core)
 
 private theorem slhdsaConcreteAlg_components (prims : Primitives p)
     [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
     [SampleableType prims.PkSeed] [SampleableType prims.Y] [DecidableEq prims.Y] :
-    slhdsaConcreteAlg prims =
+    slhdsaConcreteAlg hd prims =
       ({ keygen := do
             let skSeed ← $ᵗ prims.SkSeed
             let skPrf ← $ᵗ prims.SkPrf
             let pkSeed ← $ᵗ prims.PkSeed
-            pure (slhKeygenInternal prims skSeed skPrf pkSeed)
+            pure (slhKeygenInternal hd prims skSeed skPrf pkSeed)
          sign := fun _pk sk msg => do
             let addrnd ← $ᵗ prims.Y
-            pure (slhSignInternal prims (emptyContextMessage msg) sk addrnd)
+            pure (slhSignInternal hd prims (emptyContextMessage msg) sk addrnd)
          verify := fun pk msg sig =>
-            pure (slhVerifyInternal prims (emptyContextMessage msg) sig pk) } :
+            pure (slhVerifyInternal hd prims (emptyContextMessage msg) sig pk) } :
         SignatureAlg ProbComp (List Byte) (PublicKeyCore prims.core)
           (SecretKeyCore prims.core) (SignatureCore p prims.core)) := by
   let _ : HasQuery (publicHashSpec prims.core) ProbComp :=
@@ -124,18 +125,18 @@ private theorem slhdsaConcreteAlg_components (prims : Primitives p)
       HasQuery.toQueryImpl_eq_id', simulateQ_id']
   have hMap :
       SignatureAlg.map F.toMonadHom
-          (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec prims.core)) prims.core) =
-        slhdsaAlg (m := ProbComp) prims.core := by
+          (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec prims.core)) hd prims.core) =
+        slhdsaAlg (m := ProbComp) hd prims.core := by
     apply SignatureAlg.ext
     · simp [slhdsaAlg, slhKeygenM, hLift ($ᵗ prims.SkSeed), hLift ($ᵗ prims.SkPrf),
-        hLift ($ᵗ prims.PkSeed), slhKeygenInternalM_natural prims.core F]
+        hLift ($ᵗ prims.PkSeed), slhKeygenInternalM_natural hd prims.core F]
     · funext pk sk msg
       simp [slhdsaAlg, slhSignM, hLift ($ᵗ prims.Y),
-        slhSignInternalM_natural prims.core F]
+        slhSignInternalM_natural hd prims.core F]
     · funext pk msg sig
-      exact slhVerifyInternalM_natural prims.core F (emptyContextMessage msg) sig pk
+      exact slhVerifyInternalM_natural hd prims.core F (emptyContextMessage msg) sig pk
   change SignatureAlg.map F.toMonadHom
-      (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec prims.core)) prims.core) = _
+      (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec prims.core)) hd prims.core) = _
   rw [hMap]
   have hImpl :
       (HasQuery.toQueryImpl (spec := publicHashSpec prims.core) (m := ProbComp)) =
@@ -144,55 +145,55 @@ private theorem slhdsaConcreteAlg_components (prims : Primitives p)
     rfl
   have hKeygen : ∀ skSeed skPrf pkSeed,
       simulateQ (HasQuery.toQueryImpl (spec := publicHashSpec prims.core) (m := ProbComp))
-          (slhKeygenInternalM prims.core skSeed skPrf pkSeed :
+          (slhKeygenInternalM hd prims.core skSeed skPrf pkSeed :
             OracleComp (publicHashSpec prims.core) _) =
-        pure (slhKeygenInternal prims skSeed skPrf pkSeed) := by
+        pure (slhKeygenInternal hd prims skSeed skPrf pkSeed) := by
     intro skSeed skPrf pkSeed
     rw [hImpl, simulateQ_liftTarget]
     rfl
   have hSign : ∀ msg sk addrnd,
       simulateQ (HasQuery.toQueryImpl (spec := publicHashSpec prims.core) (m := ProbComp))
-          (slhSignInternalM prims.core msg sk addrnd :
+          (slhSignInternalM hd prims.core msg sk addrnd :
             OracleComp (publicHashSpec prims.core) _) =
-        pure (slhSignInternal prims msg sk addrnd) := by
+        pure (slhSignInternal hd prims msg sk addrnd) := by
     intro msg sk addrnd
     rw [hImpl, simulateQ_liftTarget]
     rfl
   have hVerify : ∀ msg sig pk,
       simulateQ (HasQuery.toQueryImpl (spec := publicHashSpec prims.core) (m := ProbComp))
-          (slhVerifyInternalM prims.core msg sig pk :
+          (slhVerifyInternalM hd prims.core msg sig pk :
             OracleComp (publicHashSpec prims.core) _) =
-        pure (slhVerifyInternal prims msg sig pk) := by
+        pure (slhVerifyInternal hd prims msg sig pk) := by
     intro msg sig pk
     rw [hImpl, simulateQ_liftTarget]
     rfl
   apply SignatureAlg.ext
   · simp [slhdsaAlg, slhKeygenM, hKeygen,
-      ← slhKeygenInternalM_natural prims.core
+      ← slhKeygenInternalM_natural hd prims.core
         (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec prims.core) (m := ProbComp))]
   · funext pk sk msg
     simp [slhdsaAlg, slhSignM, hSign,
-      ← slhSignInternalM_natural prims.core
+      ← slhSignInternalM_natural hd prims.core
         (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec prims.core) (m := ProbComp))]
   · funext pk msg sig
     simp [slhdsaAlg, slhVerifyM, hVerify,
-      ← slhVerifyInternalM_natural prims.core
+      ← slhVerifyInternalM_natural hd prims.core
         (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec prims.core) (m := ProbComp))]
 
 /-- Perfect completeness of the definitional concrete-function specialization. -/
 theorem slhdsaConcreteAlg_perfectlyComplete (prims : Primitives p)
     [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
     [SampleableType prims.PkSeed] [SampleableType prims.Y] [DecidableEq prims.Y] :
-    (slhdsaConcreteAlg prims).PerfectlyComplete ProbCompRuntime.probComp := by
+    (slhdsaConcreteAlg hd prims).PerfectlyComplete ProbCompRuntime.probComp := by
   intro msg
   set mx : ProbComp Bool := do
-    let (pk, sk) ← (slhdsaConcreteAlg prims).keygen
-    let sig ← (slhdsaConcreteAlg prims).sign pk sk msg
-    (slhdsaConcreteAlg prims).verify pk msg sig with hmx
+    let (pk, sk) ← (slhdsaConcreteAlg hd prims).keygen
+    let sig ← (slhdsaConcreteAlg hd prims).sign pk sk msg
+    (slhdsaConcreteAlg hd prims).verify pk msg sig with hmx
   have huniq : ∀ y ∈ support mx, y = true := by
     intro y hy
     rw [hmx] at hy
-    rw [slhdsaConcreteAlg_components prims] at hy
+    rw [slhdsaConcreteAlg_components hd prims] at hy
     rw [mem_support_bind_iff] at hy
     obtain ⟨⟨pk, sk⟩, hpksk, hy⟩ := hy
     rw [mem_support_bind_iff] at hy
@@ -210,12 +211,12 @@ theorem slhdsaConcreteAlg_perfectlyComplete (prims : Primitives p)
     obtain ⟨addrnd, -, hsig⟩ := hsig
     simp only [support_pure, Set.mem_singleton_iff] at hsig
     subst hsig
-    have hpk : pk = (slhKeygenInternal prims skSeed skPrf pkSeed).1 :=
+    have hpk : pk = (slhKeygenInternal hd prims skSeed skPrf pkSeed).1 :=
       congrArg Prod.fst hpksk
-    have hsk : sk = (slhKeygenInternal prims skSeed skPrf pkSeed).2 :=
+    have hsk : sk = (slhKeygenInternal hd prims skSeed skPrf pkSeed).2 :=
       congrArg Prod.snd hpksk
     subst hpk; subst hsk
-    exact slhVerifyInternal_slhSignInternal prims (emptyContextMessage msg)
+    exact slhVerifyInternal_slhSignInternal hd prims (emptyContextMessage msg)
       skSeed skPrf pkSeed addrnd
   change Pr[= true | mx] = 1
   exact probOutput_eq_one_of_support_subset_singleton
@@ -261,13 +262,13 @@ theorem slhdsaAlg_perfectlyComplete (core : CorePrimitives p)
     [SampleableType core.SkSeed] [SampleableType core.SkPrf]
     [SampleableType core.PkSeed] [SampleableType core.Y]
     [SampleableType (Bytes p.m)] :
-    (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec core)) core).PerfectlyComplete
+    (slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec core)) hd core).PerfectlyComplete
       (PublicHash.runtime core) := by
   let _ : ∀ q : (publicHashSpec core).Domain,
       SampleableType ((publicHashSpec core).Range q) := fun q => by
     cases q <;> infer_instance
   intro msg
-  let alg := slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec core)) core
+  let alg := slhdsaAlg (m := OracleComp (unifSpec + publicHashSpec core)) hd core
   let oa : OracleComp (unifSpec + publicHashSpec core) Bool := do
     let (pk, sk) ← alg.keygen
     let sig ← alg.sign pk sk msg
@@ -285,7 +286,7 @@ theorem slhdsaAlg_perfectlyComplete (core : CorePrimitives p)
   intro f _hf
   let prims := PublicHash.withPublicHash core f
   have hAlg' : SignatureAlg.map (simulateQ' (unifFwdAnswerImpl f)) alg =
-      slhdsaConcreteAlg prims := by
+      slhdsaConcreteAlg hd prims := by
     simp [alg, prims, slhdsaConcreteAlg, PublicHash.impl_withPublicHash]
   rw [probEvent_eq_eq_probOutput]
   simp only [oa, simulateQ_bind]
@@ -296,6 +297,6 @@ theorem slhdsaAlg_perfectlyComplete (core : CorePrimitives p)
       (SignatureAlg.map (simulateQ' (unifFwdAnswerImpl f)) alg).sign pk sk msg
     (SignatureAlg.map (simulateQ' (unifFwdAnswerImpl f)) alg).verify pk msg sig] = 1
   rw [hAlg']
-  exact slhdsaConcreteAlg_perfectlyComplete prims msg
+  exact slhdsaConcreteAlg_perfectlyComplete hd prims msg
 
 end SLHDSA

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -45,6 +45,7 @@ open OracleComp OracleSpec
 namespace SLHDSA
 
 variable {p : Params}
+variable (hd : p.d = 1)
 
 /-- The SLH-DSA public key over an implementation-independent context: public seed and
 hypertree root. -/
@@ -66,10 +67,14 @@ structure SecretKeyCore (core : CorePrimitives p) where
   /-- Hypertree root `PK.root`. -/
   pkRoot : core.Y
 
-/-- An SLH-DSA signature: randomizer `R`, FORS signature, and hypertree signature
-(`R ‖ SIG_FORS ‖ SIG_HT`). -/
-abbrev SignatureCore (p : Params) (core : CorePrimitives p) :=
-  core.Y × ForsSigCore p core × HtSigCore p core
+/-- An intrinsically shaped SLH-DSA signature (`R ‖ SIG_FORS ‖ SIG_HT`). -/
+structure SignatureCore (p : Params) (core : CorePrimitives p) where
+  /-- Message randomizer `R`. -/
+  randomness : core.Y
+  /-- Exactly `k` intrinsically shaped FORS tree signatures. -/
+  fors : ForsSigCore p core
+  /-- Exactly `d` intrinsically shaped XMSS signatures. -/
+  hypertree : HtSigCore p core
 
 /-! ### Canonical internal algorithms (FIPS 205 §9) -/
 
@@ -79,7 +84,7 @@ def slhKeygenInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m]
     (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
     m (PublicKeyCore core × SecretKeyCore core) := do
-  let pkRoot ← htRootM core skSeed pkSeed Adrs.zero 0
+  let pkRoot ← htRootM core hd skSeed pkSeed Adrs.zero 0
   return (⟨pkSeed, pkRoot⟩, ⟨skSeed, skPrf, pkSeed, pkRoot⟩)
 
 /-- Canonical SLH-DSA internal signing (FIPS 205 Algorithm 19). Its public-hash schedule is
@@ -94,18 +99,18 @@ def slhSignInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
   let parts := splitDigest p digest
   let forsSig ← forsSignM core parts.md.toList sk.skSeed sk.pkSeed parts.forsAdrs
   let forsPk ← forsPkFromSigM core forsSig parts.md.toList sk.pkSeed parts.forsAdrs
-  let htSig ← htSignM core forsPk sk.skSeed sk.pkSeed Adrs.zero 0 parts.idxLeaf.val
-  return (R, forsSig, htSig)
+  let htSig ← htSignM core hd forsPk sk.skSeed sk.pkSeed Adrs.zero 0 parts.idxLeaf.val
+  return ⟨R, forsSig, htSig⟩
 
 /-- Canonical SLH-DSA internal verification (FIPS 205 Algorithm 20). Its public-hash schedule is
 `H_msg`, FORS public-key recovery, then hypertree recovery and comparison with `PK.root`. -/
 def slhVerifyInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
     (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) : m Bool := do
-  let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
+  let digest ← PublicHash.hmsg core sig.randomness pk.pkSeed pk.pkRoot msg
   let parts := splitDigest p digest
-  let forsPk ← forsPkFromSigM core sig.2.1 parts.md.toList pk.pkSeed parts.forsAdrs
-  htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 parts.idxLeaf.val pk.pkRoot
+  let forsPk ← forsPkFromSigM core sig.fors parts.md.toList pk.pkSeed parts.forsAdrs
+  htVerifyM core hd forsPk sig.hypertree pk.pkSeed Adrs.zero 0 parts.idxLeaf.val pk.pkRoot
 
 /-! ### Pure deterministic interpretations -/
 
@@ -114,7 +119,7 @@ def slhVerifyInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
 def slhKeygenInternal (prims : Primitives p) (skSeed : prims.SkSeed) (skPrf : prims.SkPrf)
     (pkSeed : prims.PkSeed) : PublicKeyCore prims.core × SecretKeyCore prims.core :=
   simulateQ (PublicHash.impl prims)
-    (slhKeygenInternalM prims.core skSeed skPrf pkSeed :
+    (slhKeygenInternalM hd prims.core skSeed skPrf pkSeed :
       OracleComp (publicHashSpec prims.core)
         (PublicKeyCore prims.core × SecretKeyCore prims.core))
 
@@ -122,7 +127,7 @@ def slhKeygenInternal (prims : Primitives p) (skSeed : prims.SkSeed) (skPrf : pr
 def slhSignInternal (prims : Primitives p) (msg : List Byte) (sk : SecretKeyCore prims.core)
     (addrnd : prims.Y) : SignatureCore p prims.core :=
   simulateQ (PublicHash.impl prims)
-    (slhSignInternalM prims.core msg sk addrnd :
+    (slhSignInternalM hd prims.core msg sk addrnd :
       OracleComp (publicHashSpec prims.core) (SignatureCore p prims.core))
 
 /-- Pure internal verification is the deterministic interpretation of
@@ -130,7 +135,7 @@ def slhSignInternal (prims : Primitives p) (msg : List Byte) (sk : SecretKeyCore
 def slhVerifyInternal (prims : Primitives p) [DecidableEq prims.Y] (msg : List Byte)
     (sig : SignatureCore p prims.core) (pk : PublicKeyCore prims.core) : Bool :=
   simulateQ (PublicHash.impl prims)
-    (slhVerifyInternalM prims.core msg sig pk : OracleComp (publicHashSpec prims.core) Bool)
+    (slhVerifyInternalM hd prims.core msg sig pk : OracleComp (publicHashSpec prims.core) Bool)
 
 /-! ### Naturality -/
 
@@ -154,9 +159,9 @@ theorem slhKeygenInternalM_natural (core : CorePrimitives p)
     [HasQuery (publicHashSpec core) n]
     (F : HasQuery.QueryHom (publicHashSpec core) m n)
     (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
-    F.toMonadHom (slhKeygenInternalM core skSeed skPrf pkSeed) =
-      slhKeygenInternalM core skSeed skPrf pkSeed := by
-  simp [slhKeygenInternalM, htRootM_natural core F]
+    F.toMonadHom (slhKeygenInternalM hd core skSeed skPrf pkSeed) =
+      slhKeygenInternalM hd core skSeed skPrf pkSeed := by
+  simp [slhKeygenInternalM, htRootM_natural core hd F]
 
 /-- Query-preserving monad morphisms commute with canonical internal signing. -/
 theorem slhSignInternalM_natural (core : CorePrimitives p)
@@ -165,10 +170,10 @@ theorem slhSignInternalM_natural (core : CorePrimitives p)
     [HasQuery (publicHashSpec core) n]
     (F : HasQuery.QueryHom (publicHashSpec core) m n)
     (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
-    F.toMonadHom (slhSignInternalM core msg sk addrnd) =
-      slhSignInternalM core msg sk addrnd := by
+    F.toMonadHom (slhSignInternalM hd core msg sk addrnd) =
+      slhSignInternalM hd core msg sk addrnd := by
   simp [slhSignInternalM, queryHom_hmsg core F,
-    forsSignM_natural core F, forsPkFromSigM_natural core F, htSignM_natural core F]
+    forsSignM_natural core F, forsPkFromSigM_natural core F, htSignM_natural core hd F]
 
 /-- Query-preserving monad morphisms commute with canonical internal verification. -/
 theorem slhVerifyInternalM_natural (core : CorePrimitives p)
@@ -177,10 +182,10 @@ theorem slhVerifyInternalM_natural (core : CorePrimitives p)
     [HasQuery (publicHashSpec core) n] [DecidableEq core.Y]
     (F : HasQuery.QueryHom (publicHashSpec core) m n)
     (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) :
-    F.toMonadHom (slhVerifyInternalM core msg sig pk) =
-      slhVerifyInternalM core msg sig pk := by
+    F.toMonadHom (slhVerifyInternalM hd core msg sig pk) =
+      slhVerifyInternalM hd core msg sig pk := by
   simp [slhVerifyInternalM, queryHom_hmsg core F,
-    forsPkFromSigM_natural core F, htVerifyM_natural core F]
+    forsPkFromSigM_natural core F, htVerifyM_natural core hd F]
 
 /-! ### Structural query bounds -/
 
@@ -200,9 +205,8 @@ def slhSignInternalQueryBound (p : Params) : ℕ :=
 tracks the actual authentication-path lengths. The hypertree term uses the maximum WOTS+ chain
 budget plus the supplied XMSS authentication-path length. -/
 def slhVerifyInternalQueryBound (p : Params) (core : CorePrimitives p)
-    (sig : SignatureCore p core) : ℕ :=
-  1 + ((∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig.2.1[j.val]).2.length) i) + 1) +
-    (p.len * (p.w - 1) + 1 + sig.2.2.2.length)
+    (_sig : SignatureCore p core) : ℕ :=
+  1 + (p.k * (p.a + 1) + 1) + (p.len * (p.w - 1) + 1 + p.hp)
 
 private theorem publicHash_hmsg_isTotalQueryBound_one (core : CorePrimitives p)
     (r : core.Y) (pkSeed : core.PkSeed) (pkRoot : core.Y) (msg : List Byte) :
@@ -215,11 +219,11 @@ private theorem publicHash_hmsg_isTotalQueryBound_one (core : CorePrimitives p)
 theorem slhKeygenInternalM_isTotalQueryBound (core : CorePrimitives p)
     (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
     IsTotalQueryBound
-      (slhKeygenInternalM core skSeed skPrf pkSeed :
+      (slhKeygenInternalM hd core skSeed skPrf pkSeed :
         OracleComp (publicHashSpec core) (PublicKeyCore core × SecretKeyCore core))
       (slhKeygenInternalQueryBound p) := by
   simpa [slhKeygenInternalM, slhKeygenInternalQueryBound] using
-    isTotalQueryBound_bind (htRootM_isTotalQueryBound core skSeed pkSeed Adrs.zero 0)
+    isTotalQueryBound_bind (htRootM_isTotalQueryBound core hd skSeed pkSeed Adrs.zero 0)
       (fun pkRoot => show IsTotalQueryBound
         (pure (PublicKeyCore.mk pkSeed pkRoot,
           SecretKeyCore.mk skSeed skPrf pkSeed pkRoot) :
@@ -229,10 +233,10 @@ private theorem htSignM_isTotalQueryBound_coarse (core : CorePrimitives p)
     (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) :
     IsTotalQueryBound
-      (htSignM core msg sk pk adrs idxTree idxLeaf :
+      (htSignM core hd msg sk pk adrs idxTree idxLeaf :
         OracleComp (publicHashSpec core) (HtSigCore p core))
       (p.len * (p.w - 1) + xmssAuthPathQueryBound p p.hp) := by
-  apply (htSignM_isTotalQueryBound core msg sk pk adrs idxTree idxLeaf).mono
+  apply (htSignM_isTotalQueryBound core hd msg sk pk adrs idxTree idxLeaf).mono
   have hsum :
       (∑ i : Fin p.len, chainStepsCore core msg i.val) ≤ p.len * (p.w - 1) := by
     calc
@@ -251,7 +255,7 @@ not a count of distinct lazy-random-oracle cache misses or fresh samples. -/
 theorem slhSignInternalM_isTotalQueryBound (core : CorePrimitives p)
     (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
     IsTotalQueryBound
-      (slhSignInternalM core msg sk addrnd :
+      (slhSignInternalM hd core msg sk addrnd :
         OracleComp (publicHashSpec core) (SignatureCore p core))
       (slhSignInternalQueryBound p) := by
   let R := core.PRFmsg sk.skPrf addrnd msg
@@ -262,10 +266,10 @@ theorem slhSignInternalM_isTotalQueryBound (core : CorePrimitives p)
         (forsSignM_then_forsPkFromSigM_isTotalQueryBound
           core parts.md.toList sk.skSeed sk.pkSeed parts.forsAdrs) fun sigAndPk =>
             isTotalQueryBound_bind
-              (htSignM_isTotalQueryBound_coarse core sigAndPk.2 sk.skSeed sk.pkSeed
+              (htSignM_isTotalQueryBound_coarse hd core sigAndPk.2 sk.skSeed sk.pkSeed
                 Adrs.zero 0 parts.idxLeaf.val) fun htSig =>
                   show IsTotalQueryBound
-                    (pure (R, sigAndPk.1, htSig) :
+                    (pure ⟨R, sigAndPk.1, htSig⟩ :
                       OracleComp (publicHashSpec core) (SignatureCore p core)) 0 from trivial
   simpa [slhSignInternalM, slhSignInternalQueryBound, R, bind_assoc] using hbound
 
@@ -273,10 +277,10 @@ private theorem htVerifyM_isTotalQueryBound_coarse (core : CorePrimitives p)
     [DecidableEq core.Y] (msg : core.Y) (sig : HtSigCore p core)
     (pk : core.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
     IsTotalQueryBound
-      (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+      (htVerifyM core hd msg sig pk adrs idxTree idxLeaf pkRoot :
         OracleComp (publicHashSpec core) Bool)
-      (p.len * (p.w - 1) + 1 + sig.2.length) := by
-  apply (htVerifyM_isTotalQueryBound core msg sig pk adrs idxTree idxLeaf pkRoot).mono
+      (p.len * (p.w - 1) + 1 + p.hp) := by
+  apply (htVerifyM_isTotalQueryBound core hd msg sig pk adrs idxTree idxLeaf pkRoot).mono
   have hsum :
       (∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) ≤
         p.len * (p.w - 1) := by
@@ -295,15 +299,16 @@ distinct random-oracle cache misses. -/
 theorem slhVerifyInternalM_isTotalQueryBound (core : CorePrimitives p) [DecidableEq core.Y]
     (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) :
     IsTotalQueryBound
-      (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool)
+      (slhVerifyInternalM hd core msg sig pk : OracleComp (publicHashSpec core) Bool)
       (slhVerifyInternalQueryBound p core sig) := by
   have hbound := isTotalQueryBound_bind
-    (publicHash_hmsg_isTotalQueryBound_one core sig.1 pk.pkSeed pk.pkRoot msg) fun digest =>
+    (publicHash_hmsg_isTotalQueryBound_one core sig.randomness pk.pkSeed pk.pkRoot msg)
+      fun digest =>
       let parts := splitDigest p digest
       isTotalQueryBound_bind
-        (forsPkFromSigM_isTotalQueryBound core sig.2.1 parts.md.toList pk.pkSeed
+        (forsPkFromSigM_isTotalQueryBound core sig.fors parts.md.toList pk.pkSeed
           parts.forsAdrs) fun forsPk =>
-            htVerifyM_isTotalQueryBound_coarse core forsPk sig.2.2 pk.pkSeed Adrs.zero 0
+            htVerifyM_isTotalQueryBound_coarse hd core forsPk sig.hypertree pk.pkSeed Adrs.zero 0
               parts.idxLeaf.val pk.pkRoot
   simpa [slhVerifyInternalM, slhVerifyInternalQueryBound, Nat.add_assoc] using hbound
 
@@ -314,54 +319,55 @@ theorem simulateQ_slhKeygenInternalM_withPublicHash (core : CorePrimitives p)
     (answer : QueryImpl (publicHashSpec core) Id)
     (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
     simulateQ answer
-        (slhKeygenInternalM core skSeed skPrf pkSeed :
+        (slhKeygenInternalM hd core skSeed skPrf pkSeed :
           OracleComp (publicHashSpec core) (PublicKeyCore core × SecretKeyCore core)) =
-      slhKeygenInternal (PublicHash.withPublicHash core answer) skSeed skPrf pkSeed := by
+      slhKeygenInternal (p := p) hd (PublicHash.withPublicHash core answer) skSeed skPrf
+        pkSeed := by
   simp [slhKeygenInternal, PublicHash.impl_withPublicHash]
 
 @[simp]
 theorem simulateQ_slhKeygenInternalM (prims : Primitives p)
     (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) :
     simulateQ (PublicHash.impl prims)
-        (slhKeygenInternalM prims.core skSeed skPrf pkSeed :
+        (slhKeygenInternalM hd prims.core skSeed skPrf pkSeed :
           OracleComp (publicHashSpec prims.core)
             (PublicKeyCore prims.core × SecretKeyCore prims.core)) =
-      slhKeygenInternal prims skSeed skPrf pkSeed := rfl
+      slhKeygenInternal hd prims skSeed skPrf pkSeed := rfl
 
 @[simp]
 theorem simulateQ_slhSignInternalM_withPublicHash (core : CorePrimitives p)
     (answer : QueryImpl (publicHashSpec core) Id)
     (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
     simulateQ answer
-        (slhSignInternalM core msg sk addrnd :
+        (slhSignInternalM hd core msg sk addrnd :
           OracleComp (publicHashSpec core) (SignatureCore p core)) =
-      slhSignInternal (PublicHash.withPublicHash core answer) msg sk addrnd := by
+      slhSignInternal (p := p) hd (PublicHash.withPublicHash core answer) msg sk addrnd := by
   simp [slhSignInternal, PublicHash.impl_withPublicHash]
 
 @[simp]
 theorem simulateQ_slhSignInternalM (prims : Primitives p)
     (msg : List Byte) (sk : SecretKeyCore prims.core) (addrnd : prims.Y) :
     simulateQ (PublicHash.impl prims)
-        (slhSignInternalM prims.core msg sk addrnd :
+        (slhSignInternalM hd prims.core msg sk addrnd :
           OracleComp (publicHashSpec prims.core) (SignatureCore p prims.core)) =
-      slhSignInternal prims msg sk addrnd := rfl
+      slhSignInternal hd prims msg sk addrnd := rfl
 
 @[simp]
 theorem simulateQ_slhVerifyInternalM_withPublicHash (core : CorePrimitives p)
     (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
     (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) :
     simulateQ answer
-        (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool) =
-      slhVerifyInternal (PublicHash.withPublicHash core answer) msg sig pk := by
+        (slhVerifyInternalM hd core msg sig pk : OracleComp (publicHashSpec core) Bool) =
+      slhVerifyInternal (p := p) hd (PublicHash.withPublicHash core answer) msg sig pk := by
   simp [slhVerifyInternal, PublicHash.impl_withPublicHash]
 
 @[simp]
 theorem simulateQ_slhVerifyInternalM (prims : Primitives p) [DecidableEq prims.Y]
     (msg : List Byte) (sig : SignatureCore p prims.core) (pk : PublicKeyCore prims.core) :
     simulateQ (PublicHash.impl prims)
-        (slhVerifyInternalM prims.core msg sig pk :
+        (slhVerifyInternalM hd prims.core msg sig pk :
           OracleComp (publicHashSpec prims.core) Bool) =
-      slhVerifyInternal prims msg sig pk := rfl
+      slhVerifyInternal hd prims msg sig pk := rfl
 
 /-- Fixed-answer correctness of the canonical internal programs. Key generation, signing, and
 verification use one total deterministic answer function. This theorem does not install or make
@@ -372,15 +378,15 @@ theorem simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
     (msg : List Byte) (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed)
     (addrnd : core.Y) :
     simulateQ answer (do
-      let (pk, sk) ← slhKeygenInternalM core skSeed skPrf pkSeed
-      let sig ← slhSignInternalM core msg sk addrnd
-      slhVerifyInternalM core msg sig pk) = true := by
+      let (pk, sk) ← slhKeygenInternalM hd core skSeed skPrf pkSeed
+      let sig ← slhSignInternalM hd core msg sk addrnd
+      slhVerifyInternalM hd core msg sig pk) = true := by
   simp only [slhKeygenInternalM, slhSignInternalM, slhVerifyInternalM,
     simulateQ_bind, simulateQ_pure,
-    simulateQ_htRootM_withPublicHash, simulateQ_forsSignM_withPublicHash,
-    simulateQ_forsPkFromSigM_withPublicHash, simulateQ_htSignM_withPublicHash,
-    simulateQ_htVerifyM_withPublicHash]
-  exact htVerify_htSign (PublicHash.withPublicHash core answer) _ skSeed pkSeed Adrs.zero 0 _
+    simulateQ_htRootM_withPublicHash core hd, simulateQ_forsSignM_withPublicHash,
+    simulateQ_forsPkFromSigM_withPublicHash, simulateQ_htSignM_withPublicHash core hd,
+    simulateQ_htVerifyM_withPublicHash core hd]
+  exact htVerify_htSign (PublicHash.withPublicHash core answer) hd _ skSeed pkSeed Adrs.zero 0 _
     (splitDigest p _).idxLeaf.isLt
 
 /-- **Deterministic correctness core**: an honestly generated signature verifies, for every
@@ -388,15 +394,15 @@ choice of seeds, randomizer, and deterministic public-hash implementation. -/
 theorem slhVerifyInternal_slhSignInternal (prims : Primitives p) [DecidableEq prims.Y]
     (msg : List Byte) (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed)
     (addrnd : prims.Y) :
-    slhVerifyInternal prims msg
-        (slhSignInternal prims msg (slhKeygenInternal prims skSeed skPrf pkSeed).2 addrnd)
-        (slhKeygenInternal prims skSeed skPrf pkSeed).1 = true := by
+    slhVerifyInternal hd prims msg
+        (slhSignInternal hd prims msg (slhKeygenInternal hd prims skSeed skPrf pkSeed).2 addrnd)
+        (slhKeygenInternal hd prims skSeed skPrf pkSeed).1 = true := by
   have h := simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
-    prims.core (PublicHash.impl prims) msg skSeed skPrf pkSeed addrnd
+    hd prims.core (PublicHash.impl prims) msg skSeed skPrf pkSeed addrnd
   change ((do
-    let (pk, sk) ← slhKeygenInternal prims skSeed skPrf pkSeed
-    let sig ← slhSignInternal prims msg sk addrnd
-    slhVerifyInternal prims msg sig pk) : Id Bool) = true
+    let (pk, sk) ← slhKeygenInternal hd prims skSeed skPrf pkSeed
+    let sig ← slhSignInternal hd prims msg sk addrnd
+    slhVerifyInternal hd prims msg sig pk) : Id Bool) = true
   simpa only [simulateQ_bind, simulateQ_slhKeygenInternalM,
     simulateQ_slhSignInternalM, simulateQ_slhVerifyInternalM] using h
 

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -201,11 +201,11 @@ def slhSignInternalQueryBound (p : Params) : ℕ :=
       (p.k * (p.a + 1) + 1)) +
     (p.len * (p.w - 1) + xmssAuthPathQueryBound p p.hp))
 
-/-- Structural public-hash budget for verification of the supplied signature. The FORS term
-tracks the actual authentication-path lengths. The hypertree term uses the maximum WOTS+ chain
-budget plus the supplied XMSS authentication-path length. -/
-def slhVerifyInternalQueryBound (p : Params) (core : CorePrimitives p)
-    (_sig : SignatureCore p core) : ℕ :=
+/-- Structural public-hash budget for verification. Intrinsic signature shapes fix every
+authentication-path length at the type level, so the budget depends only on the parameters:
+one `H_msg`, `k * (a + 1) + 1` FORS recovery calls, and a hypertree term using the maximum
+WOTS+ chain budget plus the `h'`-step XMSS authentication path. -/
+def slhVerifyInternalQueryBound (p : Params) : ℕ :=
   1 + (p.k * (p.a + 1) + 1) + (p.len * (p.w - 1) + 1 + p.hp)
 
 private theorem publicHash_hmsg_isTotalQueryBound_one (core : CorePrimitives p)
@@ -300,7 +300,7 @@ theorem slhVerifyInternalM_isTotalQueryBound (core : CorePrimitives p) [Decidabl
     (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) :
     IsTotalQueryBound
       (slhVerifyInternalM hd core msg sig pk : OracleComp (publicHashSpec core) Bool)
-      (slhVerifyInternalQueryBound p core sig) := by
+      (slhVerifyInternalQueryBound p) := by
   have hbound := isTotalQueryBound_bind
     (publicHash_hmsg_isTotalQueryBound_one core sig.randomness pk.pkSeed pk.pkRoot msg)
       fun digest =>

--- a/HashSig/SLHDSA/Xmss.lean
+++ b/HashSig/SLHDSA/Xmss.lean
@@ -55,9 +55,16 @@ def wotsLeafAdrs (adrs : Adrs) (t : ℕ) : Adrs :=
 def xmssNodeAdrs (adrs : Adrs) (z t : ℕ) : Adrs :=
   ((adrs.setTypeAndClear .tree).setTreeHeight z).setTreeIndex t
 
-/-- An XMSS signature: a WOTS+ signature of the leaf message paired with the authentication
-path (`h'` sibling nodes). -/
-abbrev XmssSig (p : Params) (core : CorePrimitives p) := WotsSig p core × List core.Y
+/-- An XMSS signature whose WOTS+ component and authentication path have their FIPS-prescribed
+lengths in the type.  Decoding validates malformed paths before the proof-level verifier. -/
+structure XmssSigCore (p : Params) (core : CorePrimitives p) where
+  /-- The `len` WOTS+ chain values. -/
+  wots : WotsSig p core
+  /-- The `h'` sibling nodes, from the leaf level upward. -/
+  auth : Vector core.Y p.hp
+
+/-- Alias for the canonical intrinsically shaped XMSS signature. -/
+abbrev XmssSig := XmssSigCore
 
 /-! ### Low-level callback-parametric helpers -/
 
@@ -99,10 +106,11 @@ def xmssSignWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     (nodeHash : Adrs → core.Y → core.Y → m core.Y)
     (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idx : ℕ) : m (XmssSig p core) := do
-  let path ← PerfectMerkleTree.authPathM (xmssLeafWith core hash compress sk pk adrs)
+  let path ← PerfectMerkleTree.intrinsicAuthPathM
+    (xmssLeafWith core hash compress sk pk adrs)
     (xmssNodeHashWith nodeHash adrs) idx p.hp
   let sig ← wotsSignWith core hash msg sk pk (wotsLeafAdrs adrs idx)
-  return (sig, path)
+  return ⟨sig, path⟩
 
 /-- Low-level callback-parametric XMSS root recovery. The WOTS+ public key is
 recovered before the authentication path is climbed. -/
@@ -111,8 +119,8 @@ def xmssPkFromSigWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
     (compress : Adrs → List core.Y → m core.Y)
     (nodeHash : Adrs → core.Y → core.Y → m core.Y)
     (idx : ℕ) (sig : XmssSig p core) (msg : core.Y) (adrs : Adrs) : m core.Y := do
-  let leaf ← wotsPkFromSigWith core hash compress sig.1 msg (wotsLeafAdrs adrs idx)
-  PerfectMerkleTree.climbM (xmssNodeHashWith nodeHash adrs) idx leaf sig.2
+  let leaf ← wotsPkFromSigWith core hash compress sig.wots msg (wotsLeafAdrs adrs idx)
+  PerfectMerkleTree.climbM (xmssNodeHashWith nodeHash adrs) idx leaf sig.auth.toList
 
 /-! ### Canonical explicit-public-hash programs -/
 
@@ -234,22 +242,23 @@ theorem xmssRoot_eq_node (prims : Primitives p) (sk : prims.SkSeed)
     xmssRoot prims sk pk adrs = xmssNode prims sk pk adrs p.hp 0 := by
   rfl
 
-/-- The pure signing API is the FIPS authentication path paired with the WOTS+ signature. -/
+/-- The pure signing API contains the WOTS+ signature and the intrinsically shaped FIPS
+authentication path. -/
 @[simp]
 theorem xmssSign_eq_pair (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed)
     (pk : prims.PkSeed) (adrs : Adrs) (idx : ℕ) :
     xmssSign prims msg sk pk adrs idx =
-      (wotsSign prims msg sk pk (wotsLeafAdrs adrs idx),
-        PerfectMerkleTree.authPath (xmssLeaf prims sk pk adrs)
-          (xmssNodeHash prims pk adrs) idx p.hp) := by
-  unfold xmssSign
+      ⟨wotsSign prims msg sk pk (wotsLeafAdrs adrs idx),
+        PerfectMerkleTree.intrinsicAuthPath (xmssLeaf prims sk pk adrs)
+          (xmssNodeHash prims pk adrs) idx p.hp⟩ := by
+  unfold xmssSign xmssSignM xmssSignWith
   change simulateQ (PublicHash.impl prims) (do
-    let path ← PerfectMerkleTree.authPathM (xmssLeafM prims.core sk pk adrs)
+    let path ← PerfectMerkleTree.intrinsicAuthPathM (xmssLeafM prims.core sk pk adrs)
       (xmssNodeHashM prims.core pk adrs) idx p.hp
     let sig ← wotsSignM prims.core msg sk pk (wotsLeafAdrs adrs idx)
-    return (sig, path)) = _
+    return XmssSigCore.mk sig path) = _
   simp only [simulateQ_bind, simulateQ_pure]
-  rw [PerfectMerkleTree.simulateQ_authPathM, simulateQ_wotsSignM]
+  rw [PerfectMerkleTree.simulateQ_intrinsicAuthPathM, simulateQ_wotsSignM]
   rfl
 
 /-- The pure recovery API first recovers the WOTS+ leaf and then climbs the authentication path. -/
@@ -258,11 +267,11 @@ theorem xmssPkFromSig_eq_climb (prims : Primitives p) (idx : ℕ)
     (sig : XmssSig p prims) (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) :
     xmssPkFromSig prims idx sig msg pk adrs =
       PerfectMerkleTree.climb (xmssNodeHash prims pk adrs) idx
-        (wotsPkFromSig prims sig.1 msg pk (wotsLeafAdrs adrs idx)) sig.2 := by
+        (wotsPkFromSig prims sig.wots msg pk (wotsLeafAdrs adrs idx)) sig.auth.toList := by
   unfold xmssPkFromSig
   change simulateQ (PublicHash.impl prims) (do
-    let leaf ← wotsPkFromSigM prims.core sig.1 msg pk (wotsLeafAdrs adrs idx)
-    PerfectMerkleTree.climbM (xmssNodeHashM prims.core pk adrs) idx leaf sig.2) = _
+    let leaf ← wotsPkFromSigM prims.core sig.wots msg pk (wotsLeafAdrs adrs idx)
+    PerfectMerkleTree.climbM (xmssNodeHashM prims.core pk adrs) idx leaf sig.auth.toList) = _
   simp only [simulateQ_bind, simulateQ_wotsPkFromSigM]
   simp_rw [PerfectMerkleTree.simulateQ_climbM]
   rfl
@@ -349,7 +358,7 @@ theorem xmssSignWith_natural {m n : Type → Type*} [Monad m] [LawfulMonad m]
       xmssSignWith core hashn compressn nodeHashn msg sk pk adrs idx := by
   simp only [xmssSignWith, F.mmap_bind]
   simp_rw [wotsSignWith_natural F core hashm hashn hhash]
-  simp_rw [PerfectMerkleTree.authPathM_natural F
+  simp_rw [PerfectMerkleTree.intrinsicAuthPathM_natural F
     (xmssLeafWith core hashm compressm sk pk adrs)
     (xmssNodeHashWith nodeHashm adrs)
     (xmssLeafWith core hashn compressn sk pk adrs)
@@ -543,12 +552,12 @@ at every level. -/
 theorem xmssAuthPathM_isTotalQueryBound (core : CorePrimitives p)
     (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idx z : ℕ) :
     IsTotalQueryBound
-      (PerfectMerkleTree.authPathM (xmssLeafM core sk pk adrs)
+      (PerfectMerkleTree.intrinsicAuthPathM (xmssLeafM core sk pk adrs)
         (xmssNodeHashM core pk adrs) idx z :
-          OracleComp (publicHashSpec core) (List core.Y))
+          OracleComp (publicHashSpec core) (Vector core.Y z))
       (xmssAuthPathQueryBound p z) := by
   simpa [xmssAuthPathQueryBound] using
-    (PerfectMerkleTree.isTotalQueryBound_authPathM
+    (PerfectMerkleTree.isTotalQueryBound_intrinsicAuthPathM
       (xmssLeafM core sk pk adrs) (xmssNodeHashM core pk adrs)
       (p.len * (p.w - 1) + 1) 1 idx z
       (fun i => by
@@ -576,13 +585,13 @@ theorem xmssPkFromSigM_isTotalQueryBound (core : CorePrimitives p)
     IsTotalQueryBound
       (xmssPkFromSigM core idx sig msg pk adrs :
         OracleComp (publicHashSpec core) core.Y)
-      ((∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) + 1 + sig.2.length) := by
+      ((∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) + 1 + p.hp) := by
   change IsTotalQueryBound (do
-    let leaf ← wotsPkFromSigM core sig.1 msg pk (wotsLeafAdrs adrs idx)
-    PerfectMerkleTree.climbM (xmssNodeHashM core pk adrs) idx leaf sig.2) _
+    let leaf ← wotsPkFromSigM core sig.wots msg pk (wotsLeafAdrs adrs idx)
+    PerfectMerkleTree.climbM (xmssNodeHashM core pk adrs) idx leaf sig.auth.toList) _
   exact isTotalQueryBound_bind
-    (wotsPkFromSigM_isTotalQueryBound core sig.1 msg pk (wotsLeafAdrs adrs idx)) fun leaf =>
-      xmssClimbM_isTotalQueryBound core pk adrs idx leaf sig.2
+    (wotsPkFromSigM_isTotalQueryBound core sig.wots msg pk (wotsLeafAdrs adrs idx)) fun leaf =>
+      by simpa using xmssClimbM_isTotalQueryBound core pk adrs idx leaf sig.auth.toList
 
 /-- XMSS signing composes the message-selected WOTS+ chain budget with the sibling-subtree
 authentication-path budget. -/
@@ -594,17 +603,19 @@ theorem xmssSignM_isTotalQueryBound (core : CorePrimitives p)
         OracleComp (publicHashSpec core) (XmssSig p core))
       ((∑ i : Fin p.len, chainStepsCore core msg i.val) +
         xmssAuthPathQueryBound p p.hp) := by
+  unfold xmssSignM xmssSignWith
   change IsTotalQueryBound (do
-    let path ← PerfectMerkleTree.authPathM (xmssLeafM core sk pk adrs)
+    let path ← PerfectMerkleTree.intrinsicAuthPathM (xmssLeafM core sk pk adrs)
       (xmssNodeHashM core pk adrs) idx p.hp
     let sig ← wotsSignM core msg sk pk (wotsLeafAdrs adrs idx)
-    return (sig, path)) _
+    return XmssSigCore.mk sig path) _
   have hbound := isTotalQueryBound_bind
     (xmssAuthPathM_isTotalQueryBound core sk pk adrs idx p.hp) fun path =>
       isTotalQueryBound_bind
         (wotsSignM_isTotalQueryBound core msg sk pk (wotsLeafAdrs adrs idx)) fun sig =>
           show IsTotalQueryBound
-            (pure (sig, path) : OracleComp (publicHashSpec core) (XmssSig p core)) 0 from trivial
+            (pure ⟨sig, path⟩ : OracleComp (publicHashSpec core) (XmssSig p core)) 0 from
+              trivial
   simpa [Nat.add_comm] using hbound
 
 /-- Signing followed by recovery stays within one complete pass over every WOTS+ chain, one
@@ -619,44 +630,17 @@ theorem xmssSignM_then_xmssPkFromSigM_isTotalQueryBound (core : CorePrimitives p
       xmssPkFromSigM core idx sig msg pk adrs) :
         OracleComp (publicHashSpec core) core.Y)
       ((p.len * (p.w - 1) + 1) + xmssAuthPathQueryBound p p.hp + p.hp) := by
-  simp only [xmssSignM, xmssSignWith, xmssPkFromSigM, xmssPkFromSigWith,
-    bind_assoc, pure_bind]
-  have hbody : ∀ path : List core.Y, path.length = p.hp →
-      IsTotalQueryBound ((do
-        let sig ← wotsSignM core msg sk pk (wotsLeafAdrs adrs idx)
-        let leaf ← wotsPkFromSigM core sig msg pk (wotsLeafAdrs adrs idx)
-        PerfectMerkleTree.climbM (xmssNodeHashM core pk adrs) idx leaf path) :
-          OracleComp (publicHashSpec core) core.Y)
-        ((p.len * (p.w - 1) + 1) + p.hp) := by
-    intro path hlen
-    have hbound := isTotalQueryBound_bind
-      (wotsSignM_isTotalQueryBound core msg sk pk (wotsLeafAdrs adrs idx)) fun sig =>
-        isTotalQueryBound_bind
-          (wotsPkFromSigM_isTotalQueryBound core sig msg pk (wotsLeafAdrs adrs idx)) fun leaf =>
-            xmssClimbM_isTotalQueryBound core pk adrs idx leaf path
-    have hsum :
-        (∑ i : Fin p.len, chainStepsCore core msg i.val) +
-            (∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) =
-          p.len * (p.w - 1) := by
-      rw [← Finset.sum_add_distrib]
-      simp_rw [Nat.add_sub_of_le (chainStepsCore_le core msg _)]
-      simp
-    simpa [hlen, ← Nat.add_assoc, hsum] using hbound
-  have hbound := PerfectMerkleTree.isTotalQueryBound_authPathM_bind
-    (xmssLeafM core sk pk adrs) (xmssNodeHashM core pk adrs)
-    (p.len * (p.w - 1) + 1) 1 idx p.hp
-    ((p.len * (p.w - 1) + 1) + p.hp)
-    (fun i => by
-      simpa [xmssLeafM, xmssLeafWith, wotsPkGenM] using
-        wotsPkGenM_isTotalQueryBound core sk pk (wotsLeafAdrs adrs i))
-    (fun h i l r => xmssNodeHashM_isTotalQueryBound_one core pk adrs h i l r)
-    (fun path => do
-      let sig ← wotsSignM core msg sk pk (wotsLeafAdrs adrs idx)
-      let leaf ← wotsPkFromSigM core sig msg pk (wotsLeafAdrs adrs idx)
-      PerfectMerkleTree.climbM (xmssNodeHashM core pk adrs) idx leaf path) hbody
-  unfold xmssLeafM xmssNodeHashM at hbound
-  simpa only [xmssAuthPathQueryBound, Nat.mul_one, wotsSignM, wotsPkFromSigM,
-    Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hbound
+  have hbound := isTotalQueryBound_bind
+    (xmssSignM_isTotalQueryBound core msg sk pk adrs idx) fun sig =>
+      xmssPkFromSigM_isTotalQueryBound core idx sig msg pk adrs
+  have hsum :
+      (∑ i : Fin p.len, chainStepsCore core msg i.val) +
+          (∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) =
+        p.len * (p.w - 1) := by
+    rw [← Finset.sum_add_distrib]
+    simp_rw [Nat.add_sub_of_le (chainStepsCore_le core msg _)]
+    simp
+  simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hsum] using hbound
 
 /-! ### Deterministic interpretations -/
 
@@ -801,7 +785,7 @@ theorem xmssPkFromSig_xmssSign (prims : Primitives p) (msg : prims.Y) (sk : prim
   have key := PerfectMerkleTree.climb_authPath (xmssLeaf prims sk pk adrs)
     (xmssNodeHash prims pk adrs) idx p.hp
   rw [Nat.div_eq_of_lt hidx] at key
-  exact key
+  simpa using key
 
 /-- Functional XMSS completeness for one fixed total public-hash answer function shared by
 signing, recovery, and root computation. This is a deterministic interpretation theorem; it does
@@ -827,10 +811,10 @@ a distinct pair hash to the same value. The first endpoint is fixed by the hones
 determined by `(idx, h)` (a valid target for a multi-target target-collision reduction). -/
 theorem xmssPkFromSig_binding (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed)
     (pk : prims.PkSeed) (adrs : Adrs) (idx : ℕ) (hidx : idx < 2 ^ p.hp)
-    (sig : XmssSig p prims) (hlen : sig.2.length = p.hp)
+    (sig : XmssSig p prims)
     (hroot : xmssPkFromSig prims idx sig msg pk adrs = xmssRoot prims sk pk adrs)
     (hne : xmssLeaf prims sk pk adrs idx
-      ≠ wotsPkFromSig prims sig.1 msg pk (wotsLeafAdrs adrs idx)) :
+      ≠ wotsPkFromSig prims sig.wots msg pk (wotsLeafAdrs adrs idx)) :
     ∃ (h : ℕ) (c : prims.Y × prims.Y), 0 < h ∧ h ≤ p.hp ∧
       (xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h)),
           xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h) + 1))
@@ -840,13 +824,13 @@ theorem xmssPkFromSig_binding (prims : Primitives p) (msg : prims.Y) (sk : prims
           (xmssNode prims sk pk adrs (h - 1) (2 * (idx / 2 ^ h) + 1))
         = prims.H pk (xmssNodeAdrs adrs h (idx / 2 ^ h)) c.1 c.2 := by
   have hroot' : PerfectMerkleTree.climb (xmssNodeHash prims pk adrs) idx
-      (wotsPkFromSig prims sig.1 msg pk (wotsLeafAdrs adrs idx)) sig.2
+      (wotsPkFromSig prims sig.wots msg pk (wotsLeafAdrs adrs idx)) sig.auth.toList
       = PerfectMerkleTree.merkleRoot (xmssLeaf prims sk pk adrs) (xmssNodeHash prims pk adrs)
           p.hp (idx / 2 ^ p.hp) := by
     rw [Nat.div_eq_of_lt hidx]
     simpa only [xmssPkFromSig_eq_climb, xmssRoot_eq_node, xmssNode_eq_merkleRoot] using hroot
   simpa only [xmssNode_eq_merkleRoot, xmssNodeHash_eq_h] using
     (PerfectMerkleTree.climb_binding (xmssLeaf prims sk pk adrs)
-      (xmssNodeHash prims pk adrs) p.hp idx _ sig.2 hlen hroot' hne)
+      (xmssNodeHash prims pk adrs) p.hp idx _ sig.auth.toList (by simp) hroot' hne)
 
 end SLHDSA

--- a/HashSig/SLHDSA/Xmss.lean
+++ b/HashSig/SLHDSA/Xmss.lean
@@ -56,7 +56,7 @@ def xmssNodeAdrs (adrs : Adrs) (z t : ℕ) : Adrs :=
   ((adrs.setTypeAndClear .tree).setTreeHeight z).setTreeIndex t
 
 /-- An XMSS signature whose WOTS+ component and authentication path have their FIPS-prescribed
-lengths in the type.  Decoding validates malformed paths before the proof-level verifier. -/
+lengths in the type, so no caller-supplied length invariant is needed downstream. -/
 structure XmssSigCore (p : Params) (core : CorePrimitives p) where
   /-- The `len` WOTS+ chain values. -/
   wots : WotsSig p core

--- a/HashSigTest/SLHDSA/Fors.lean
+++ b/HashSigTest/SLHDSA/Fors.lean
@@ -39,10 +39,10 @@ example (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
     forsSignM prims.core md sk pk adrs =
       (Vector.ofFnM fun i : Fin p.k => do
         let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-        let path ← PerfectMerkleTree.authPathM
+        let path ← PerfectMerkleTree.intrinsicAuthPathM
           (forsLeafWith prims.core (PublicHash.f prims.core pk) sk pk adrs)
           (forsNodeHashWith (PublicHash.h prims.core pk) adrs) idx p.a
-        return (forsSkGenCore prims.core sk pk adrs idx, path) :
+        return ForsTreeSigCore.mk (forsSkGenCore prims.core sk pk adrs idx) path :
         OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) := rfl
 
 /-- Recovery performs one `F`, then a leaf-to-root climb, per tree in increasing order, followed
@@ -51,10 +51,16 @@ example (sig : ForsSigCore p prims.core) (md : List Byte) (pk : prims.PkSeed) (a
     forsPkFromSigM prims.core sig md pk adrs = (do
       let roots ← Vector.ofFnM fun i : Fin p.k => do
         let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-        let leaf ← PublicHash.f prims.core pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
+        let leaf ← PublicHash.f prims.core pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).sk
         PerfectMerkleTree.climbM
-          (forsNodeHashWith (PublicHash.h prims.core pk) adrs) idx leaf (sig[i.val]).2
+          (forsNodeHashWith (PublicHash.h prims.core pk) adrs) idx leaf (sig[i.val]).auth.toList
       PublicHash.tl prims.core pk (forsPkAdrs adrs) roots.toList :
       OracleComp (publicHashSpec prims.core) prims.Y) := rfl
+
+/-- The forest and every tree path have their FIPS lengths in the type, so replacing either
+vector by a differently sized path is rejected before recovery can run. -/
+example (sig : ForsSigCore p prims.core) :
+    sig.toList.length = p.k ∧ ∀ i : Fin p.k, (sig[i.val]).auth.toList.length = p.a := by
+  simp
 
 end SLHDSA.ForsTest

--- a/HashSigTest/SLHDSA/Hypertree.lean
+++ b/HashSigTest/SLHDSA/Hypertree.lean
@@ -15,29 +15,89 @@ These examples cover the two observable contracts of the `d = 1` hypertree layer
 transparent XMSS composition, and verification recovers a root before its final comparison.
 -/
 
-public section
+@[expose] public section
 
 namespace SLHDSA.HypertreeTest
 
 open OracleComp
 
-variable {p : Params} (core : CorePrimitives p)
+variable {p : Params} (hd : p.d = 1) (core : CorePrimitives p)
 
 /-- The canonical hypertree signer is exactly the addressed XMSS signer. -/
 example (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) :
-    (htSignM core msg sk pk adrs idxTree idxLeaf :
+    (htSignM core hd msg sk pk adrs idxTree idxLeaf :
       OracleComp (publicHashSpec core) (HtSigCore p core)) =
-    xmssSignM core msg sk pk (htAdrs adrs idxTree) idxLeaf := by
-  rfl
+    (do
+      let sig ← xmssSignM core msg sk pk (htAdrs adrs idxTree) idxLeaf
+      return HtSigCore.singleLayer hd sig) := rfl
 
 /-- Verification exposes recovery before the final pure comparison. -/
 example [DecidableEq core.Y] (msg : core.Y) (sig : HtSigCore p core)
     (pk : core.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
-    (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+    (htVerifyM core hd msg sig pk adrs idxTree idxLeaf pkRoot :
       OracleComp (publicHashSpec core) Bool) = (do
-        let recovered ← htPkFromSigM core msg sig pk adrs idxTree idxLeaf
+        let recovered ← htPkFromSigM core hd msg sig pk adrs idxTree idxLeaf
         return decide (recovered = pkRoot)) := by
   rfl
+
+/-- A single-layer wrapper stores exactly one XMSS signature, rather than repeating it through
+the vector representation. -/
+example (sig : XmssSigCore p core) : (HtSigCore.singleLayer hd sig).toList = [sig] := by
+  change (Vector.ofFn fun _ : Fin p.d => sig).toList = [sig]
+  rw [hd]
+  simp only [Vector.toList_ofFn, List.ofFn_succ, List.ofFn_zero]
+
+/-- The single-layer projections form a round trip for every vector admitted by the intrinsic
+representation, rather than only for signatures first built by `singleLayer`. -/
+example (sig : HtSigCore p core) :
+    HtSigCore.singleLayer hd (HtSigCore.getSingleLayer hd sig) = sig :=
+  HtSigCore.singleLayer_getSingleLayer hd sig
+
+/-- The exported equivalence exposes both compatibility directions through one reusable API. -/
+example (sig : XmssSigCore p core) :
+    (HtSigCore.singleLayerEquiv hd).symm sig = HtSigCore.singleLayer hd sig := rfl
+
+/-- The equivalence's inverse round trip is definitionally the explicit single-layer wrapper. -/
+example (sig : HtSigCore p core) :
+    (HtSigCore.singleLayerEquiv hd).symm (HtSigCore.singleLayerEquiv hd sig) = sig := by
+  exact (HtSigCore.singleLayerEquiv hd).symm_apply_apply sig
+
+/-- A small two-layer arithmetic shape used to make layer order observable. -/
+def twoLayerParams : Params :=
+  { n := 1, h := 2, d := 2, hp := 1, a := 1, k := 1, lgw := 1 }
+
+/-- Construct a two-layer hypertree signature with intentionally distinguishable components. -/
+def twoLayerSig (core : CorePrimitives twoLayerParams)
+    (lower upper : XmssSigCore twoLayerParams core) : HtSigCore twoLayerParams core :=
+  Vector.ofFn fun i => if i.val = 0 then lower else upper
+
+/-- Intrinsic hypertree vectors retain each layer and its order. This rejects replacing the
+representation with a duplicated singleton or swapping layer traversal order. -/
+example (core : CorePrimitives twoLayerParams) (lower upper : XmssSigCore twoLayerParams core)
+    (hne : lower ≠ upper) :
+    (twoLayerSig core lower upper).toList = [lower, upper] ∧
+      (twoLayerSig core lower upper)[0]'(by decide) = lower ∧
+      (twoLayerSig core lower upper)[1]'(by decide) = upper ∧
+      (twoLayerSig core lower upper)[0]'(by decide) ≠
+        (twoLayerSig core lower upper)[1]'(by decide) := by
+  change
+    (Vector.ofFn fun i : Fin 2 => if i.val = 0 then lower else upper).toList = [lower, upper] ∧
+      (Vector.ofFn fun i : Fin 2 => if i.val = 0 then lower else upper)[0]'(by decide) = lower ∧
+      (Vector.ofFn fun i : Fin 2 => if i.val = 0 then lower else upper)[1]'(by decide) = upper ∧
+      (Vector.ofFn fun i : Fin 2 => if i.val = 0 then lower else upper)[0]'(by decide) ≠
+        (Vector.ofFn fun i : Fin 2 => if i.val = 0 then lower else upper)[1]'(by decide)
+  simp only [Vector.toList_ofFn, List.ofFn_succ, List.ofFn_zero]
+  simp [hne]
+
+/-- A named FIPS shape is multi-layer and therefore cannot satisfy the compatibility premise
+required by the present wrappers. Its signature representation nevertheless records all layers. -/
+example (core : CorePrimitives (.SLHDSA_SHA2_128s : FipsParameterSet).params)
+    (sig : HtSigCore (.SLHDSA_SHA2_128s : FipsParameterSet).params core) :
+    sig.toList.length = 7 ∧
+      ¬(.SLHDSA_SHA2_128s : FipsParameterSet).params.d = 1 := by
+  constructor
+  · simpa [FipsParameterSet.params] using (Vector.length_toList (xs := sig))
+  · decide
 
 end SLHDSA.HypertreeTest

--- a/HashSigTest/SLHDSA/Scheme.lean
+++ b/HashSigTest/SLHDSA/Scheme.lean
@@ -22,12 +22,12 @@ namespace SLHDSA.SchemeTest
 
 open OracleComp
 
-variable {p : Params} (core : CorePrimitives p)
+variable {p : Params} (hd : p.d = 1) (core : CorePrimitives p)
 
 /-- FIPS 205 Algorithm 19 recovers the FORS public key from the generated signature before
 hypertree signing. Replacing that recovery with `forsPkGenM` makes this canary fail. -/
 example (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
-    (slhSignInternalM core msg sk addrnd :
+    (slhSignInternalM hd core msg sk addrnd :
       OracleComp (publicHashSpec core) (SignatureCore p core)) = (do
         let R := core.PRFmsg sk.skPrf addrnd msg
         let digest ← PublicHash.hmsg core R sk.pkSeed sk.pkRoot msg
@@ -35,18 +35,19 @@ example (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
         let forsSig ← forsSignM core parts.md.toList sk.skSeed sk.pkSeed parts.forsAdrs
         let forsPk ←
           forsPkFromSigM core forsSig parts.md.toList sk.pkSeed parts.forsAdrs
-        let htSig ← htSignM core forsPk sk.skSeed sk.pkSeed Adrs.zero 0 parts.idxLeaf.val
-        return (R, forsSig, htSig)) := by
+        let htSig ← htSignM core hd forsPk sk.skSeed sk.pkSeed Adrs.zero 0 parts.idxLeaf.val
+        return ⟨R, forsSig, htSig⟩) := by
   rfl
 
 /-- Verification performs `H_msg`, FORS recovery, and hypertree recovery/comparison in order. -/
 example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
     (pk : PublicKeyCore core) :
-    (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool) = (do
-      let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
+    (slhVerifyInternalM hd core msg sig pk : OracleComp (publicHashSpec core) Bool) = (do
+      let digest ← PublicHash.hmsg core sig.randomness pk.pkSeed pk.pkRoot msg
       let parts := splitDigest p digest
-      let forsPk ← forsPkFromSigM core sig.2.1 parts.md.toList pk.pkSeed parts.forsAdrs
-      htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 parts.idxLeaf.val pk.pkRoot) := by
+      let forsPk ← forsPkFromSigM core sig.fors parts.md.toList pk.pkSeed parts.forsAdrs
+      htVerifyM core hd forsPk sig.hypertree pk.pkSeed Adrs.zero 0 parts.idxLeaf.val
+        pk.pkRoot) := by
   rfl
 
 end SLHDSA.SchemeTest

--- a/HashSigTest/SLHDSA/Sha2KAT.lean
+++ b/HashSigTest/SLHDSA/Sha2KAT.lean
@@ -40,6 +40,19 @@ example (pkSeed pkRoot : Bytes 16) (msg : List Byte) (sigBytes : ByteArray) :
     verifyBytes pkSeed pkRoot msg sigBytes =
       verifyInternalBytes pkSeed pkRoot (emptyContextMessage msg) sigBytes := rfl
 
+/-- The fixed-width decoder directly produces the intrinsic FORS, XMSS, and hypertree shapes.
+This rejects a decoder mutation that restores unconstrained list-valued authentication paths or
+silently drops the one hypertree layer. -/
+example (sigBytes : ByteArray) :
+    let sig := decodeSignature sigBytes
+    sig.fors.toList.length = 6 ∧
+      (∀ i : Fin 6, (sig.fors[i.val]).auth.toList.length = 24) ∧
+      sig.hypertree.toList.length = 1 ∧
+      (HtSigCore.getSingleLayer shaParams_d_eq_one sig.hypertree).wots.toList.length = 68 ∧
+      (HtSigCore.getSingleLayer shaParams_d_eq_one sig.hypertree).auth.toList.length = 22 := by
+  simp only [Vector.length_toList, forall_const]
+  decide
+
 /-- Reference vector `pk_seed(16) ‖ pk_root(16) ‖ sig(3856)` (hex). -/
 def vectorHex : String :=
   "00000000000000000000000000000000c3e6fbd47a5ef8978dc5bd9be0a3076c5dbe24f3fe0e24549613d7baba\

--- a/HashSigTest/SLHDSA/Xmss.lean
+++ b/HashSigTest/SLHDSA/Xmss.lean
@@ -52,17 +52,23 @@ example (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
     (adrs : Adrs) (idx : ℕ) :
     (xmssSignM core msg sk pk adrs idx :
       OracleComp (publicHashSpec core) (XmssSig p core)) = (do
-      let path ← PerfectMerkleTree.authPathM (xmssLeafM core sk pk adrs)
+      let path ← PerfectMerkleTree.intrinsicAuthPathM (xmssLeafM core sk pk adrs)
         (xmssNodeHashM core pk adrs) idx p.hp
       let sig ← wotsSignM core msg sk pk (wotsLeafAdrs adrs idx)
-      return (sig, path)) := rfl
+      return XmssSigCore.mk sig path) := rfl
 
 /-- Recovery computes the WOTS+ leaf before climbing the leaf-first authentication path. -/
 example (idx : ℕ) (sig : XmssSig p core) (msg : core.Y)
     (pk : core.PkSeed) (adrs : Adrs) :
     (xmssPkFromSigM core idx sig msg pk adrs :
       OracleComp (publicHashSpec core) core.Y) = (do
-      let leaf ← wotsPkFromSigM core sig.1 msg pk (wotsLeafAdrs adrs idx)
-      PerfectMerkleTree.climbM (xmssNodeHashM core pk adrs) idx leaf sig.2) := rfl
+      let leaf ← wotsPkFromSigM core sig.wots msg pk (wotsLeafAdrs adrs idx)
+      PerfectMerkleTree.climbM (xmssNodeHashM core pk adrs) idx leaf sig.auth.toList) := rfl
+
+/-- The two XMSS signature components are intrinsically fixed: no malformed WOTS+ or
+authentication-path length can inhabit the internal representation. -/
+example (sig : XmssSigCore p core) :
+    sig.wots.toList.length = p.len ∧ sig.auth.toList.length = p.hp := by
+  simp
 
 end SLHDSA.XmssTest

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
@@ -79,6 +79,33 @@ def authPathM {m : Type v → Type*} [Monad m] (leaf : ℕ → m Y)
       let siblingRoot ← merkleRootM leaf nodeHash z (sibling (idx / 2 ^ z))
       return path ++ [siblingRoot]
 
+/-- Effectfully compute an authentication path whose height is retained in the result type.
+Only sibling subtrees are evaluated, in leaf-to-root order. -/
+def intrinsicAuthPathM {m : Type v → Type*} [Monad m] (leaf : ℕ → m Y)
+    (nodeHash : ℕ → ℕ → Y → Y → m Y) (idx : ℕ) : (z : ℕ) → m (Vector Y z)
+  | 0 => pure #v[]
+  | z + 1 => do
+      let path ← intrinsicAuthPathM leaf nodeHash idx z
+      let siblingRoot ← merkleRootM leaf nodeHash z (sibling (idx / 2 ^ z))
+      return path.push siblingRoot
+
+/-- Pure authentication path with its exact height retained in the result type. -/
+def intrinsicAuthPath (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y)
+    (idx : ℕ) : (z : ℕ) → Vector Y z
+  | 0 => #v[]
+  | z + 1 => (intrinsicAuthPath leaf nodeHash idx z).push
+      (merkleRoot leaf nodeHash z (sibling (idx / 2 ^ z)))
+
+/-- Erasing the intrinsic length agrees with the list-valued authentication path. -/
+@[simp]
+theorem intrinsicAuthPath_toList (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y)
+    (idx z : ℕ) :
+    (intrinsicAuthPath leaf nodeHash idx z).toList = authPath leaf nodeHash idx z := by
+  induction z with
+  | zero => rfl
+  | succ z ih =>
+      rw [intrinsicAuthPath, Vector.toList_push, ih, authPath_succ]
+
 /-- Effectfully recover a root from a leaf value and a leaf-first authentication path. -/
 def climbM {m : Type v → Type*} [Monad m] (nodeHash : ℕ → ℕ → Y → Y → m Y)
     (idx : ℕ) (node : Y) (auth : List Y) : m Y :=
@@ -138,6 +165,21 @@ theorem authPathM_natural (F : m →ᵐ n)
   | zero => simp [authPathM]
   | succ z ih =>
       simp [authPathM, F.mmap_bind, ih,
+        merkleRootM_natural F leafₘ hashₘ leafₙ hashₙ hleaf hhash]
+
+/-- Intrinsic authentication-path construction commutes with a monad morphism mapping its
+leaf and node callbacks pointwise. -/
+theorem intrinsicAuthPathM_natural (F : m →ᵐ n)
+    (leafₘ : ℕ → m Y) (hashₘ : ℕ → ℕ → Y → Y → m Y)
+    (leafₙ : ℕ → n Y) (hashₙ : ℕ → ℕ → Y → Y → n Y)
+    (hleaf : ∀ i, F (leafₘ i) = leafₙ i)
+    (hhash : ∀ h i l r, F (hashₘ h i l r) = hashₙ h i l r)
+    (idx z : ℕ) :
+    F (intrinsicAuthPathM leafₘ hashₘ idx z) = intrinsicAuthPathM leafₙ hashₙ idx z := by
+  induction z with
+  | zero => simp [intrinsicAuthPathM, F.mmap_pure]
+  | succ z ih =>
+      simp [intrinsicAuthPathM, F.mmap_bind, ih,
         merkleRootM_natural F leafₘ hashₘ leafₙ hashₙ hleaf hhash]
 
 /-- Root recovery commutes with any monad morphism mapping node hashing pointwise. -/
@@ -233,6 +275,22 @@ theorem simulateQ_merkleRootM (impl : QueryImpl spec Id) (leaf : ℕ → OracleC
   | zero => rfl
   | succ z ih =>
       simp only [merkleRootM, simulateQ_bind, merkleRoot_succ, ih]
+      rfl
+
+/-- Simulating an intrinsic authentication-path program with a deterministic oracle handler
+maps its leaves and node hashes pointwise. -/
+@[simp]
+theorem simulateQ_intrinsicAuthPathM (impl : QueryImpl spec Id)
+    (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y) (idx z : ℕ) :
+    simulateQ impl (intrinsicAuthPathM leaf nodeHash idx z) =
+      intrinsicAuthPath (fun i => simulateQ impl (leaf i))
+        (fun h i l r => simulateQ impl (nodeHash h i l r)) idx z := by
+  induction z with
+  | zero => rfl
+  | succ z ih =>
+      simp only [intrinsicAuthPathM, simulateQ_bind, simulateQ_pure, intrinsicAuthPath, ih,
+        simulateQ_merkleRootM]
       rfl
 
 /-- A deterministic handler commutes with effectful authentication-path production. -/

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
@@ -106,6 +106,20 @@ theorem intrinsicAuthPath_toList (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → 
   | succ z ih =>
       rw [intrinsicAuthPath, Vector.toList_push, ih, authPath_succ]
 
+/-- Forgetting the intrinsic path width preserves the complete monadic program, including the
+order of all leaf and node callbacks. This is the bridge that lets distributional and
+query-tracking facts about `authPathM` transfer to `intrinsicAuthPathM` and back inside any
+lawful monad, `OracleComp` included. -/
+theorem intrinsicAuthPathM_toList {m : Type v → Type*} [Monad m] [LawfulMonad m]
+    (leaf : ℕ → m Y) (nodeHash : ℕ → ℕ → Y → Y → m Y) (idx z : ℕ) :
+    (fun path => path.toList) <$> intrinsicAuthPathM leaf nodeHash idx z =
+      authPathM leaf nodeHash idx z := by
+  induction z with
+  | zero => simp [intrinsicAuthPathM, authPathM]
+  | succ z ih =>
+      rw [intrinsicAuthPathM, authPathM, ← ih]
+      simp [Vector.toList_push]
+
 /-- Effectfully recover a root from a leaf value and a leaf-first authentication path. -/
 def climbM {m : Type v → Type*} [Monad m] (nodeHash : ℕ → ℕ → Y → Y → m Y)
     (idx : ℕ) (node : Y) (auth : List Y) : m Y :=

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/QueryBound.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/QueryBound.lean
@@ -140,6 +140,30 @@ theorem isTotalQueryBound_authPathM
       rw [← auth_query_budget_succ]
       omega
 
+/-- The intrinsically shaped authentication-path program has the same callback budget as the
+list-valued traversal. -/
+theorem isTotalQueryBound_intrinsicAuthPathM
+    (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y)
+    (leafBudget nodeBudget idx z : ℕ)
+    (hleaf : ∀ i, IsTotalQueryBound (leaf i) leafBudget)
+    (hnode : ∀ h i l r, IsTotalQueryBound (nodeHash h i l r) nodeBudget) :
+    IsTotalQueryBound (intrinsicAuthPathM leaf nodeHash idx z)
+      ((2 ^ z - 1) * leafBudget + (2 ^ z - z - 1) * nodeBudget) := by
+  induction z with
+  | zero => exact trivial
+  | succ z ih =>
+      simp only [intrinsicAuthPathM]
+      have hsibling := isTotalQueryBound_merkleRootM leaf nodeHash
+        leafBudget nodeBudget z (sibling (idx / 2 ^ z)) hleaf hnode
+      have hboth := isTotalQueryBound_bind ih fun path =>
+        isTotalQueryBound_bind hsibling fun siblingRoot =>
+          show IsTotalQueryBound
+            (pure (path.push siblingRoot) : OracleComp spec _) 0 from trivial
+      refine hboth.mono ?_
+      rw [← auth_query_budget_succ]
+      omega
+
 /-- Compose an authentication-path traversal with a continuation whose bound applies to every
 well-formed result.  The path-length premise retains the structural fact that `authPathM` returns
 exactly one sibling per level; ordinary `isTotalQueryBound_bind` cannot express this refinement


### PR DESCRIPTION
## Summary

This is the G3 slice from the SLH-DSA FIPS 205 generalization plan. It makes every internal signature length intrinsic while preserving the currently executable `d = 1` algorithms behind an explicit compatibility proof.

- `XmssSigCore` stores the WOTS+ signature and a `Vector _ p.hp` authentication path.
- `ForsTreeSigCore` stores one secret value and a `Vector _ p.a` authentication path; `ForsSigCore` remains a `Vector _ p.k`.
- `HtSigCore` is canonically `Vector (XmssSigCore p core) p.d`.
- `SignatureCore` is a named structure containing randomness, FORS, and hypertree components.
- `HtSigCore.singleLayerEquiv` gives the explicit `d = 1` compatibility equivalence, with both round trips proved.
- The generic addressed perfect-Merkle owner now supplies intrinsic authentication-path construction, naturality, deterministic interpretation, and query bounds. XMSS and FORS consume this shared API directly.
- Existing one-layer scheme/oracle APIs require an explicit `p.d = 1` proof rather than manufacturing or discarding layers.
- The legacy fixed-width SHA2-128-24 decoder and executable KAT are migrated to the intrinsic representation.

The `d = 2` canary uses distinguishable lower and upper signatures to make vector order observable. It tests only the representation contract; multi-layer traversal belongs to G4.

## Stack manifest

- **Target branch:** `main`
- **Exact base:** `c82bfa9fa9111d3eedb9db765bfda7da85f1b134`
- **Exact head:** `cf1b6a79b9ec296444bf55074a8f0892076960fa`
- **Merge base:** `c82bfa9fa9111d3eedb9db765bfda7da85f1b134`
- **Unique commits:** 1
- **Unique change:** 13 files, +609/-388
- **Owning slice:** G3 — intrinsic FORS/XMSS/hypertree signature shapes and migrated consumers
- **Inherited prerequisites:** G1/#593 parameter validity and FIPS sets; G2/#595 digest and layer-position calculus

## Compatibility boundary

The canonical data representation is general in `d`, but this PR intentionally does not implement Algorithms 12–13 for arbitrary depth. The existing executable signer, root recovery, verifier, internal scheme, random-oracle wrapper, and concrete compatibility profile now take an explicit `p.d = 1` proof. At depth one:

```lean
HtSigCore p core ≃ XmssSigCore p core
```

Both wrapper/projection round trips are exported and tested. No signature is duplicated to fill a multi-layer vector, and no multi-layer input is silently projected without the `d = 1` premise.

## Validation on exact head

All commands below passed at `cf1b6a79b9ec296444bf55074a8f0892076960fa`:

- `lake build HashSig`
- `lake build HashSigTest`
- `lake build HashSig.SLHDSA.Hypertree`
- `lake env lean HashSigTest/SLHDSA/Hypertree.lean`
- `lake exe slhdsa_kat`
  - `SLH-DSA-SHA2-128-24 KAT: PASS`
- `lake exe slhdsa_c13_kat`
  - valid signature accepted; tampered signature rejected
- `lake build ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets`
  - full non-test umbrella build: 9,354 jobs
- `./scripts/test-axiomsweep.sh`
- `lake exe axiomsweep --check`
  - 16,113 declarations across 502 modules; no new axiom, `sorryAx`, or native trust taint
- `lake exe mk_all --lib VCVio --module --check`
- `lake exe mk_all --lib HashSig --module --check`
- `lake exe lint-style VCVio HashSig` plus the changed SLH-DSA test modules
- `bash scripts/check-pmf-boundary.sh --report origin/main`
  - zero PMF/SPMF delta
- `bash scripts/check-interop-isolation.sh`
- `bash scripts/check-extern-isolation.sh`
- `git diff --check origin/main...HEAD`
- changed-file scan for `sorry`, `admit`, `stop`, `unsafe`, `native_decide`, and custom `axiom`: no matches

An independent `review-lean-formalization` gate reviewed and froze this exact local head with **PASS, no findings**. Hosted checks on the exact remote head remain the integration gate.

## Falsifiable coverage

- depth-one wrapper produces exactly one XMSS component;
- both directions of the depth-one equivalence round-trip;
- a depth-two signature retains distinguishable lower/upper values in order;
- a named FIPS 128s signature has seven layers and cannot satisfy the one-layer premise;
- FORS and XMSS authentication paths expose their exact lengths through their vector types;
- the legacy decoder directly produces the expected FORS, WOTS+, XMSS-auth, and hypertree shapes;
- existing SHA2-128-24 and C13 executable KAT behavior is preserved.

## Explicitly deferred

- G4: arbitrary-depth Algorithms 12–13 traversal, naturality, query bounds, and correctness
- G5: arbitrary-depth Algorithms 18–20 and general scheme correctness
- G6: strict general wire codecs and malformed-input rejection
- G7–G10: all FIPS primitive suites, external APIs, efficient refinement-linked execution, and complete ACVP/KAT corpus
- cryptographic reductions and general-`d` security

Those later slices may build on the canonical intrinsic representation introduced here; this PR contains no G4 traversal, G5 general scheme, new codecs, or security claims.
