### PR TITLE
feat(SLHDSA): complete FIPS external interfaces and prehash registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,6 +310,8 @@ jobs:
         run: lake exe slhdsa_wots_tests
       - name: Run SLH-DSA XMSS construction tests
         run: lake exe slhdsa_xmss_tests
+      - name: Run SLH-DSA external-interface tests
+        run: lake exe slhdsa_external_tests
       # - name: Run ML-KEM tests
       #   run: |
       #     .lake/build/bin/mlkem_test

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -107,6 +107,7 @@ jobs:
           HashSigTest.SLHDSA.Params HashSigTest.SLHDSA.Position HashSigTest.SLHDSA.Oracle
           HashSigTest.SLHDSA.DataCodecTests
           HashSigTest.SLHDSA.External
+          HashSig.SLHDSA.Concrete.Prehash
           HashSigTest.SLHDSA.PrimitiveTests HashSigTest.SLHDSA.WotsEncoding
           HashSigTest.SLHDSA.WotsConstructionTests HashSigTest.SLHDSA.XmssConstructionTests
           HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -106,6 +106,7 @@ jobs:
           VCVioTest.ITSR VCVioTest.SMDTDSPR VCVioTest.SMDTOpenPRE VCVioTest.SMDTUDC
           HashSigTest.SLHDSA.Params HashSigTest.SLHDSA.Position HashSigTest.SLHDSA.Oracle
           HashSigTest.SLHDSA.DataCodecTests
+          HashSigTest.SLHDSA.External
           HashSigTest.SLHDSA.PrimitiveTests HashSigTest.SLHDSA.WotsEncoding
           HashSigTest.SLHDSA.WotsConstructionTests HashSigTest.SLHDSA.XmssConstructionTests
           HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors

--- a/HashSig.lean
+++ b/HashSig.lean
@@ -13,6 +13,7 @@ public import HashSig.SLHDSA.Codec
 public import HashSig.SLHDSA.Concrete.FIPS
 public import HashSig.SLHDSA.Concrete.Instance
 public import HashSig.SLHDSA.Concrete.Keccak
+public import HashSig.SLHDSA.Concrete.Prehash
 public import HashSig.SLHDSA.Concrete.Sha2
 public import HashSig.SLHDSA.Concrete.Wots
 public import HashSig.SLHDSA.Concrete.Xmss

--- a/HashSig.lean
+++ b/HashSig.lean
@@ -18,6 +18,7 @@ public import HashSig.SLHDSA.Concrete.Wots
 public import HashSig.SLHDSA.Concrete.Xmss
 public import HashSig.SLHDSA.DepthOneCompatibility
 public import HashSig.SLHDSA.Encoding
+public import HashSig.SLHDSA.External
 public import HashSig.SLHDSA.FipsParams
 public import HashSig.SLHDSA.Fors
 public import HashSig.SLHDSA.GeneralScheme

--- a/HashSig/SLHDSA/Concrete/FIPS.lean
+++ b/HashSig/SLHDSA/Concrete/FIPS.lean
@@ -348,4 +348,51 @@ theorem approvedPrimitives_byteLaws (set : FipsParameterSet) :
     (approvedPrimitives set).core.ByteLaws := by
   cases set <;> exact ⟨fun _ _ h => h⟩
 
+/-! ## Deterministic-variant randomizer pinning
+
+FIPS 205 Algorithm 19 line 2 fixes the deterministic signing variants' hedging input to
+`opt_rand = PK.seed`.  The abstract primitive interface deliberately keeps `PkSeed` and `Y`
+independent, so the normative pin is expressed here, where both carriers of every approved
+family are concrete `n`-byte vectors and the conversion is the identity. -/
+
+/-- FIPS 205 Algorithm 19 line 2 for the SHA2 family: the deterministic variant's `opt_rand`
+is exactly `PK.seed`.  Both carriers are `Bytes p.n`, so the conversion is the identity. -/
+def sha2RandomizerOfPkSeed (p : Params) :
+    (sha2Primitives p).PkSeed → (sha2Primitives p).Y := id
+
+/-- FIPS 205 Algorithm 19 line 2 for the SHAKE family: the deterministic variant's `opt_rand`
+is exactly `PK.seed`.  Both carriers are `Bytes p.n`, so the conversion is the identity. -/
+def shakeRandomizerOfPkSeed (p : Params) :
+    (shakePrimitives p).PkSeed → (shakePrimitives p).Y := id
+
+/-- The SHA2 pinned randomizer's byte encoding is exactly the public-seed bytes. -/
+@[simp] theorem yToBytes_sha2RandomizerOfPkSeed (p : Params)
+    (seed : (sha2Primitives p).PkSeed) :
+    (sha2Primitives p).yToBytes (sha2RandomizerOfPkSeed p seed) = seed := rfl
+
+/-- The SHAKE pinned randomizer's byte encoding is exactly the public-seed bytes. -/
+@[simp] theorem yToBytes_shakeRandomizerOfPkSeed (p : Params)
+    (seed : (shakePrimitives p).PkSeed) :
+    (shakePrimitives p).yToBytes (shakeRandomizerOfPkSeed p seed) = seed := rfl
+
+/-- Set-level FIPS 205 Algorithm 19 line 2 dispatch: the canonical `opt_rand = PK.seed`
+conversion for each of the twelve approved parameter sets, in the exact primitive family
+selected by `approvedPrimitives`.  FIPS-conforming deterministic signing must pass this
+conversion (or use an entry point that already does). -/
+def approvedRandomizerOfPkSeed :
+    (set : FipsParameterSet) → (approvedPrimitives set).PkSeed → (approvedPrimitives set).Y
+  | .SLHDSA_SHA2_128s | .SLHDSA_SHA2_128f | .SLHDSA_SHA2_192s | .SLHDSA_SHA2_192f
+  | .SLHDSA_SHA2_256s | .SLHDSA_SHA2_256f => sha2RandomizerOfPkSeed _
+  | .SLHDSA_SHAKE_128s | .SLHDSA_SHAKE_128f | .SLHDSA_SHAKE_192s | .SLHDSA_SHAKE_192f
+  | .SLHDSA_SHAKE_256s | .SLHDSA_SHAKE_256f => shakeRandomizerOfPkSeed _
+
+/-- Set-level binding of FIPS 205 Algorithm 19 line 2: for every approved parameter set the
+pinned deterministic randomizer *is* the public seed.  The equality is heterogeneous because
+the seed and node carriers coincide only after the family dispatch reduces; the per-family
+`@[simp]` byte-encoding lemmas state the homogeneous form. -/
+theorem approvedRandomizerOfPkSeed_heq (set : FipsParameterSet)
+    (seed : (approvedPrimitives set).PkSeed) :
+    HEq (approvedRandomizerOfPkSeed set seed) seed := by
+  cases set <;> rfl
+
 end SLHDSA.Concrete

--- a/HashSig/SLHDSA/Concrete/Prehash.lean
+++ b/HashSig/SLHDSA/Concrete/Prehash.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.External
+public import HashSig.SLHDSA.Concrete.Sha2
+public import HashSig.SLHDSA.Concrete.Keccak
+
+/-!
+# Checked FIPS 205 pre-hash adapter
+
+This module closes the descriptor-parametric external semantics over the twelve hash algorithms
+named by ACVP. An `Algorithm` determines the digest implementation, exact output width, and DER
+OID together. The public signing and verification entry points also enforce FIPS 205 §10.2's
+`2n`-byte collision-strength boundary.
+-/
+
+@[expose] public section
+
+namespace SLHDSA.Concrete.Prehash
+
+open OracleComp
+open SLHDSA.External
+
+/-- The complete pre-hash algorithm menu named by the FIPS 205 ACVP external interface. -/
+inductive Algorithm where
+  | sha2_224
+  | sha2_256
+  | sha2_384
+  | sha2_512
+  | sha2_512_224
+  | sha2_512_256
+  | sha3_224
+  | sha3_256
+  | sha3_384
+  | sha3_512
+  | shake128
+  | shake256
+deriving Repr, DecidableEq, BEq
+
+/-- Every ACVP pre-hash algorithm, in registration order. -/
+def all : List Algorithm :=
+  [.sha2_224, .sha2_256, .sha2_384, .sha2_512, .sha2_512_224, .sha2_512_256,
+    .sha3_224, .sha3_256, .sha3_384, .sha3_512, .shake128, .shake256]
+
+/-- Exact ACVP spelling. -/
+def Algorithm.name : Algorithm → String
+  | .sha2_224 => "SHA2-224"
+  | .sha2_256 => "SHA2-256"
+  | .sha2_384 => "SHA2-384"
+  | .sha2_512 => "SHA2-512"
+  | .sha2_512_224 => "SHA2-512/224"
+  | .sha2_512_256 => "SHA2-512/256"
+  | .sha3_224 => "SHA3-224"
+  | .sha3_256 => "SHA3-256"
+  | .sha3_384 => "SHA3-384"
+  | .sha3_512 => "SHA3-512"
+  | .shake128 => "SHAKE-128"
+  | .shake256 => "SHAKE-256"
+
+/-- Parse an exact ACVP algorithm name. -/
+def Algorithm.ofName? : String → Option Algorithm
+  | "SHA2-224" => some .sha2_224
+  | "SHA2-256" => some .sha2_256
+  | "SHA2-384" => some .sha2_384
+  | "SHA2-512" => some .sha2_512
+  | "SHA2-512/224" => some .sha2_512_224
+  | "SHA2-512/256" => some .sha2_512_256
+  | "SHA3-224" => some .sha3_224
+  | "SHA3-256" => some .sha3_256
+  | "SHA3-384" => some .sha3_384
+  | "SHA3-512" => some .sha3_512
+  | "SHAKE-128" => some .shake128
+  | "SHAKE-256" => some .shake256
+  | _ => none
+
+@[simp] theorem Algorithm.ofName?_name (algorithm : Algorithm) :
+    Algorithm.ofName? algorithm.name = some algorithm := by
+  cases algorithm <;> rfl
+
+/-- Digest width, including FIPS 205's fixed 32/64-byte SHAKE outputs. -/
+def Algorithm.outputLength : Algorithm → ℕ
+  | .sha2_224 | .sha2_512_224 | .sha3_224 => 28
+  | .sha2_256 | .sha2_512_256 | .sha3_256 | .shake128 => 32
+  | .sha2_384 | .sha3_384 => 48
+  | .sha2_512 | .sha3_512 | .shake256 => 64
+
+/-- FIPS 205 §10.2 compatibility: collision strength requires at least `2n` digest bytes. -/
+def Algorithm.validFor (algorithm : Algorithm) (p : Params) : Bool :=
+  2 * p.n ≤ algorithm.outputLength
+
+/-- Proposition-level strength requirement. -/
+def Algorithm.ValidFor (algorithm : Algorithm) (p : Params) : Prop :=
+  2 * p.n ≤ algorithm.outputLength
+
+theorem Algorithm.validFor_iff (algorithm : Algorithm) (p : Params) :
+    algorithm.validFor p = true ↔ algorithm.ValidFor p := by
+  simp [Algorithm.validFor, Algorithm.ValidFor]
+
+/-- Complete DER encoding of the NIST hash-algorithm OID (`hashAlgs` arcs 1–12). -/
+def Algorithm.oidDer : Algorithm → List Byte
+  | .sha2_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01]
+  | .sha2_384 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02]
+  | .sha2_512 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03]
+  | .sha2_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04]
+  | .sha2_512_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x05]
+  | .sha2_512_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x06]
+  | .sha3_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x07]
+  | .sha3_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x08]
+  | .sha3_384 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x09]
+  | .sha3_512 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0a]
+  | .shake128 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0b]
+  | .shake256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0c]
+
+/-- Concrete FFI-free digest bytes. -/
+def Algorithm.digestRaw (algorithm : Algorithm) (message : List Byte) : ByteArray :=
+  let input := ByteArray.mk message.toArray
+  match algorithm with
+  | .sha2_224 => Sha2.sha224 input
+  | .sha2_256 => Sha2.sha256 input
+  | .sha2_384 => Sha2.sha384 input
+  | .sha2_512 => Sha2.sha512 input
+  | .sha2_512_224 => Sha2.sha512_224 input
+  | .sha2_512_256 => Sha2.sha512_256 input
+  | .sha3_224 => Keccak.sha3_224 input
+  | .sha3_256 => Keccak.sha3_256 input
+  | .sha3_384 => Keccak.sha3_384 input
+  | .sha3_512 => Keccak.sha3_512 input
+  | .shake128 => Keccak.squeeze (Keccak.absorb input 168 0x1f) 32
+  | .shake256 => Keccak.squeeze (Keccak.absorb input 136 0x1f) 64
+
+@[simp] theorem Algorithm.digestRaw_size (algorithm : Algorithm) (message : List Byte) :
+    (algorithm.digestRaw message).size = algorithm.outputLength := by
+  cases algorithm <;> simp [Algorithm.digestRaw, Algorithm.outputLength]
+
+/-- Fail-closed exact-width projection; there is no padding or truncation path. -/
+def digestBytesExact (n : ℕ) (digest : ByteArray) : Except Error (Bytes n) :=
+  if h : digest.size = n then
+    .ok (Vector.ofFn fun i : Fin n => digest[i.val]'(by omega))
+  else
+    .error (.digestLengthMismatch n digest.size)
+
+/-- Exact-width digest checked against the engine's advertised width. -/
+def Algorithm.digest (algorithm : Algorithm) (message : List Byte) :
+    Except Error (Bytes algorithm.outputLength) :=
+  .ok (Vector.ofFn fun i : Fin algorithm.outputLength =>
+    (algorithm.digestRaw message)[i.val]'(by
+      rw [algorithm.digestRaw_size message]
+      exact i.isLt))
+
+/-- Canonical binding of one registry entry's DER OID and digest implementation. -/
+def Algorithm.descriptor (algorithm : Algorithm) : PrehashDescriptor where
+  oidDer := algorithm.oidDer
+  outputLength := algorithm.outputLength
+  digest := algorithm.digest
+
+/-- Reject a pre-hash algorithm below the selected parameter set's claimed strength. -/
+def requireStrength (p : Params) (algorithm : Algorithm) : Except Error Unit :=
+  if algorithm.validFor p then
+    .ok ()
+  else
+    .error (.prehashTooWeak p.n algorithm.outputLength)
+
+/-- Checked Algorithm 23/25 message encoding. -/
+def encodeMessage (p : Params) (algorithm : Algorithm) (context message : List Byte) :
+    Except Error (List Byte) := do
+  requireStrength p algorithm
+  encodePrehashMessageWithDescriptor algorithm.descriptor context message
+
+/-- Checked Algorithm 23 with caller-supplied hedging randomness. -/
+def signWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
+    (algorithm : Algorithm) (message context : List Byte) (sk : SecretKeyCore prims.core)
+    (addrnd : prims.Y) : Except Error (GeneralScheme.SignatureCore vp prims.core) := do
+  requireStrength vp.params algorithm
+  signPrehashWithDescriptorAndRandomizer vp prims algorithm.descriptor message context sk addrnd
+
+/-- Checked deterministic Algorithm 23. -/
+def signDeterministic (vp : ValidatedParams) (prims : Primitives vp.params)
+    (pkSeedToRandomizer : prims.PkSeed → prims.Y) (algorithm : Algorithm)
+    (message context : List Byte) (sk : SecretKeyCore prims.core) :
+    Except Error (GeneralScheme.SignatureCore vp prims.core) := do
+  requireStrength vp.params algorithm
+  signPrehashWithDescriptorDeterministic vp prims pkSeedToRandomizer algorithm.descriptor
+    message context sk
+
+/-- Checked hedged Algorithm 23 under the ideal total random source. -/
+noncomputable def sign (vp : ValidatedParams) (prims : Primitives vp.params)
+    [SampleableType prims.Y] (algorithm : Algorithm) (message context : List Byte)
+    (sk : SecretKeyCore prims.core) :
+    ProbComp (Except Error (GeneralScheme.SignatureCore vp prims.core)) :=
+  match requireStrength vp.params algorithm with
+  | .error error => pure (.error error)
+  | .ok _ => signPrehashWithDescriptor vp prims algorithm.descriptor message context sk
+
+/-- Checked Algorithm 25. Weak pairings and message-boundary failures reject as `false`. -/
+def verify (vp : ValidatedParams) (prims : Primitives vp.params) [DecidableEq prims.Y]
+    (algorithm : Algorithm) (message : List Byte)
+    (signature : GeneralScheme.SignatureCore vp prims.core) (context : List Byte)
+    (pk : PublicKeyCore prims.core) : Bool :=
+  match requireStrength vp.params algorithm with
+  | .error _ => false
+  | .ok _ => verifyPrehashWithDescriptor vp prims algorithm.descriptor message signature context pk
+
+end SLHDSA.Concrete.Prehash

--- a/HashSig/SLHDSA/Concrete/Prehash.lean
+++ b/HashSig/SLHDSA/Concrete/Prehash.lean
@@ -167,6 +167,7 @@ def requireStrength (p : Params) (algorithm : Algorithm) : Except Error Unit :=
 /-- Checked Algorithm 23/25 message encoding. -/
 def encodeMessage (p : Params) (algorithm : Algorithm) (context message : List Byte) :
     Except Error (List Byte) := do
+  requireContext context
   requireStrength p algorithm
   encodePrehashMessageWithDescriptor algorithm.descriptor context message
 
@@ -174,6 +175,7 @@ def encodeMessage (p : Params) (algorithm : Algorithm) (context message : List B
 def signWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
     (algorithm : Algorithm) (message context : List Byte) (sk : SecretKeyCore prims.core)
     (addrnd : prims.Y) : Except Error (GeneralScheme.SignatureCore vp prims.core) := do
+  requireContext context
   requireStrength vp.params algorithm
   signPrehashWithDescriptorAndRandomizer vp prims algorithm.descriptor message context sk addrnd
 
@@ -182,6 +184,7 @@ def signDeterministic (vp : ValidatedParams) (prims : Primitives vp.params)
     (pkSeedToRandomizer : prims.PkSeed → prims.Y) (algorithm : Algorithm)
     (message context : List Byte) (sk : SecretKeyCore prims.core) :
     Except Error (GeneralScheme.SignatureCore vp prims.core) := do
+  requireContext context
   requireStrength vp.params algorithm
   signPrehashWithDescriptorDeterministic vp prims pkSeedToRandomizer algorithm.descriptor
     message context sk
@@ -191,17 +194,24 @@ noncomputable def sign (vp : ValidatedParams) (prims : Primitives vp.params)
     [SampleableType prims.Y] (algorithm : Algorithm) (message context : List Byte)
     (sk : SecretKeyCore prims.core) :
     ProbComp (Except Error (GeneralScheme.SignatureCore vp prims.core)) :=
-  match requireStrength vp.params algorithm with
+  match requireContext context with
   | .error error => pure (.error error)
-  | .ok _ => signPrehashWithDescriptor vp prims algorithm.descriptor message context sk
+  | .ok _ =>
+      match requireStrength vp.params algorithm with
+      | .error error => pure (.error error)
+      | .ok _ => signPrehashWithDescriptor vp prims algorithm.descriptor message context sk
 
 /-- Checked Algorithm 25. Weak pairings and message-boundary failures reject as `false`. -/
 def verify (vp : ValidatedParams) (prims : Primitives vp.params) [DecidableEq prims.Y]
     (algorithm : Algorithm) (message : List Byte)
     (signature : GeneralScheme.SignatureCore vp prims.core) (context : List Byte)
     (pk : PublicKeyCore prims.core) : Bool :=
-  match requireStrength vp.params algorithm with
+  match requireContext context with
   | .error _ => false
-  | .ok _ => verifyPrehashWithDescriptor vp prims algorithm.descriptor message signature context pk
+  | .ok _ =>
+      match requireStrength vp.params algorithm with
+      | .error _ => false
+      | .ok _ =>
+          verifyPrehashWithDescriptor vp prims algorithm.descriptor message signature context pk
 
 end SLHDSA.Concrete.Prehash

--- a/HashSig/SLHDSA/Concrete/Prehash.lean
+++ b/HashSig/SLHDSA/Concrete/Prehash.lean
@@ -8,6 +8,7 @@ module
 public import HashSig.SLHDSA.External
 public import HashSig.SLHDSA.Concrete.Sha2
 public import HashSig.SLHDSA.Concrete.Keccak
+public import HashSig.SLHDSA.Concrete.FIPS
 
 /-!
 # Checked FIPS 205 pre-hash adapter
@@ -16,6 +17,11 @@ This module closes the descriptor-parametric external semantics over the twelve 
 named by ACVP. An `Algorithm` determines the digest implementation, exact output width, and DER
 OID together. The public signing and verification entry points also enforce FIPS 205 §10.2's
 `2n`-byte collision-strength boundary.
+
+It also hosts the FIPS-pinned deterministic entry points (`signDeterministicApproved` and
+`signPureDeterministicApproved`), which bind the deterministic variants' `opt_rand` input to
+`PK.seed` via `SLHDSA.Concrete.approvedRandomizerOfPkSeed` as FIPS 205 Algorithm 19 line 2
+requires, together with sign→verify completeness theorems for the checked boundary.
 -/
 
 @[expose] public section
@@ -143,13 +149,23 @@ def digestBytesExact (n : ℕ) (digest : ByteArray) : Except Error (Bytes n) :=
   else
     .error (.digestLengthMismatch n digest.size)
 
-/-- Exact-width digest checked against the engine's advertised width. -/
+/-- Exact-width digest checked against the engine's advertised width through the fail-closed
+projection; `Algorithm.digest_eq_ok` shows the error branch is unreachable for the registry
+engines. -/
 def Algorithm.digest (algorithm : Algorithm) (message : List Byte) :
     Except Error (Bytes algorithm.outputLength) :=
-  .ok (Vector.ofFn fun i : Fin algorithm.outputLength =>
-    (algorithm.digestRaw message)[i.val]'(by
-      rw [algorithm.digestRaw_size message]
-      exact i.isLt))
+  digestBytesExact algorithm.outputLength (algorithm.digestRaw message)
+
+/-- Every registry digest engine meets its advertised exact width (`digestRaw_size`), so the
+checked digest succeeds on every message. -/
+theorem Algorithm.digest_eq_ok (algorithm : Algorithm) (message : List Byte) :
+    algorithm.digest message =
+      .ok (Vector.ofFn fun i : Fin algorithm.outputLength =>
+        (algorithm.digestRaw message)[i.val]'(by
+          rw [algorithm.digestRaw_size message]
+          exact i.isLt)) := by
+  unfold Algorithm.digest digestBytesExact
+  rw [dif_pos (algorithm.digestRaw_size message)]
 
 /-- Canonical binding of one registry entry's DER OID and digest implementation. -/
 def Algorithm.descriptor (algorithm : Algorithm) : PrehashDescriptor where
@@ -179,7 +195,10 @@ def signWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
   requireStrength vp.params algorithm
   signPrehashWithDescriptorAndRandomizer vp prims algorithm.descriptor message context sk addrnd
 
-/-- Checked deterministic Algorithm 23. -/
+/-- Checked deterministic Algorithm 23. FIPS 205 Algorithm 19 line 2 normatively sets
+`opt_rand = PK.seed`; FIPS-conforming callers must pass the canonical conversion for the
+selected approved family (`SLHDSA.Concrete.approvedRandomizerOfPkSeed`), or use the pinned
+entry point `signDeterministicApproved` which does so. -/
 def signDeterministic (vp : ValidatedParams) (prims : Primitives vp.params)
     (pkSeedToRandomizer : prims.PkSeed → prims.Y) (algorithm : Algorithm)
     (message context : List Byte) (sk : SecretKeyCore prims.core) :
@@ -214,4 +233,111 @@ def verify (vp : ValidatedParams) (prims : Primitives vp.params) [DecidableEq pr
       | .ok _ =>
           verifyPrehashWithDescriptor vp prims algorithm.descriptor message signature context pk
 
+/-! ## Checked completeness and boundary rejection -/
+
+/-- A registry algorithm meeting the §10.2 strength policy passes the checked boundary. -/
+theorem requireStrength_eq_ok (p : Params) (algorithm : Algorithm)
+    (h : algorithm.ValidFor p) : requireStrength p algorithm = .ok () :=
+  if_pos ((algorithm.validFor_iff p).mpr h)
+
+/-- **Checked pre-hash completeness** (Algorithms 21, 23, 25): under the FIPS 205 context
+bound and the §10.2 strength policy, checked pre-hash signing under an honestly generated key
+succeeds, and checked verification of the produced signature for the same message and context
+with the matching public key accepts. -/
+theorem verify_signWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
+    [DecidableEq prims.Y] (algorithm : Algorithm) (message context : List Byte)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) (addrnd : prims.Y)
+    (hcontext : context.length ≤ 255) (hstrength : algorithm.ValidFor vp.params) :
+    (signWithRandomizer vp prims algorithm message context
+        (keygenWithSeeds vp prims skSeed skPrf pkSeed).1 addrnd).map
+      (fun signature => verify vp prims algorithm message signature context
+        (keygenWithSeeds vp prims skSeed skPrf pkSeed).2) = .ok true := by
+  simp only [signWithRandomizer, verify, requireContext_eq_ok context hcontext,
+    requireStrength_eq_ok vp.params algorithm hstrength]
+  exact verifyPrehashWithDescriptor_signPrehashWithDescriptorAndRandomizer vp prims
+    algorithm.descriptor message context skSeed skPrf pkSeed addrnd hcontext
+    (algorithm.digest_eq_ok message)
+
+/-- Algorithm 25 lines 1--2: checked verification rejects an overlong context as `false` for
+every signature and public key, before the strength policy and before any hashing. -/
+theorem verify_eq_false_of_contextTooLong (vp : ValidatedParams)
+    (prims : Primitives vp.params) [DecidableEq prims.Y] (algorithm : Algorithm)
+    (message : List Byte) (signature : GeneralScheme.SignatureCore vp prims.core)
+    (context : List Byte) (pk : PublicKeyCore prims.core) (h : 255 < context.length) :
+    verify vp prims algorithm message signature context pk = false := by
+  unfold verify
+  rw [requireContext_eq_error context h]
+
+/-! ## FIPS-pinned deterministic entry point -/
+
+/-- Checked deterministic Algorithm 23 pinned to FIPS 205 Algorithm 19 line 2: `opt_rand` is
+`PK.seed` under `approvedRandomizerOfPkSeed`, in the exact approved primitive family selected
+by `approvedPrimitives`. FIPS-conforming deterministic pre-hash signing must use this entry
+point (or pass the same conversion to `signDeterministic` explicitly). -/
+def signDeterministicApproved (set : FipsParameterSet) (algorithm : Algorithm)
+    (message context : List Byte) (sk : SecretKeyCore (approvedPrimitives set).core) :
+    Except Error
+      (GeneralScheme.SignatureCore set.validatedParams (approvedPrimitives set).core) :=
+  signDeterministic set.validatedParams (approvedPrimitives set)
+    (approvedRandomizerOfPkSeed set) algorithm message context sk
+
+/-- Completeness of the pinned deterministic checked entry point: the honest key pair produced
+by Algorithm 21 round-trips through `signDeterministicApproved` and `verify`. -/
+theorem verify_signDeterministicApproved (set : FipsParameterSet)
+    [DecidableEq (approvedPrimitives set).Y] (algorithm : Algorithm)
+    (message context : List Byte) (skSeed : (approvedPrimitives set).SkSeed)
+    (skPrf : (approvedPrimitives set).SkPrf) (pkSeed : (approvedPrimitives set).PkSeed)
+    (hcontext : context.length ≤ 255) (hstrength : algorithm.ValidFor set.params) :
+    (signDeterministicApproved set algorithm message context
+        (keygenWithSeeds set.validatedParams (approvedPrimitives set)
+          skSeed skPrf pkSeed).1).map
+      (fun signature => verify set.validatedParams (approvedPrimitives set) algorithm message
+        signature context
+        (keygenWithSeeds set.validatedParams (approvedPrimitives set)
+          skSeed skPrf pkSeed).2) = .ok true :=
+  verify_signWithRandomizer set.validatedParams (approvedPrimitives set) algorithm message
+    context skSeed skPrf pkSeed
+    (approvedRandomizerOfPkSeed set
+      (keygenWithSeeds set.validatedParams (approvedPrimitives set)
+        skSeed skPrf pkSeed).1.pkSeed)
+    hcontext hstrength
+
 end SLHDSA.Concrete.Prehash
+
+namespace SLHDSA.Concrete
+
+/-! ## FIPS-pinned deterministic pure-mode entry point -/
+
+/-- Deterministic Algorithm 22 pinned to FIPS 205 Algorithm 19 line 2: `opt_rand` is `PK.seed`
+under `approvedRandomizerOfPkSeed`, in the exact approved primitive family selected by
+`approvedPrimitives`. FIPS-conforming deterministic pure-mode signing must use this entry
+point (or pass the same conversion to `External.signPureDeterministic` explicitly). -/
+def signPureDeterministicApproved (set : FipsParameterSet) (message context : List Byte)
+    (sk : SecretKeyCore (approvedPrimitives set).core) :
+    Except External.Error
+      (GeneralScheme.SignatureCore set.validatedParams (approvedPrimitives set).core) :=
+  External.signPureDeterministic set.validatedParams (approvedPrimitives set)
+    (approvedRandomizerOfPkSeed set) message context sk
+
+/-- Completeness of the pinned deterministic pure-mode entry point: the honest key pair
+produced by Algorithm 21 round-trips through `signPureDeterministicApproved` and
+`External.verifyPure`. -/
+theorem verifyPure_signPureDeterministicApproved (set : FipsParameterSet)
+    [DecidableEq (approvedPrimitives set).Y] (message context : List Byte)
+    (skSeed : (approvedPrimitives set).SkSeed) (skPrf : (approvedPrimitives set).SkPrf)
+    (pkSeed : (approvedPrimitives set).PkSeed) (hcontext : context.length ≤ 255) :
+    (signPureDeterministicApproved set message context
+        (External.keygenWithSeeds set.validatedParams (approvedPrimitives set)
+          skSeed skPrf pkSeed).1).map
+      (fun signature => External.verifyPure set.validatedParams (approvedPrimitives set)
+        message signature context
+        (External.keygenWithSeeds set.validatedParams (approvedPrimitives set)
+          skSeed skPrf pkSeed).2) = .ok true :=
+  External.verifyPure_signPureWithRandomizer set.validatedParams (approvedPrimitives set)
+    message context skSeed skPrf pkSeed
+    (approvedRandomizerOfPkSeed set
+      (External.keygenWithSeeds set.validatedParams (approvedPrimitives set)
+        skSeed skPrf pkSeed).1.pkSeed)
+    hcontext
+
+end SLHDSA.Concrete

--- a/HashSig/SLHDSA/External.lean
+++ b/HashSig/SLHDSA/External.lean
@@ -38,9 +38,12 @@ inductive Error where
   | digestLengthMismatch (expected actual : ℕ)
 deriving Repr, DecidableEq
 
-/-- Abstract pre-hash/OID binding used by the descriptor-parametric semantics. This is an
-extension boundary, not by itself an assertion that the pair is FIPS approved. Concrete FIPS
-adapters provide a closed algorithm registry and strength checks. -/
+/-- Abstract pre-hash/OID binding used by the descriptor-parametric semantics. This descriptor
+surface is an extension seam only: constructing a value is not by itself an assertion that the
+OID/digest pair is FIPS approved. The closed `SLHDSA.Concrete.Prehash.Algorithm` enumeration is
+the FIPS-approved registry; callers wanting FIPS conformance must use the enum entry points in
+`SLHDSA.Concrete.Prehash` (which also enforce the §10.2 strength policy) rather than
+instantiating descriptors directly. -/
 structure PrehashDescriptor where
   oidDer : List Byte
   outputLength : ℕ
@@ -53,6 +56,15 @@ def requireContext (context : List Byte) : Except Error Unit :=
   else
     .error (.contextTooLong context.length)
 
+/-- A context within the FIPS 205 255-byte bound passes the boundary check. -/
+theorem requireContext_eq_ok (context : List Byte) (h : context.length ≤ 255) :
+    requireContext context = .ok () := if_pos h
+
+/-- A context beyond the FIPS 205 255-byte bound is rejected with its observed length. -/
+theorem requireContext_eq_error (context : List Byte) (h : 255 < context.length) :
+    requireContext context = .error (.contextTooLong context.length) :=
+  if_neg (Nat.not_le.mpr h)
+
 /-- Common FIPS external-message encoder. Domain `0` denotes pure signing and domain `1`
 denotes pre-hash signing. -/
 def encodeMessage (domain : Byte) (context body : List Byte) : Except Error (List Byte) := do
@@ -63,6 +75,15 @@ def encodeMessage (domain : Byte) (context body : List Byte) : Except Error (Lis
 def encodePureMessage (context message : List Byte) : Except Error (List Byte) :=
   encodeMessage 0 context message
 
+/-- Under the context bound, the pure encoder is a deterministic total function of its inputs;
+in particular signing and verification compute the same `M'`. -/
+theorem encodePureMessage_eq_ok (context message : List Byte) (h : context.length ≤ 255) :
+    encodePureMessage context message =
+      .ok ([0, UInt8.ofNat context.length] ++ context ++ message) := by
+  unfold encodePureMessage encodeMessage
+  rw [requireContext_eq_ok context h]
+  rfl
+
 /-- Descriptor-parametric Algorithm 23/25 message input:
 `0x01 || toByte(|ctx|, 1) || ctx || OID || PH(M)`. FIPS-facing adapters must bind the descriptor
 to an approved algorithm and enforce the security-strength requirement. -/
@@ -71,6 +92,19 @@ def encodePrehashMessageWithDescriptor (prehash : PrehashDescriptor)
   requireContext context
   let digest ← prehash.digest message
   encodeMessage 1 context (prehash.oidDer ++ digest.toList)
+
+/-- Under the context bound and a successful descriptor digest, the pre-hash encoder is a
+deterministic total function of its inputs; in particular signing and verification compute the
+same `M'`. -/
+theorem encodePrehashMessageWithDescriptor_eq_ok (prehash : PrehashDescriptor)
+    (context message : List Byte) (h : context.length ≤ 255)
+    {digest : Bytes prehash.outputLength} (hdigest : prehash.digest message = .ok digest) :
+    encodePrehashMessageWithDescriptor prehash context message =
+      .ok ([1, UInt8.ofNat context.length] ++ context ++
+        (prehash.oidDer ++ digest.toList)) := by
+  unfold encodePrehashMessageWithDescriptor encodeMessage
+  rw [requireContext_eq_ok context h, hdigest]
+  rfl
 
 /-- Algorithm 21 after its approved random-bit generator has produced the three seeds. This
 explicit boundary is the deterministic entry point used by ACVP key-generation vectors. -/
@@ -97,8 +131,12 @@ def signPureWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
   let encoded ← encodePureMessage context message
   return GeneralScheme.signInternal vp prims encoded sk addrnd
 
-/-- Deterministic Algorithm 22. FIPS sets `opt_rand = PK.seed`; the conversion is explicit
-because the proof-level primitive interface deliberately keeps `PkSeed` and `Y` independent. -/
+/-- Deterministic Algorithm 22. FIPS 205 Algorithm 19 line 2 normatively sets
+`opt_rand = PK.seed`; the conversion is an explicit parameter only because the proof-level
+primitive interface deliberately keeps `PkSeed` and `Y` independent. FIPS-conforming callers
+must pass the canonical conversion for the selected approved family
+(`SLHDSA.Concrete.approvedRandomizerOfPkSeed`), or use the pinned entry point
+`SLHDSA.Concrete.signPureDeterministicApproved` which does so. -/
 def signPureDeterministic (vp : ValidatedParams) (prims : Primitives vp.params)
     (pkSeedToRandomizer : prims.PkSeed → prims.Y) (message context : List Byte)
     (sk : SecretKeyCore prims.core) :
@@ -123,7 +161,10 @@ def signPrehashWithDescriptorAndRandomizer (vp : ValidatedParams)
   let encoded ← encodePrehashMessageWithDescriptor prehash context message
   return GeneralScheme.signInternal vp prims encoded sk addrnd
 
-/-- Deterministic descriptor-parametric Algorithm 23 core. -/
+/-- Deterministic descriptor-parametric Algorithm 23 core. FIPS 205 Algorithm 19 line 2
+normatively sets `opt_rand = PK.seed`; FIPS-conforming callers must pass the canonical
+conversion (`SLHDSA.Concrete.approvedRandomizerOfPkSeed`), or use the pinned checked entry
+point `SLHDSA.Concrete.Prehash.signDeterministicApproved` which does so. -/
 def signPrehashWithDescriptorDeterministic (vp : ValidatedParams)
     (prims : Primitives vp.params) (pkSeedToRandomizer : prims.PkSeed → prims.Y)
     (prehash : PrehashDescriptor)
@@ -161,5 +202,70 @@ def verifyPrehashWithDescriptor (vp : ValidatedParams) (prims : Primitives vp.pa
   match encodePrehashMessageWithDescriptor prehash context message with
   | .error _ => false
   | .ok encoded => GeneralScheme.verifyInternal vp prims encoded signature pk
+
+/-! ## External completeness and boundary rejection
+
+Signing and verification encode `M'` with the same deterministic encoder, so the external
+sign→verify round trips are corollaries of the internal completeness theorem
+`GeneralScheme.verifyInternal_signInternal`.  Both statements quantify over an arbitrary
+hedging randomizer, covering the hedged and the deterministic (`opt_rand = PK.seed`) variants
+at once. -/
+
+/-- **External pure completeness** (Algorithms 21, 22, 24): under the FIPS 205 context bound,
+pure-mode signing under an honestly generated key succeeds, and verifying the produced
+signature for the same message and context with the matching public key accepts. -/
+theorem verifyPure_signPureWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
+    [DecidableEq prims.Y] (message context : List Byte)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) (addrnd : prims.Y)
+    (hcontext : context.length ≤ 255) :
+    (signPureWithRandomizer vp prims message context
+        (keygenWithSeeds vp prims skSeed skPrf pkSeed).1 addrnd).map
+      (fun signature => verifyPure vp prims message signature context
+        (keygenWithSeeds vp prims skSeed skPrf pkSeed).2) = .ok true := by
+  simp only [signPureWithRandomizer, verifyPure,
+    encodePureMessage_eq_ok context message hcontext]
+  exact congrArg Except.ok
+    (GeneralScheme.verifyInternal_signInternal vp prims _ skSeed skPrf pkSeed addrnd)
+
+/-- **External pre-hash completeness** (Algorithms 21, 23, 25): under the FIPS 205 context
+bound and a successful descriptor digest, pre-hash signing under an honestly generated key
+succeeds, and verifying the produced signature for the same message and context with the
+matching public key accepts. -/
+theorem verifyPrehashWithDescriptor_signPrehashWithDescriptorAndRandomizer
+    (vp : ValidatedParams) (prims : Primitives vp.params) [DecidableEq prims.Y]
+    (prehash : PrehashDescriptor) (message context : List Byte)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) (addrnd : prims.Y)
+    (hcontext : context.length ≤ 255)
+    {digest : Bytes prehash.outputLength} (hdigest : prehash.digest message = .ok digest) :
+    (signPrehashWithDescriptorAndRandomizer vp prims prehash message context
+        (keygenWithSeeds vp prims skSeed skPrf pkSeed).1 addrnd).map
+      (fun signature => verifyPrehashWithDescriptor vp prims prehash message signature context
+        (keygenWithSeeds vp prims skSeed skPrf pkSeed).2) = .ok true := by
+  simp only [signPrehashWithDescriptorAndRandomizer, verifyPrehashWithDescriptor,
+    encodePrehashMessageWithDescriptor_eq_ok prehash context message hcontext hdigest]
+  exact congrArg Except.ok
+    (GeneralScheme.verifyInternal_signInternal vp prims _ skSeed skPrf pkSeed addrnd)
+
+/-- Algorithm 24 lines 1--2: pure verification rejects an overlong context as `false` for
+every signature and public key, before any hashing. -/
+theorem verifyPure_eq_false_of_contextTooLong (vp : ValidatedParams)
+    (prims : Primitives vp.params) [DecidableEq prims.Y] (message : List Byte)
+    (signature : GeneralScheme.SignatureCore vp prims.core) (context : List Byte)
+    (pk : PublicKeyCore prims.core) (h : 255 < context.length) :
+    verifyPure vp prims message signature context pk = false := by
+  unfold verifyPure encodePureMessage encodeMessage
+  rw [requireContext_eq_error context h]
+  rfl
+
+/-- Algorithm 25 lines 1--2: pre-hash verification rejects an overlong context as `false` for
+every signature and public key, before evaluating the pre-hash. -/
+theorem verifyPrehashWithDescriptor_eq_false_of_contextTooLong (vp : ValidatedParams)
+    (prims : Primitives vp.params) [DecidableEq prims.Y] (prehash : PrehashDescriptor)
+    (message : List Byte) (signature : GeneralScheme.SignatureCore vp prims.core)
+    (context : List Byte) (pk : PublicKeyCore prims.core) (h : 255 < context.length) :
+    verifyPrehashWithDescriptor vp prims prehash message signature context pk = false := by
+  unfold verifyPrehashWithDescriptor encodePrehashMessageWithDescriptor
+  rw [requireContext_eq_error context h]
+  rfl
 
 end SLHDSA.External

--- a/HashSig/SLHDSA/External.lean
+++ b/HashSig/SLHDSA/External.lean
@@ -6,6 +6,8 @@ Authors: Quang Dao
 
 module
 public import HashSig.SLHDSA.GeneralScheme
+public import HashSig.SLHDSA.Concrete.Sha2
+public import HashSig.SLHDSA.Concrete.Keccak
 public import VCVio.OracleComp.Constructions.SampleableType
 
 /-!
@@ -27,6 +29,7 @@ boundary exposed here.
 namespace SLHDSA.External
 
 open OracleComp
+open Concrete
 
 /-- Failures rejected at the FIPS external-message boundary. -/
 inductive Error where
@@ -41,6 +44,114 @@ structure PrehashDescriptor where
   oidDer : List Byte
   outputLength : ℕ
   digest : List Byte → Bytes outputLength
+
+/-- The complete pre-hash algorithm menu accepted by the FIPS 205 ACVP external interface.
+SHAKE128 is squeezed to 256 bits and SHAKE256 to 512 bits, as required by Algorithm 23. -/
+inductive PrehashAlgorithm where
+  | sha2_224
+  | sha2_256
+  | sha2_384
+  | sha2_512
+  | sha2_512_224
+  | sha2_512_256
+  | sha3_224
+  | sha3_256
+  | sha3_384
+  | sha3_512
+  | shake128
+  | shake256
+deriving Repr, DecidableEq, BEq
+
+/-- Every approved pre-hash algorithm, in the ACVP registration order. -/
+def allPrehashAlgorithms : List PrehashAlgorithm :=
+  [.sha2_224, .sha2_256, .sha2_384, .sha2_512, .sha2_512_224, .sha2_512_256,
+    .sha3_224, .sha3_256, .sha3_384, .sha3_512, .shake128, .shake256]
+
+/-- ACVP spelling of an approved pre-hash algorithm. -/
+def PrehashAlgorithm.name : PrehashAlgorithm → String
+  | .sha2_224 => "SHA2-224"
+  | .sha2_256 => "SHA2-256"
+  | .sha2_384 => "SHA2-384"
+  | .sha2_512 => "SHA2-512"
+  | .sha2_512_224 => "SHA2-512/224"
+  | .sha2_512_256 => "SHA2-512/256"
+  | .sha3_224 => "SHA3-224"
+  | .sha3_256 => "SHA3-256"
+  | .sha3_384 => "SHA3-384"
+  | .sha3_512 => "SHA3-512"
+  | .shake128 => "SHAKE-128"
+  | .shake256 => "SHAKE-256"
+
+/-- Parse the exact ACVP spelling of an approved pre-hash algorithm. -/
+def PrehashAlgorithm.ofName? : String → Option PrehashAlgorithm
+  | "SHA2-224" => some .sha2_224
+  | "SHA2-256" => some .sha2_256
+  | "SHA2-384" => some .sha2_384
+  | "SHA2-512" => some .sha2_512
+  | "SHA2-512/224" => some .sha2_512_224
+  | "SHA2-512/256" => some .sha2_512_256
+  | "SHA3-224" => some .sha3_224
+  | "SHA3-256" => some .sha3_256
+  | "SHA3-384" => some .sha3_384
+  | "SHA3-512" => some .sha3_512
+  | "SHAKE-128" => some .shake128
+  | "SHAKE-256" => some .shake256
+  | _ => none
+
+@[simp] theorem PrehashAlgorithm.ofName?_name (algorithm : PrehashAlgorithm) :
+    PrehashAlgorithm.ofName? algorithm.name = some algorithm := by
+  cases algorithm <;> rfl
+
+/-- Digest widths fixed by FIPS 180-4/FIPS 202 and the FIPS 205 SHAKE choices. -/
+def PrehashAlgorithm.outputLength : PrehashAlgorithm → ℕ
+  | .sha2_224 | .sha2_512_224 | .sha3_224 => 28
+  | .sha2_256 | .sha2_512_256 | .sha3_256 | .shake128 => 32
+  | .sha2_384 | .sha3_384 => 48
+  | .sha2_512 | .sha3_512 | .shake256 => 64
+
+/-- Complete DER encoding of the NIST hash-algorithm object identifier (`hashAlgs` arcs 1–12). -/
+def PrehashAlgorithm.oidDer : PrehashAlgorithm → List Byte
+  | .sha2_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01]
+  | .sha2_384 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02]
+  | .sha2_512 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03]
+  | .sha2_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04]
+  | .sha2_512_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x05]
+  | .sha2_512_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x06]
+  | .sha3_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x07]
+  | .sha3_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x08]
+  | .sha3_384 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x09]
+  | .sha3_512 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0a]
+  | .shake128 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0b]
+  | .shake256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0c]
+
+/-- Project an exact-width digest engine into its intrinsic byte-vector boundary. Each approved
+engine below has the corresponding fixed output width; executable KATs pin that invariant. -/
+def digestBytes (n : ℕ) (digest : ByteArray) : Bytes n :=
+  Vector.ofFn fun i : Fin n => digest[i.val]?.getD 0
+
+/-- The concrete, FFI-free digest for an approved pre-hash algorithm. -/
+def PrehashAlgorithm.digest (algorithm : PrehashAlgorithm) (message : List Byte) :
+    Bytes algorithm.outputLength :=
+  let input := ByteArray.mk message.toArray
+  match algorithm with
+  | .sha2_224 => digestBytes 28 (Sha2.sha224 input)
+  | .sha2_256 => digestBytes 32 (Sha2.sha256 input)
+  | .sha2_384 => digestBytes 48 (Sha2.sha384 input)
+  | .sha2_512 => digestBytes 64 (Sha2.sha512 input)
+  | .sha2_512_224 => digestBytes 28 (Sha2.sha512_224 input)
+  | .sha2_512_256 => digestBytes 32 (Sha2.sha512_256 input)
+  | .sha3_224 => digestBytes 28 (Keccak.sha3_224 input)
+  | .sha3_256 => digestBytes 32 (Keccak.sha3_256 input)
+  | .sha3_384 => digestBytes 48 (Keccak.sha3_384 input)
+  | .sha3_512 => digestBytes 64 (Keccak.sha3_512 input)
+  | .shake128 => digestBytes 32 (Keccak.shake128 input 32)
+  | .shake256 => digestBytes 64 (Keccak.shake256 input 64)
+
+/-- Canonical FIPS descriptor for an approved pre-hash algorithm. -/
+def PrehashAlgorithm.descriptor (algorithm : PrehashAlgorithm) : PrehashDescriptor where
+  oidDer := algorithm.oidDer
+  outputLength := algorithm.outputLength
+  digest := algorithm.digest
 
 /-- Common FIPS external-message encoder. Domain `0` denotes pure signing and domain `1`
 denotes pre-hash signing. -/

--- a/HashSig/SLHDSA/External.lean
+++ b/HashSig/SLHDSA/External.lean
@@ -6,8 +6,6 @@ Authors: Quang Dao
 
 module
 public import HashSig.SLHDSA.GeneralScheme
-public import HashSig.SLHDSA.Concrete.Sha2
-public import HashSig.SLHDSA.Concrete.Keccak
 public import VCVio.OracleComp.Constructions.SampleableType
 
 /-!
@@ -29,129 +27,24 @@ boundary exposed here.
 namespace SLHDSA.External
 
 open OracleComp
-open Concrete
 
 /-- Failures rejected at the FIPS external-message boundary. -/
 inductive Error where
   /-- FIPS 205 limits the context string to at most 255 bytes. -/
   | contextTooLong (actual : ℕ)
+  /-- FIPS 205 requires at least `2n` digest bytes for the claimed SLH-DSA security strength. -/
+  | prehashTooWeak (n digestBytes : ℕ)
+  /-- A built-in digest engine violated its advertised exact output width. -/
+  | digestLengthMismatch (expected actual : ℕ)
 deriving Repr, DecidableEq
 
-/-- A pre-hash function together with the complete DER encoding of its object identifier.
-The output width is intrinsic, so the encoded pre-hash message cannot disagree with the
-descriptor's declared digest length. -/
+/-- Abstract pre-hash/OID binding used by the descriptor-parametric semantics. This is an
+extension boundary, not by itself an assertion that the pair is FIPS approved. Concrete FIPS
+adapters provide a closed algorithm registry and strength checks. -/
 structure PrehashDescriptor where
   oidDer : List Byte
   outputLength : ℕ
-  digest : List Byte → Bytes outputLength
-
-/-- The complete pre-hash algorithm menu accepted by the FIPS 205 ACVP external interface.
-SHAKE128 is squeezed to 256 bits and SHAKE256 to 512 bits, as required by Algorithm 23. -/
-inductive PrehashAlgorithm where
-  | sha2_224
-  | sha2_256
-  | sha2_384
-  | sha2_512
-  | sha2_512_224
-  | sha2_512_256
-  | sha3_224
-  | sha3_256
-  | sha3_384
-  | sha3_512
-  | shake128
-  | shake256
-deriving Repr, DecidableEq, BEq
-
-/-- Every approved pre-hash algorithm, in the ACVP registration order. -/
-def allPrehashAlgorithms : List PrehashAlgorithm :=
-  [.sha2_224, .sha2_256, .sha2_384, .sha2_512, .sha2_512_224, .sha2_512_256,
-    .sha3_224, .sha3_256, .sha3_384, .sha3_512, .shake128, .shake256]
-
-/-- ACVP spelling of an approved pre-hash algorithm. -/
-def PrehashAlgorithm.name : PrehashAlgorithm → String
-  | .sha2_224 => "SHA2-224"
-  | .sha2_256 => "SHA2-256"
-  | .sha2_384 => "SHA2-384"
-  | .sha2_512 => "SHA2-512"
-  | .sha2_512_224 => "SHA2-512/224"
-  | .sha2_512_256 => "SHA2-512/256"
-  | .sha3_224 => "SHA3-224"
-  | .sha3_256 => "SHA3-256"
-  | .sha3_384 => "SHA3-384"
-  | .sha3_512 => "SHA3-512"
-  | .shake128 => "SHAKE-128"
-  | .shake256 => "SHAKE-256"
-
-/-- Parse the exact ACVP spelling of an approved pre-hash algorithm. -/
-def PrehashAlgorithm.ofName? : String → Option PrehashAlgorithm
-  | "SHA2-224" => some .sha2_224
-  | "SHA2-256" => some .sha2_256
-  | "SHA2-384" => some .sha2_384
-  | "SHA2-512" => some .sha2_512
-  | "SHA2-512/224" => some .sha2_512_224
-  | "SHA2-512/256" => some .sha2_512_256
-  | "SHA3-224" => some .sha3_224
-  | "SHA3-256" => some .sha3_256
-  | "SHA3-384" => some .sha3_384
-  | "SHA3-512" => some .sha3_512
-  | "SHAKE-128" => some .shake128
-  | "SHAKE-256" => some .shake256
-  | _ => none
-
-@[simp] theorem PrehashAlgorithm.ofName?_name (algorithm : PrehashAlgorithm) :
-    PrehashAlgorithm.ofName? algorithm.name = some algorithm := by
-  cases algorithm <;> rfl
-
-/-- Digest widths fixed by FIPS 180-4/FIPS 202 and the FIPS 205 SHAKE choices. -/
-def PrehashAlgorithm.outputLength : PrehashAlgorithm → ℕ
-  | .sha2_224 | .sha2_512_224 | .sha3_224 => 28
-  | .sha2_256 | .sha2_512_256 | .sha3_256 | .shake128 => 32
-  | .sha2_384 | .sha3_384 => 48
-  | .sha2_512 | .sha3_512 | .shake256 => 64
-
-/-- Complete DER encoding of the NIST hash-algorithm object identifier (`hashAlgs` arcs 1–12). -/
-def PrehashAlgorithm.oidDer : PrehashAlgorithm → List Byte
-  | .sha2_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01]
-  | .sha2_384 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02]
-  | .sha2_512 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03]
-  | .sha2_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04]
-  | .sha2_512_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x05]
-  | .sha2_512_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x06]
-  | .sha3_224 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x07]
-  | .sha3_256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x08]
-  | .sha3_384 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x09]
-  | .sha3_512 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0a]
-  | .shake128 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0b]
-  | .shake256 => [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0c]
-
-/-- Project an exact-width digest engine into its intrinsic byte-vector boundary. Each approved
-engine below has the corresponding fixed output width; executable KATs pin that invariant. -/
-def digestBytes (n : ℕ) (digest : ByteArray) : Bytes n :=
-  Vector.ofFn fun i : Fin n => digest[i.val]?.getD 0
-
-/-- The concrete, FFI-free digest for an approved pre-hash algorithm. -/
-def PrehashAlgorithm.digest (algorithm : PrehashAlgorithm) (message : List Byte) :
-    Bytes algorithm.outputLength :=
-  let input := ByteArray.mk message.toArray
-  match algorithm with
-  | .sha2_224 => digestBytes 28 (Sha2.sha224 input)
-  | .sha2_256 => digestBytes 32 (Sha2.sha256 input)
-  | .sha2_384 => digestBytes 48 (Sha2.sha384 input)
-  | .sha2_512 => digestBytes 64 (Sha2.sha512 input)
-  | .sha2_512_224 => digestBytes 28 (Sha2.sha512_224 input)
-  | .sha2_512_256 => digestBytes 32 (Sha2.sha512_256 input)
-  | .sha3_224 => digestBytes 28 (Keccak.sha3_224 input)
-  | .sha3_256 => digestBytes 32 (Keccak.sha3_256 input)
-  | .sha3_384 => digestBytes 48 (Keccak.sha3_384 input)
-  | .sha3_512 => digestBytes 64 (Keccak.sha3_512 input)
-  | .shake128 => digestBytes 32 (Keccak.shake128 input 32)
-  | .shake256 => digestBytes 64 (Keccak.shake256 input 64)
-
-/-- Canonical FIPS descriptor for an approved pre-hash algorithm. -/
-def PrehashAlgorithm.descriptor (algorithm : PrehashAlgorithm) : PrehashDescriptor where
-  oidDer := algorithm.oidDer
-  outputLength := algorithm.outputLength
-  digest := algorithm.digest
+  digest : List Byte → Except Error (Bytes outputLength)
 
 /-- Common FIPS external-message encoder. Domain `0` denotes pure signing and domain `1`
 denotes pre-hash signing. -/
@@ -165,11 +58,13 @@ def encodeMessage (domain : Byte) (context body : List Byte) : Except Error (Lis
 def encodePureMessage (context message : List Byte) : Except Error (List Byte) :=
   encodeMessage 0 context message
 
-/-- Algorithm 23/25 message input:
-`0x01 || toByte(|ctx|, 1) || ctx || OID || PH(M)`. -/
-def encodePrehashMessage (prehash : PrehashDescriptor) (context message : List Byte) :
-    Except Error (List Byte) :=
-  encodeMessage 1 context (prehash.oidDer ++ (prehash.digest message).toList)
+/-- Descriptor-parametric Algorithm 23/25 message input:
+`0x01 || toByte(|ctx|, 1) || ctx || OID || PH(M)`. FIPS-facing adapters must bind the descriptor
+to an approved algorithm and enforce the security-strength requirement. -/
+def encodePrehashMessageWithDescriptor (prehash : PrehashDescriptor)
+    (context message : List Byte) : Except Error (List Byte) := do
+  let digest ← prehash.digest message
+  encodeMessage 1 context (prehash.oidDer ++ digest.toList)
 
 /-- Algorithm 21 after its approved random-bit generator has produced the three seeds. This
 explicit boundary is the deterministic entry point used by ACVP key-generation vectors. -/
@@ -213,28 +108,30 @@ noncomputable def signPure (vp : ValidatedParams) (prims : Primitives vp.params)
       let addrnd ← $ᵗ prims.Y
       pure (.ok (GeneralScheme.signInternal vp prims encoded sk addrnd))
 
-/-- Algorithm 23 with caller-supplied hedging randomness. -/
-def signPrehashWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
-    (prehash : PrehashDescriptor) (message context : List Byte)
+/-- Descriptor-parametric Algorithm 23 core with caller-supplied hedging randomness. -/
+def signPrehashWithDescriptorAndRandomizer (vp : ValidatedParams)
+    (prims : Primitives vp.params) (prehash : PrehashDescriptor) (message context : List Byte)
     (sk : SecretKeyCore prims.core) (addrnd : prims.Y) :
     Except Error (GeneralScheme.SignatureCore vp prims.core) := do
-  let encoded ← encodePrehashMessage prehash context message
+  let encoded ← encodePrehashMessageWithDescriptor prehash context message
   return GeneralScheme.signInternal vp prims encoded sk addrnd
 
-/-- Deterministic Algorithm 23 with explicit `PK.seed`-to-node conversion. -/
-def signPrehashDeterministic (vp : ValidatedParams) (prims : Primitives vp.params)
-    (pkSeedToRandomizer : prims.PkSeed → prims.Y) (prehash : PrehashDescriptor)
+/-- Deterministic descriptor-parametric Algorithm 23 core. -/
+def signPrehashWithDescriptorDeterministic (vp : ValidatedParams)
+    (prims : Primitives vp.params) (pkSeedToRandomizer : prims.PkSeed → prims.Y)
+    (prehash : PrehashDescriptor)
     (message context : List Byte) (sk : SecretKeyCore prims.core) :
     Except Error (GeneralScheme.SignatureCore vp prims.core) :=
-  signPrehashWithRandomizer vp prims prehash message context sk
+  signPrehashWithDescriptorAndRandomizer vp prims prehash message context sk
     (pkSeedToRandomizer sk.pkSeed)
 
-/-- Default hedged Algorithm 23 under the repository's ideal total random source. -/
-noncomputable def signPrehash (vp : ValidatedParams) (prims : Primitives vp.params)
-    [SampleableType prims.Y] (prehash : PrehashDescriptor) (message context : List Byte)
+/-- Descriptor-parametric hedged Algorithm 23 core under the ideal total random source. -/
+noncomputable def signPrehashWithDescriptor (vp : ValidatedParams)
+    (prims : Primitives vp.params) [SampleableType prims.Y] (prehash : PrehashDescriptor)
+    (message context : List Byte)
     (sk : SecretKeyCore prims.core) :
     ProbComp (Except Error (GeneralScheme.SignatureCore vp prims.core)) :=
-  match encodePrehashMessage prehash context message with
+  match encodePrehashMessageWithDescriptor prehash context message with
   | .error error => pure (.error error)
   | .ok encoded => do
       let addrnd ← $ᵗ prims.Y
@@ -249,12 +146,12 @@ def verifyPure (vp : ValidatedParams) (prims : Primitives vp.params)
   | .error _ => false
   | .ok encoded => GeneralScheme.verifyInternal vp prims encoded signature pk
 
-/-- Algorithm 25. An overlong context is rejected as `false`. -/
-def verifyPrehash (vp : ValidatedParams) (prims : Primitives vp.params)
+/-- Descriptor-parametric Algorithm 25 core. An overlong context or digest failure is rejected. -/
+def verifyPrehashWithDescriptor (vp : ValidatedParams) (prims : Primitives vp.params)
     [DecidableEq prims.Y] (prehash : PrehashDescriptor) (message : List Byte)
     (signature : GeneralScheme.SignatureCore vp prims.core) (context : List Byte)
     (pk : PublicKeyCore prims.core) : Bool :=
-  match encodePrehashMessage prehash context message with
+  match encodePrehashMessageWithDescriptor prehash context message with
   | .error _ => false
   | .ok encoded => GeneralScheme.verifyInternal vp prims encoded signature pk
 

--- a/HashSig/SLHDSA/External.lean
+++ b/HashSig/SLHDSA/External.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.GeneralScheme
+public import VCVio.OracleComp.Constructions.UniformSelect
+
+/-!
+# SLH-DSA external interfaces
+
+The pure and pre-hash message encodings and the external key-generation, signing, and
+verification interfaces from FIPS 205 Algorithms 21--25. The randomized definitions use the
+repository's ideal, total `SampleableType` source. An implementation whose random-bit generator
+can fail must translate that failure before calling the explicit-seed or explicit-randomizer
+boundary exposed here.
+
+## References
+
+- NIST FIPS 205, Section 10, Algorithms 21--25
+-/
+
+@[expose] public section
+
+namespace SLHDSA.External
+
+open OracleComp
+
+/-- Failures rejected at the FIPS external-message boundary. -/
+inductive Error where
+  /-- FIPS 205 limits the context string to at most 255 bytes. -/
+  | contextTooLong (actual : ℕ)
+deriving Repr, DecidableEq
+
+/-- A pre-hash function together with the complete DER encoding of its object identifier.
+The output width is intrinsic, so the encoded pre-hash message cannot disagree with the
+descriptor's declared digest length. -/
+structure PrehashDescriptor where
+  oidDer : List Byte
+  outputLength : ℕ
+  digest : List Byte → Bytes outputLength
+
+/-- Common FIPS external-message encoder. Domain `0` denotes pure signing and domain `1`
+denotes pre-hash signing. -/
+def encodeMessage (domain : Byte) (context body : List Byte) : Except Error (List Byte) :=
+  if context.length ≤ 255 then
+    .ok ([domain, UInt8.ofNat context.length] ++ context ++ body)
+  else
+    .error (.contextTooLong context.length)
+
+/-- Algorithm 22/24 message input: `0x00 || toByte(|ctx|, 1) || ctx || M`. -/
+def encodePureMessage (context message : List Byte) : Except Error (List Byte) :=
+  encodeMessage 0 context message
+
+/-- Algorithm 23/25 message input:
+`0x01 || toByte(|ctx|, 1) || ctx || OID || PH(M)`. -/
+def encodePrehashMessage (prehash : PrehashDescriptor) (context message : List Byte) :
+    Except Error (List Byte) :=
+  encodeMessage 1 context (prehash.oidDer ++ (prehash.digest message).toList)
+
+/-- Algorithm 21 after its approved random-bit generator has produced the three seeds. This
+explicit boundary is the deterministic entry point used by ACVP key-generation vectors. -/
+def keygenWithSeeds (vp : ValidatedParams) (prims : Primitives vp.params)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) :
+    PublicKeyCore prims.core × SecretKeyCore prims.core :=
+  GeneralScheme.keygenInternal vp prims skSeed skPrf pkSeed
+
+/-- Algorithm 21 under the repository's ideal total random source. -/
+noncomputable def keygen (vp : ValidatedParams) (prims : Primitives vp.params)
+    [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+    [SampleableType prims.PkSeed] :
+    ProbComp (PublicKeyCore prims.core × SecretKeyCore prims.core) := do
+  let skSeed ← $ᵗ prims.SkSeed
+  let skPrf ← $ᵗ prims.SkPrf
+  let pkSeed ← $ᵗ prims.PkSeed
+  pure (keygenWithSeeds vp prims skSeed skPrf pkSeed)
+
+/-- Algorithm 22 with caller-supplied hedging randomness. -/
+def signPureWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
+    (message context : List Byte) (sk : SecretKeyCore prims.core) (addrnd : prims.Y) :
+    Except Error (GeneralScheme.SignatureCore vp prims.core) := do
+  let encoded ← encodePureMessage context message
+  return GeneralScheme.signInternal vp prims encoded sk addrnd
+
+/-- Deterministic Algorithm 22. FIPS sets `opt_rand = PK.seed`; the conversion is explicit
+because the proof-level primitive interface deliberately keeps `PkSeed` and `Y` independent. -/
+def signPureDeterministic (vp : ValidatedParams) (prims : Primitives vp.params)
+    (pkSeedToRandomizer : prims.PkSeed → prims.Y) (message context : List Byte)
+    (sk : SecretKeyCore prims.core) :
+    Except Error (GeneralScheme.SignatureCore vp prims.core) :=
+  signPureWithRandomizer vp prims message context sk (pkSeedToRandomizer sk.pkSeed)
+
+/-- Default hedged Algorithm 22 under the repository's ideal total random source. -/
+noncomputable def signPure (vp : ValidatedParams) (prims : Primitives vp.params)
+    [SampleableType prims.Y] (message context : List Byte) (sk : SecretKeyCore prims.core) :
+    ProbComp (Except Error (GeneralScheme.SignatureCore vp prims.core)) :=
+  match encodePureMessage context message with
+  | .error error => pure (.error error)
+  | .ok encoded => do
+      let addrnd ← $ᵗ prims.Y
+      pure (.ok (GeneralScheme.signInternal vp prims encoded sk addrnd))
+
+/-- Algorithm 23 with caller-supplied hedging randomness. -/
+def signPrehashWithRandomizer (vp : ValidatedParams) (prims : Primitives vp.params)
+    (prehash : PrehashDescriptor) (message context : List Byte)
+    (sk : SecretKeyCore prims.core) (addrnd : prims.Y) :
+    Except Error (GeneralScheme.SignatureCore vp prims.core) := do
+  let encoded ← encodePrehashMessage prehash context message
+  return GeneralScheme.signInternal vp prims encoded sk addrnd
+
+/-- Deterministic Algorithm 23 with explicit `PK.seed`-to-node conversion. -/
+def signPrehashDeterministic (vp : ValidatedParams) (prims : Primitives vp.params)
+    (pkSeedToRandomizer : prims.PkSeed → prims.Y) (prehash : PrehashDescriptor)
+    (message context : List Byte) (sk : SecretKeyCore prims.core) :
+    Except Error (GeneralScheme.SignatureCore vp prims.core) :=
+  signPrehashWithRandomizer vp prims prehash message context sk
+    (pkSeedToRandomizer sk.pkSeed)
+
+/-- Default hedged Algorithm 23 under the repository's ideal total random source. -/
+noncomputable def signPrehash (vp : ValidatedParams) (prims : Primitives vp.params)
+    [SampleableType prims.Y] (prehash : PrehashDescriptor) (message context : List Byte)
+    (sk : SecretKeyCore prims.core) :
+    ProbComp (Except Error (GeneralScheme.SignatureCore vp prims.core)) :=
+  match encodePrehashMessage prehash context message with
+  | .error error => pure (.error error)
+  | .ok encoded => do
+      let addrnd ← $ᵗ prims.Y
+      pure (.ok (GeneralScheme.signInternal vp prims encoded sk addrnd))
+
+/-- Algorithm 24. An overlong context is rejected as `false`. -/
+def verifyPure (vp : ValidatedParams) (prims : Primitives vp.params)
+    [DecidableEq prims.Y] (message : List Byte)
+    (signature : GeneralScheme.SignatureCore vp prims.core) (context : List Byte)
+    (pk : PublicKeyCore prims.core) : Bool :=
+  match encodePureMessage context message with
+  | .error _ => false
+  | .ok encoded => GeneralScheme.verifyInternal vp prims encoded signature pk
+
+/-- Algorithm 25. An overlong context is rejected as `false`. -/
+def verifyPrehash (vp : ValidatedParams) (prims : Primitives vp.params)
+    [DecidableEq prims.Y] (prehash : PrehashDescriptor) (message : List Byte)
+    (signature : GeneralScheme.SignatureCore vp prims.core) (context : List Byte)
+    (pk : PublicKeyCore prims.core) : Bool :=
+  match encodePrehashMessage prehash context message with
+  | .error _ => false
+  | .ok encoded => GeneralScheme.verifyInternal vp prims encoded signature pk
+
+end SLHDSA.External

--- a/HashSig/SLHDSA/External.lean
+++ b/HashSig/SLHDSA/External.lean
@@ -76,14 +76,15 @@ def encodePrehashMessageWithDescriptor (prehash : PrehashDescriptor)
 explicit boundary is the deterministic entry point used by ACVP key-generation vectors. -/
 def keygenWithSeeds (vp : ValidatedParams) (prims : Primitives vp.params)
     (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) :
-    PublicKeyCore prims.core × SecretKeyCore prims.core :=
-  GeneralScheme.keygenInternal vp prims skSeed skPrf pkSeed
+    SecretKeyCore prims.core × PublicKeyCore prims.core :=
+  let (pk, sk) := GeneralScheme.keygenInternal vp prims skSeed skPrf pkSeed
+  (sk, pk)
 
 /-- Algorithm 21 under the repository's ideal total random source. -/
 noncomputable def keygen (vp : ValidatedParams) (prims : Primitives vp.params)
     [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
     [SampleableType prims.PkSeed] :
-    ProbComp (PublicKeyCore prims.core × SecretKeyCore prims.core) := do
+    ProbComp (SecretKeyCore prims.core × PublicKeyCore prims.core) := do
   let skSeed ← $ᵗ prims.SkSeed
   let skPrf ← $ᵗ prims.SkPrf
   let pkSeed ← $ᵗ prims.PkSeed

--- a/HashSig/SLHDSA/External.lean
+++ b/HashSig/SLHDSA/External.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 
 module
 public import HashSig.SLHDSA.GeneralScheme
-public import VCVio.OracleComp.Constructions.UniformSelect
+public import VCVio.OracleComp.Constructions.SampleableType
 
 /-!
 # SLH-DSA external interfaces

--- a/HashSig/SLHDSA/External.lean
+++ b/HashSig/SLHDSA/External.lean
@@ -46,13 +46,18 @@ structure PrehashDescriptor where
   outputLength : ℕ
   digest : List Byte → Except Error (Bytes outputLength)
 
-/-- Common FIPS external-message encoder. Domain `0` denotes pure signing and domain `1`
-denotes pre-hash signing. -/
-def encodeMessage (domain : Byte) (context body : List Byte) : Except Error (List Byte) :=
+/-- Enforce the Algorithm 22--25 context bound before evaluating the message body or pre-hash. -/
+def requireContext (context : List Byte) : Except Error Unit :=
   if context.length ≤ 255 then
-    .ok ([domain, UInt8.ofNat context.length] ++ context ++ body)
+    .ok ()
   else
     .error (.contextTooLong context.length)
+
+/-- Common FIPS external-message encoder. Domain `0` denotes pure signing and domain `1`
+denotes pre-hash signing. -/
+def encodeMessage (domain : Byte) (context body : List Byte) : Except Error (List Byte) := do
+  requireContext context
+  return [domain, UInt8.ofNat context.length] ++ context ++ body
 
 /-- Algorithm 22/24 message input: `0x00 || toByte(|ctx|, 1) || ctx || M`. -/
 def encodePureMessage (context message : List Byte) : Except Error (List Byte) :=
@@ -63,6 +68,7 @@ def encodePureMessage (context message : List Byte) : Except Error (List Byte) :
 to an approved algorithm and enforce the security-strength requirement. -/
 def encodePrehashMessageWithDescriptor (prehash : PrehashDescriptor)
     (context message : List Byte) : Except Error (List Byte) := do
+  requireContext context
   let digest ← prehash.digest message
   encodeMessage 1 context (prehash.oidDer ++ digest.toList)
 

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -160,6 +160,9 @@ def run : IO Unit := do
     (SLHDSA.Concrete.Prehash.all == expectedAlgorithms.map (·.algorithm))
   ensure "prehash menu has no duplicates"
     (SLHDSA.Concrete.Prehash.all.eraseDups == SLHDSA.Concrete.Prehash.all)
+  ensure "unknown prehash name rejected" (Algorithm.ofName? "SHA2-999" == none)
+  ensure "prehash names are case-sensitive" (Algorithm.ofName? "sha2-256" == none)
+  ensure "prehash names reject trailing bytes" (Algorithm.ofName? "SHA2-256 " == none)
   let encoded ← match SLHDSA.Concrete.Prehash.encodeMessage
       FipsParameterSet.SLHDSA_SHA2_128s.params
       .sha2_256 [0x10, 0x11] [0xff] with

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -5,7 +5,7 @@ Authors: Quang Dao
 -/
 
 module
-public import HashSig.SLHDSA.External
+public import HashSig.SLHDSA.Concrete.Prehash
 
 /-!
 # SLH-DSA external-interface canaries
@@ -19,19 +19,10 @@ public section
 namespace SLHDSA.ExternalTest
 
 open SLHDSA.External
-
-def twoBytePrehash : PrehashDescriptor where
-  oidDer := [0x06, 0x01, 0x2a]
-  outputLength := 2
-  digest := fun _ => #v[0xaa, 0xbb]
+open SLHDSA.Concrete.Prehash
 
 /-- Rejects a wrong pure domain byte or a missing empty-context length byte. -/
 example : encodePureMessage [] [0xcc] = .ok [0x00, 0x00, 0xcc] := by
-  decide
-
-/-- Rejects wrong ordering among domain, context length, context, DER OID, and digest. -/
-example : encodePrehashMessage twoBytePrehash [0x10, 0x11] [0xff] =
-    .ok [0x01, 0x02, 0x10, 0x11, 0x06, 0x01, 0x2a, 0xaa, 0xbb] := by
   decide
 
 set_option maxRecDepth 2048 in
@@ -44,8 +35,15 @@ set_option maxRecDepth 2048 in
 example : encodePureMessage (List.replicate 256 0x7f) [] = .error (.contextTooLong 256) := by
   decide
 
-/-- Pure and pre-hash encodings remain separated even when both context and content are empty. -/
-example : encodePureMessage [] [] ≠ encodePrehashMessage twoBytePrehash [] [] := by
+/-- A category-5 parameter rejects the category-1 SHA-256 pre-hash before signing. -/
+example : SLHDSA.Concrete.Prehash.encodeMessage
+    FipsParameterSet.SLHDSA_SHA2_256s.params .sha2_256 [] [] =
+    .error (.prehashTooWeak 32 32) := by
+  decide
+
+/-- Exact digest conversion fails closed rather than padding a short engine result. -/
+example : digestBytesExact 2 (ByteArray.mk #[0xaa]) =
+    .error (.digestLengthMismatch 2 1) := by
   decide
 
 private def hexValue (c : Char) : UInt8 :=
@@ -61,7 +59,7 @@ private def parseHex (hex : String) : ByteArray := Id.run do
     out := out.push (hexValue chars[2 * i]! <<< 4 ||| hexValue chars[2 * i + 1]!)
   return out
 
-private def expectedAbc : PrehashAlgorithm → String
+private def expectedAbc : Algorithm → String
   | .sha2_224 => "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7"
   | .sha2_256 => "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
   | .sha2_384 =>
@@ -85,7 +83,7 @@ private def expectedAbc : PrehashAlgorithm → String
       "483366601360a8771c6863080cc4114d8db44530f8f1e1ee4f94ea37e78b5739\
       d5a15bef186a5386c75744c0527e1faa9f8726e462a12a4feb06bd8801e751e4"
 
-private def expectedOidArc : PrehashAlgorithm → ℕ
+private def expectedOidArc : Algorithm → ℕ
   | .sha2_256 => 1
   | .sha2_384 => 2
   | .sha2_512 => 3
@@ -102,27 +100,58 @@ private def expectedOidArc : PrehashAlgorithm → ℕ
 private def ensure (label : String) (condition : Bool) : IO Unit :=
   unless condition do throw (IO.userError s!"SLH-DSA external-interface check failed: {label}")
 
-private def checkDigest (label : String) (algorithm : PrehashAlgorithm)
-    (message : List Byte) (expected : String) : IO Unit :=
-  ensure label
-    (ByteArray.mk (algorithm.digest message).toArray == parseHex expected)
+private def checkDigest (label : String) (algorithm : Algorithm)
+    (message : List Byte) (expected : String) : IO Unit := do
+  match algorithm.digest message with
+  | .error error => throw (IO.userError s!"{label}: unexpected digest error {repr error}")
+  | .ok digest =>
+      ensure label (ByteArray.mk digest.toArray == parseHex expected)
 
 /-- Executable FIPS 180-4/FIPS 202 canaries for all twelve ACVP pre-hash choices, including
 their exact DER OIDs and digest widths. -/
 def run : IO Unit := do
-  ensure "complete prehash menu" (allPrehashAlgorithms.length == 12)
-  for algorithm in allPrehashAlgorithms do
-    let descriptor := algorithm.descriptor
-    let digest := descriptor.digest [0x61, 0x62, 0x63]
+  ensure "complete prehash menu" (SLHDSA.Concrete.Prehash.all.length == 12)
+  let encoded ← match SLHDSA.Concrete.Prehash.encodeMessage
+      FipsParameterSet.SLHDSA_SHA2_128s.params
+      .sha2_256 [0x10, 0x11] [0xff] with
+    | .error error => throw (IO.userError s!"prehash encoding failed: {repr error}")
+    | .ok value => pure value
+  ensure "domain/context/OID order"
+    (encoded.take 15 == [0x01, 0x02, 0x10, 0x11, 0x06, 0x09, 0x60, 0x86,
+      0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01])
+  ensure "digest placement"
+    (ByteArray.mk (encoded.drop 15).toArray ==
+      parseHex "a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89")
+  ensure "pure/prehash domain separation"
+    (encodePureMessage [] [] !=
+      SLHDSA.Concrete.Prehash.encodeMessage
+        FipsParameterSet.SLHDSA_SHA2_128s.params .sha2_256 [] [])
+  for algorithm in SLHDSA.Concrete.Prehash.all do
     ensure s!"{algorithm.name}: ACVP name round-trip"
-      (PrehashAlgorithm.ofName? algorithm.name == some algorithm)
-    ensure s!"{algorithm.name}: DER OID width" (descriptor.oidDer.length == 11)
+      (Algorithm.ofName? algorithm.name == some algorithm)
+    ensure s!"{algorithm.name}: DER OID width" (algorithm.oidDer.length == 11)
     ensure s!"{algorithm.name}: DER OID arc"
-      (descriptor.oidDer.getLast? == some (UInt8.ofNat (expectedOidArc algorithm)))
-    ensure s!"{algorithm.name}: intrinsic digest width"
-      (digest.toList.length == descriptor.outputLength)
-    ensure s!"{algorithm.name}: abc digest"
-      (ByteArray.mk digest.toArray == parseHex (expectedAbc algorithm))
+      (algorithm.oidDer.getLast? == some (UInt8.ofNat (expectedOidArc algorithm)))
+    checkDigest s!"{algorithm.name}: abc digest" algorithm [0x61, 0x62, 0x63]
+      (expectedAbc algorithm)
+  ensure "SHA2-224 is below category 1"
+    (!Algorithm.sha2_224.validFor FipsParameterSet.SLHDSA_SHA2_128s.params)
+  ensure "SHA2-256 reaches category 1"
+    (Algorithm.sha2_256.validFor FipsParameterSet.SLHDSA_SHA2_128s.params)
+  ensure "SHA2-256 is below category 3"
+    (!Algorithm.sha2_256.validFor FipsParameterSet.SLHDSA_SHA2_192s.params)
+  ensure "SHA2-384 reaches category 3"
+    (Algorithm.sha2_384.validFor FipsParameterSet.SLHDSA_SHA2_192s.params)
+  ensure "SHA2-384 is below category 5"
+    (!Algorithm.sha2_384.validFor FipsParameterSet.SLHDSA_SHA2_256s.params)
+  ensure "SHA2-512 reaches category 5"
+    (Algorithm.sha2_512.validFor FipsParameterSet.SLHDSA_SHA2_256s.params)
+  ensure "SHAKE128 reaches category 1"
+    (Algorithm.shake128.validFor FipsParameterSet.SLHDSA_SHAKE_128s.params)
+  ensure "SHAKE128 is below category 3"
+    (!Algorithm.shake128.validFor FipsParameterSet.SLHDSA_SHAKE_192s.params)
+  ensure "SHAKE256 reaches category 5"
+    (Algorithm.shake256.validFor FipsParameterSet.SLHDSA_SHAKE_256s.params)
   checkDigest "SHA3-224 exact-rate padding" .sha3_224 (List.replicate 144 0x61)
     "f9019111996dcf160e284e320fd6d8825cabcd41a5ffdc4c5e9d64b6"
   checkDigest "SHA3-384 exact-rate padding" .sha3_384 (List.replicate 104 0x61)
@@ -133,7 +162,7 @@ def run : IO Unit := do
     cd86e81296852359bf2faddb5153c0a7445722987875e74287adac21adebe952"
   checkDigest "SHAKE128 exact-rate padding" .shake128 (List.replicate 168 0x61)
     "c22e11586c22b713bde373fce93314d76829de2c21d940a28eb659b8dec953a2"
-  IO.println "SLH-DSA external-interface tests: PASS (12 prehash OIDs/digests; context boundary)"
+  IO.println "SLH-DSA external-interface tests: PASS (12 bound OIDs/digests; strength/context)"
 
 end SLHDSA.ExternalTest
 

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -102,6 +102,11 @@ private def expectedOidArc : PrehashAlgorithm → ℕ
 private def ensure (label : String) (condition : Bool) : IO Unit :=
   unless condition do throw (IO.userError s!"SLH-DSA external-interface check failed: {label}")
 
+private def checkDigest (label : String) (algorithm : PrehashAlgorithm)
+    (message : List Byte) (expected : String) : IO Unit :=
+  ensure label
+    (ByteArray.mk (algorithm.digest message).toArray == parseHex expected)
+
 /-- Executable FIPS 180-4/FIPS 202 canaries for all twelve ACVP pre-hash choices, including
 their exact DER OIDs and digest widths. -/
 def run : IO Unit := do
@@ -118,6 +123,16 @@ def run : IO Unit := do
       (digest.toList.length == descriptor.outputLength)
     ensure s!"{algorithm.name}: abc digest"
       (ByteArray.mk digest.toArray == parseHex (expectedAbc algorithm))
+  checkDigest "SHA3-224 exact-rate padding" .sha3_224 (List.replicate 144 0x61)
+    "f9019111996dcf160e284e320fd6d8825cabcd41a5ffdc4c5e9d64b6"
+  checkDigest "SHA3-384 exact-rate padding" .sha3_384 (List.replicate 104 0x61)
+    "3a4f3b6284e571238884e95655e8c8a60e068e4059a9734abc08823a900d1615\
+    92860243f00619ae699a29092ed91a16"
+  checkDigest "SHA3-512 exact-rate padding" .sha3_512 (List.replicate 72 0x61)
+    "a8ae722a78e10cbbc413886c02eb5b369a03f6560084aff566bd597bb7ad8c1c\
+    cd86e81296852359bf2faddb5153c0a7445722987875e74287adac21adebe952"
+  checkDigest "SHAKE128 exact-rate padding" .shake128 (List.replicate 168 0x61)
+    "c22e11586c22b713bde373fce93314d76829de2c21d940a28eb659b8dec953a2"
   IO.println "SLH-DSA external-interface tests: PASS (12 prehash OIDs/digests; context boundary)"
 
 end SLHDSA.ExternalTest

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -31,6 +31,37 @@ def fixedDescriptor : PrehashDescriptor where
   outputLength := 2
   digest := fun _ => .ok #v[0xaa, 0xbb]
 
+structure ExpectedAlgorithm where
+  algorithm : Algorithm
+  name : String
+  oidDer : List Byte
+  outputLength : ℕ
+
+def expectedAlgorithms : List ExpectedAlgorithm :=
+  [⟨.sha2_224, "SHA2-224", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04], 28⟩,
+   ⟨.sha2_256, "SHA2-256", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01], 32⟩,
+   ⟨.sha2_384, "SHA2-384", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02], 48⟩,
+   ⟨.sha2_512, "SHA2-512", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03], 64⟩,
+   ⟨.sha2_512_224, "SHA2-512/224",
+     [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x05], 28⟩,
+   ⟨.sha2_512_256, "SHA2-512/256",
+     [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x06], 32⟩,
+   ⟨.sha3_224, "SHA3-224", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x07], 28⟩,
+   ⟨.sha3_256, "SHA3-256", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x08], 32⟩,
+   ⟨.sha3_384, "SHA3-384", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x09], 48⟩,
+   ⟨.sha3_512, "SHA3-512", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0a], 64⟩,
+   ⟨.shake128, "SHAKE-128", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0b], 32⟩,
+   ⟨.shake256, "SHAKE-256", [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0c], 64⟩]
+
+/-! A seeded canary pins the FIPS Algorithm 21 `(SK, PK)` adapter over the canonical internal
+`(PK, SK)` convenience order. A regression that removes the swap changes both the type and value. -/
+example (vp : ValidatedParams) (prims : Primitives vp.params)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) :
+    keygenWithSeeds vp prims skSeed skPrf pkSeed =
+      let (pk, sk) := GeneralScheme.keygenInternal vp prims skSeed skPrf pkSeed
+      (sk, pk) := by
+  rfl
+
 /-- Rejects a wrong pure domain byte or a missing empty-context length byte. -/
 example : encodePureMessage [] [0xcc] = .ok [0x00, 0x00, 0xcc] := by
   decide
@@ -112,20 +143,6 @@ private def expectedAbc : Algorithm → String
       "483366601360a8771c6863080cc4114d8db44530f8f1e1ee4f94ea37e78b5739\
       d5a15bef186a5386c75744c0527e1faa9f8726e462a12a4feb06bd8801e751e4"
 
-private def expectedOidArc : Algorithm → ℕ
-  | .sha2_256 => 1
-  | .sha2_384 => 2
-  | .sha2_512 => 3
-  | .sha2_224 => 4
-  | .sha2_512_224 => 5
-  | .sha2_512_256 => 6
-  | .sha3_224 => 7
-  | .sha3_256 => 8
-  | .sha3_384 => 9
-  | .sha3_512 => 10
-  | .shake128 => 11
-  | .shake256 => 12
-
 private def ensure (label : String) (condition : Bool) : IO Unit :=
   unless condition do throw (IO.userError s!"SLH-DSA external-interface check failed: {label}")
 
@@ -139,7 +156,10 @@ private def checkDigest (label : String) (algorithm : Algorithm)
 /-- Executable FIPS 180-4/FIPS 202 canaries for all twelve ACVP pre-hash choices, including
 their exact DER OIDs and digest widths. -/
 def run : IO Unit := do
-  ensure "complete prehash menu" (SLHDSA.Concrete.Prehash.all.length == 12)
+  ensure "complete independent prehash menu"
+    (SLHDSA.Concrete.Prehash.all == expectedAlgorithms.map (·.algorithm))
+  ensure "prehash menu has no duplicates"
+    (SLHDSA.Concrete.Prehash.all.eraseDups == SLHDSA.Concrete.Prehash.all)
   let encoded ← match SLHDSA.Concrete.Prehash.encodeMessage
       FipsParameterSet.SLHDSA_SHA2_128s.params
       .sha2_256 [0x10, 0x11] [0xff] with
@@ -155,13 +175,13 @@ def run : IO Unit := do
     (encodePureMessage [] [] !=
       SLHDSA.Concrete.Prehash.encodeMessage
         FipsParameterSet.SLHDSA_SHA2_128s.params .sha2_256 [] [])
-  for algorithm in SLHDSA.Concrete.Prehash.all do
-    ensure s!"{algorithm.name}: ACVP name round-trip"
-      (Algorithm.ofName? algorithm.name == some algorithm)
-    ensure s!"{algorithm.name}: DER OID width" (algorithm.oidDer.length == 11)
-    ensure s!"{algorithm.name}: DER OID arc"
-      (algorithm.oidDer.getLast? == some (UInt8.ofNat (expectedOidArc algorithm)))
-    checkDigest s!"{algorithm.name}: abc digest" algorithm [0x61, 0x62, 0x63]
+  for row in expectedAlgorithms do
+    let algorithm := row.algorithm
+    ensure s!"{row.name}: exact ACVP name" (algorithm.name == row.name)
+    ensure s!"{row.name}: exact parser binding" (Algorithm.ofName? row.name == some algorithm)
+    ensure s!"{row.name}: complete DER OID" (algorithm.oidDer == row.oidDer)
+    ensure s!"{row.name}: exact output width" (algorithm.outputLength == row.outputLength)
+    checkDigest s!"{row.name}: abc digest" algorithm [0x61, 0x62, 0x63]
       (expectedAbc algorithm)
   ensure "SHA2-224 is below category 1"
     (!Algorithm.sha2_224.validFor FipsParameterSet.SLHDSA_SHA2_128s.params)

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -21,6 +21,16 @@ namespace SLHDSA.ExternalTest
 open SLHDSA.External
 open SLHDSA.Concrete.Prehash
 
+def failingDescriptor : PrehashDescriptor where
+  oidDer := [0x06, 0x01, 0x2a]
+  outputLength := 2
+  digest := fun _ => .error (.digestLengthMismatch 2 0)
+
+def fixedDescriptor : PrehashDescriptor where
+  oidDer := [0x06, 0x01, 0x2a]
+  outputLength := 2
+  digest := fun _ => .ok #v[0xaa, 0xbb]
+
 /-- Rejects a wrong pure domain byte or a missing empty-context length byte. -/
 example : encodePureMessage [] [0xcc] = .ok [0x00, 0x00, 0xcc] := by
   decide
@@ -33,6 +43,25 @@ example : (encodePureMessage (List.replicate 255 0x7f) []).map List.length = .ok
 set_option maxRecDepth 2048 in
 /-- The first forbidden context length is rejected with its observed size. -/
 example : encodePureMessage (List.replicate 256 0x7f) [] = .error (.contextTooLong 256) := by
+  decide
+
+set_option maxRecDepth 2048 in
+/-- Algorithm 23 rejects the context before evaluating even a failing pre-hash descriptor. -/
+example : encodePrehashMessageWithDescriptor failingDescriptor
+    (List.replicate 256 0x7f) [] = .error (.contextTooLong 256) := by
+  decide
+
+set_option maxRecDepth 2048 in
+/-- The largest permitted pre-hash context remains accepted. -/
+example : (encodePrehashMessageWithDescriptor fixedDescriptor
+    (List.replicate 255 0x7f) []).map List.length = .ok 262 := by
+  decide
+
+set_option maxRecDepth 2048 in
+/-- Context rejection also precedes the concrete strength-policy check. -/
+example : SLHDSA.Concrete.Prehash.encodeMessage
+    FipsParameterSet.SLHDSA_SHA2_256s.params .sha2_256 (List.replicate 256 0x7f) [] =
+    .error (.contextTooLong 256) := by
   decide
 
 /-- A category-5 parameter rejects the category-1 SHA-256 pre-hash before signing. -/

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -34,10 +34,12 @@ example : encodePrehashMessage twoBytePrehash [0x10, 0x11] [0xff] =
     .ok [0x01, 0x02, 0x10, 0x11, 0x06, 0x01, 0x2a, 0xaa, 0xbb] := by
   decide
 
+set_option maxRecDepth 2048 in
 /-- The largest permitted context is accepted and contributes exactly 257 prefix bytes. -/
 example : (encodePureMessage (List.replicate 255 0x7f) []).map List.length = .ok 257 := by
   decide
 
+set_option maxRecDepth 2048 in
 /-- The first forbidden context length is rejected with its observed size. -/
 example : encodePureMessage (List.replicate 256 0x7f) [] = .error (.contextTooLong 256) := by
   decide
@@ -46,4 +48,78 @@ example : encodePureMessage (List.replicate 256 0x7f) [] = .error (.contextTooLo
 example : encodePureMessage [] [] ≠ encodePrehashMessage twoBytePrehash [] [] := by
   decide
 
+private def hexValue (c : Char) : UInt8 :=
+  if '0' ≤ c ∧ c ≤ '9' then (c.toNat - '0'.toNat).toUInt8
+  else if 'a' ≤ c ∧ c ≤ 'f' then (c.toNat - 'a'.toNat + 10).toUInt8
+  else if 'A' ≤ c ∧ c ≤ 'F' then (c.toNat - 'A'.toNat + 10).toUInt8
+  else 0
+
+private def parseHex (hex : String) : ByteArray := Id.run do
+  let chars := hex.toList.toArray
+  let mut out := ByteArray.empty
+  for i in [0:chars.size / 2] do
+    out := out.push (hexValue chars[2 * i]! <<< 4 ||| hexValue chars[2 * i + 1]!)
+  return out
+
+private def expectedAbc : PrehashAlgorithm → String
+  | .sha2_224 => "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7"
+  | .sha2_256 => "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+  | .sha2_384 =>
+      "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed\
+      8086072ba1e7cc2358baeca134c825a7"
+  | .sha2_512 =>
+      "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a\
+      2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+  | .sha2_512_224 => "4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa"
+  | .sha2_512_256 => "53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23"
+  | .sha3_224 => "e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf"
+  | .sha3_256 => "3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532"
+  | .sha3_384 =>
+      "ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b\
+      298d88cea927ac7f539f1edf228376d25"
+  | .sha3_512 =>
+      "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e\
+      10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0"
+  | .shake128 => "5881092dd818bf5cf8a3ddb793fbcba74097d5c526a6d35f97b83351940f2cc8"
+  | .shake256 =>
+      "483366601360a8771c6863080cc4114d8db44530f8f1e1ee4f94ea37e78b5739\
+      d5a15bef186a5386c75744c0527e1faa9f8726e462a12a4feb06bd8801e751e4"
+
+private def expectedOidArc : PrehashAlgorithm → ℕ
+  | .sha2_256 => 1
+  | .sha2_384 => 2
+  | .sha2_512 => 3
+  | .sha2_224 => 4
+  | .sha2_512_224 => 5
+  | .sha2_512_256 => 6
+  | .sha3_224 => 7
+  | .sha3_256 => 8
+  | .sha3_384 => 9
+  | .sha3_512 => 10
+  | .shake128 => 11
+  | .shake256 => 12
+
+private def ensure (label : String) (condition : Bool) : IO Unit :=
+  unless condition do throw (IO.userError s!"SLH-DSA external-interface check failed: {label}")
+
+/-- Executable FIPS 180-4/FIPS 202 canaries for all twelve ACVP pre-hash choices, including
+their exact DER OIDs and digest widths. -/
+def run : IO Unit := do
+  ensure "complete prehash menu" (allPrehashAlgorithms.length == 12)
+  for algorithm in allPrehashAlgorithms do
+    let descriptor := algorithm.descriptor
+    let digest := descriptor.digest [0x61, 0x62, 0x63]
+    ensure s!"{algorithm.name}: ACVP name round-trip"
+      (PrehashAlgorithm.ofName? algorithm.name == some algorithm)
+    ensure s!"{algorithm.name}: DER OID width" (descriptor.oidDer.length == 11)
+    ensure s!"{algorithm.name}: DER OID arc"
+      (descriptor.oidDer.getLast? == some (UInt8.ofNat (expectedOidArc algorithm)))
+    ensure s!"{algorithm.name}: intrinsic digest width"
+      (digest.toList.length == descriptor.outputLength)
+    ensure s!"{algorithm.name}: abc digest"
+      (ByteArray.mk digest.toArray == parseHex (expectedAbc algorithm))
+  IO.println "SLH-DSA external-interface tests: PASS (12 prehash OIDs/digests; context boundary)"
+
 end SLHDSA.ExternalTest
+
+def main : IO Unit := SLHDSA.ExternalTest.run

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -11,7 +11,12 @@ public import HashSig.SLHDSA.Concrete.Prehash
 # SLH-DSA external-interface canaries
 
 Direct boundary examples that distinguish the pure and pre-hash domains, context placement,
-DER-OID placement, digest placement, and the required 255/256-byte rejection boundary.
+DER-OID placement, digest placement, and the required 255/256-byte rejection boundary. The
+executable suite also pins the FIPS 205 Algorithm 19 line 2 deterministic randomizer
+(`opt_rand = PK.seed`) across all twelve approved profiles and runs end-to-end
+keygen→sign→verify round trips through the pinned deterministic external entry points for one
+SHA2 and one SHAKE profile, including tamper, wrong-message, and verify-side overlong-context
+rejections.
 -/
 
 public section
@@ -146,6 +151,82 @@ private def expectedAbc : Algorithm → String
 private def ensure (label : String) (condition : Bool) : IO Unit :=
   unless condition do throw (IO.userError s!"SLH-DSA external-interface check failed: {label}")
 
+/-! ## FIPS deterministic-variant pinning and pinned external round trips -/
+
+private def testBytes (n offset : ℕ) : SLHDSA.Bytes n :=
+  Vector.ofFn fun i => UInt8.ofNat (i.val * 7 + offset)
+
+private def flip16 (bytes : SLHDSA.Bytes 16) : SLHDSA.Bytes 16 :=
+  bytes.set 0 (bytes[0] ^^^ 0x01)
+
+private def checkPin (set : FipsParameterSet)
+    (seed : (SLHDSA.Concrete.approvedPrimitives set).PkSeed)
+    (expected : SLHDSA.Bytes set.params.n) : Bool :=
+  ((SLHDSA.Concrete.approvedPrimitives set).yToBytes
+    (SLHDSA.Concrete.approvedRandomizerOfPkSeed set seed)).toList == expected.toList
+
+/-- FIPS 205 Algorithm 19 line 2: the pinned deterministic randomizer's byte encoding is
+exactly the `PK.seed` bytes, exercised through the set-level dispatch for each profile. -/
+private def pinnedRandomizerAgrees : FipsParameterSet → Bool
+  | .SLHDSA_SHA2_128s => checkPin .SLHDSA_SHA2_128s (testBytes 16 5) (testBytes 16 5)
+  | .SLHDSA_SHA2_128f => checkPin .SLHDSA_SHA2_128f (testBytes 16 6) (testBytes 16 6)
+  | .SLHDSA_SHA2_192s => checkPin .SLHDSA_SHA2_192s (testBytes 24 7) (testBytes 24 7)
+  | .SLHDSA_SHA2_192f => checkPin .SLHDSA_SHA2_192f (testBytes 24 8) (testBytes 24 8)
+  | .SLHDSA_SHA2_256s => checkPin .SLHDSA_SHA2_256s (testBytes 32 9) (testBytes 32 9)
+  | .SLHDSA_SHA2_256f => checkPin .SLHDSA_SHA2_256f (testBytes 32 10) (testBytes 32 10)
+  | .SLHDSA_SHAKE_128s => checkPin .SLHDSA_SHAKE_128s (testBytes 16 11) (testBytes 16 11)
+  | .SLHDSA_SHAKE_128f => checkPin .SLHDSA_SHAKE_128f (testBytes 16 12) (testBytes 16 12)
+  | .SLHDSA_SHAKE_192s => checkPin .SLHDSA_SHAKE_192s (testBytes 24 13) (testBytes 24 13)
+  | .SLHDSA_SHAKE_192f => checkPin .SLHDSA_SHAKE_192f (testBytes 24 14) (testBytes 24 14)
+  | .SLHDSA_SHAKE_256s => checkPin .SLHDSA_SHAKE_256s (testBytes 32 15) (testBytes 32 15)
+  | .SLHDSA_SHAKE_256f => checkPin .SLHDSA_SHAKE_256f (testBytes 32 16) (testBytes 32 16)
+
+/-- End-to-end keygen→sign→verify through the pinned deterministic external entry points
+(pure Algorithm 22 and checked pre-hash Algorithm 23), with tampered-signature,
+wrong-message, and verify-side overlong-context rejections. -/
+private def roundTrip (label : String) (set : FipsParameterSet)
+    (inst : DecidableEq (SLHDSA.Concrete.approvedPrimitives set).Y)
+    (skSeed : (SLHDSA.Concrete.approvedPrimitives set).SkSeed)
+    (skPrf : (SLHDSA.Concrete.approvedPrimitives set).SkPrf)
+    (pkSeed : (SLHDSA.Concrete.approvedPrimitives set).PkSeed)
+    (algorithm : Algorithm)
+    (tamper : GeneralScheme.SignatureCore set.validatedParams
+        (SLHDSA.Concrete.approvedPrimitives set).core →
+      GeneralScheme.SignatureCore set.validatedParams
+        (SLHDSA.Concrete.approvedPrimitives set).core) : IO Unit := do
+  let vp := set.validatedParams
+  let prims := SLHDSA.Concrete.approvedPrimitives set
+  let message : List Byte := [0x4d, 0x53, 0x47]
+  let wrongMessage : List Byte := [0x4d, 0x53, 0x58]
+  let context : List Byte := [0xc0, 0xff]
+  let longContext : List Byte := List.replicate 256 0x00
+  let (sk, pk) := keygenWithSeeds vp prims skSeed skPrf pkSeed
+  let pureSig ← match SLHDSA.Concrete.signPureDeterministicApproved set message context sk with
+    | .error error => throw (IO.userError s!"{label}: pure pinned signing failed: {repr error}")
+    | .ok signature => pure signature
+  ensure s!"{label}: pure pinned sign/verify round trip"
+    (@verifyPure vp prims inst message pureSig context pk)
+  ensure s!"{label}: pure tampered-signature reject"
+    (!(@verifyPure vp prims inst message (tamper pureSig) context pk))
+  ensure s!"{label}: pure wrong-message reject"
+    (!(@verifyPure vp prims inst wrongMessage pureSig context pk))
+  ensure s!"{label}: pure overlong-context verify reject"
+    (!(@verifyPure vp prims inst message pureSig longContext pk))
+  let preSig ← match SLHDSA.Concrete.Prehash.signDeterministicApproved set algorithm
+      message context sk with
+    | .error error =>
+        throw (IO.userError s!"{label}: prehash pinned signing failed: {repr error}")
+    | .ok signature => pure signature
+  ensure s!"{label}: prehash pinned sign/verify round trip"
+    (@SLHDSA.Concrete.Prehash.verify vp prims inst algorithm message preSig context pk)
+  ensure s!"{label}: prehash tampered-signature reject"
+    (!(@SLHDSA.Concrete.Prehash.verify vp prims inst algorithm message
+      (tamper preSig) context pk))
+  ensure s!"{label}: prehash wrong-message reject"
+    (!(@SLHDSA.Concrete.Prehash.verify vp prims inst algorithm wrongMessage preSig context pk))
+  ensure s!"{label}: prehash overlong-context verify reject"
+    (!(@SLHDSA.Concrete.Prehash.verify vp prims inst algorithm message preSig longContext pk))
+
 private def checkDigest (label : String) (algorithm : Algorithm)
     (message : List Byte) (expected : String) : IO Unit := do
   match algorithm.digest message with
@@ -214,7 +295,17 @@ def run : IO Unit := do
     cd86e81296852359bf2faddb5153c0a7445722987875e74287adac21adebe952"
   checkDigest "SHAKE128 exact-rate padding" .shake128 (List.replicate 168 0x61)
     "c22e11586c22b713bde373fce93314d76829de2c21d940a28eb659b8dec953a2"
-  IO.println "SLH-DSA external-interface tests: PASS (12 bound OIDs/digests; strength/context)"
+  for set in FipsParameterSet.all do
+    ensure s!"{set.name}: pinned deterministic randomizer equals PK.seed bytes"
+      (pinnedRandomizerAgrees set)
+  roundTrip "SLH-DSA-SHA2-128f" .SLHDSA_SHA2_128f
+    (inferInstanceAs (DecidableEq (SLHDSA.Bytes 16))) (testBytes 16 1) (testBytes 16 2)
+    (testBytes 16 3) .sha2_256 (fun sig => { sig with randomness := flip16 sig.randomness })
+  roundTrip "SLH-DSA-SHAKE-128f" .SLHDSA_SHAKE_128f
+    (inferInstanceAs (DecidableEq (SLHDSA.Bytes 16))) (testBytes 16 1) (testBytes 16 2)
+    (testBytes 16 3) .shake128 (fun sig => { sig with randomness := flip16 sig.randomness })
+  IO.println "SLH-DSA external-interface tests: PASS (12 bound OIDs/digests; strength/context; \
+    12 pinned opt_rand = PK.seed profiles; SHA2-128f and SHAKE-128f pinned round trips)"
 
 end SLHDSA.ExternalTest
 

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.External
+
+/-!
+# SLH-DSA external-interface canaries
+
+Direct boundary examples that distinguish the pure and pre-hash domains, context placement,
+DER-OID placement, digest placement, and the required 255/256-byte rejection boundary.
+-/
+
+public section
+
+namespace SLHDSA.ExternalTest
+
+open SLHDSA.External
+
+def twoBytePrehash : PrehashDescriptor where
+  oidDer := [0x06, 0x01, 0x2a]
+  outputLength := 2
+  digest := fun _ => #v[0xaa, 0xbb]
+
+/-- Rejects a wrong pure domain byte or a missing empty-context length byte. -/
+example : encodePureMessage [] [0xcc] = .ok [0x00, 0x00, 0xcc] := by
+  decide
+
+/-- Rejects wrong ordering among domain, context length, context, DER OID, and digest. -/
+example : encodePrehashMessage twoBytePrehash [0x10, 0x11] [0xff] =
+    .ok [0x01, 0x02, 0x10, 0x11, 0x06, 0x01, 0x2a, 0xaa, 0xbb] := by
+  decide
+
+/-- The largest permitted context is accepted and contributes exactly 257 prefix bytes. -/
+example : (encodePureMessage (List.replicate 255 0x7f) []).map List.length = .ok 257 := by
+  decide
+
+/-- The first forbidden context length is rejected with its observed size. -/
+example : encodePureMessage (List.replicate 256 0x7f) [] = .error (.contextTooLong 256) := by
+  decide
+
+/-- Pure and pre-hash encodings remain separated even when both context and content are empty. -/
+example : encodePureMessage [] [] ≠ encodePrehashMessage twoBytePrehash [] [] := by
+  decide
+
+end SLHDSA.ExternalTest

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -394,6 +394,10 @@ lean_exe slhdsa_wots_tests where
 lean_exe slhdsa_xmss_tests where
   root := `HashSigTest.SLHDSA.XmssConstructionTests
 
+/-- Algorithms 21--25 message boundary and all twelve ACVP pre-hash digest/OID canaries. -/
+lean_exe slhdsa_external_tests where
+  root := `HashSigTest.SLHDSA.External
+
 /-- Kernel-level axiom / `sorry` accounting across the non-test libraries, with a
 committed regression baseline (`scripts/axiom_baseline.json`). Complements the Interop
 TCB-isolation gate: that gate bounds imports, this one accounts for the axioms every


### PR DESCRIPTION
## Summary

This PR completes the FIPS 205 external-message boundary over the generalized internal SLH-DSA scheme.

It lands:

- Algorithms 21--25 entry points for explicit-seed key generation in FIPS `(SK, PK)` order, pure signing/verification, and pre-hash signing/verification;
- deterministic, caller-randomized, and ideal hedged signing boundaries;
- exact pure/pre-hash domain encoding with the 255-byte context limit and FIPS rejection order;
- a generic descriptor-parametric semantic extension point;
- a separate closed twelve-algorithm FIPS pre-hash registry that binds each name, DER OID, output width, and digest engine together;
- FIPS 205 §10.2 strength checks and proof-backed exact digest widths with no padding or truncation.

Normative design: [`docs/design/slh-dsa-fips205-generalization.md`](https://github.com/Verified-zkEVM/VCVio/blob/main/docs/design/slh-dsa-fips205-generalization.md).

### Diff metadata

- Base: `a81afeb5542d64089223d6a1f7690e3bbd32c98e` (G7)
- Head: `97337acdf3c65d62ba781328a3eaddd5bce4089f`
- Commits: 8
- Files changed: 6
- Diff: 611 insertions, 0 deletions

## Motivation

The internal Algorithms 18--20 operate on an already-encoded message. FIPS 205 also specifies how applications supply pure messages, pre-hashed messages, contexts, deterministic randomness, and hedging randomness. Those policy and encoding rules must be explicit: otherwise callers can confuse domains, bind an OID to the wrong digest, claim an unsupported security category, or hash an invalid request before rejecting its context.

## Architecture

```mermaid
flowchart LR
    M[message + context] --> E[generic External encoding]
    D[descriptor: OID + exact digest] --> E
    R[closed FIPS prehash registry] --> D
    P[validated SLH-DSA params] --> S[2n strength policy]
    S --> R
    E --> I[Algorithms 18--20 internal scheme]
```

## Change-surface overview

| Area | Before | After |
|---|---|---|
| External modes | Internal scheme only | Pure and pre-hash Algorithms 21--25 |
| Context handling | No complete external boundary | Exact `0..255` acceptance; `256+` rejected before strength or digest evaluation |
| Pre-hash identity | No complete registry | Closed enum derives name, OID, width, and engine together |
| Extensions | Concrete policy could leak into semantics | Explicitly named `*WithDescriptor*` generic core, disclaimed as non-approval |
| Strength | No external digest-category check | `2 * n ≤ outputLength` enforced by every concrete encode/sign/verify entry point |
| Digest width | Runtime projection risk | Engine-width theorems construct exact vectors; fail-closed helper rejects mismatches |

## External algorithms

`HashSig.SLHDSA.External` owns the descriptor-parametric semantics:

- `keygenWithSeeds` and ideal `keygen`;
- pure deterministic, explicit-randomizer, hedged, and verify entry points;
- pre-hash equivalents whose names contain `WithDescriptor`;
- domain-separated external encodings:
  - pure: `0x00 || toByte(|ctx|, 1) || ctx || M`;
  - pre-hash: `0x01 || toByte(|ctx|, 1) || ctx || OID || PH(M)`.

`requireContext` runs before pre-hash evaluation. This pins FIPS Algorithm 23/25 sequencing, avoids needless hashing of invalid requests, and gives deterministic typed-error precedence.

## Closed FIPS pre-hash registry

`HashSig.SLHDSA.Concrete.Prehash.Algorithm` enumerates the twelve ACVP algorithms:

- SHA2-224/256/384/512 and SHA2-512/224, SHA2-512/256;
- SHA3-224/256/384/512;
- SHAKE128 with 32 output bytes and SHAKE256 with 64 output bytes.

Each constructor determines the exact ACVP spelling, DER-encoded NIST OID, digest width, and pure-Lean engine. Callers of the concrete API cannot supply a free OID/digest pair.

The concrete boundary enforces the FIPS §10.2 requirement `2n ≤ digestBytes`. This gives the expected category matrix: 256-bit/SHAKE128 outputs serve category 1; 384-bit outputs reach category 3; 512-bit/SHAKE256 outputs reach category 5; 224-bit outputs do not reach category 1.

## Safety and trust boundary

- Contexts over 255 bytes are rejected before strength checks or digest evaluation.
- Built-in digest output sizes are proved from the concrete SHA-2/SHA-3/SHAKE engines.
- `Algorithm.digest` constructs an exact-width vector under that theorem; it does not use `getD`, zero padding, or truncation.
- The generic descriptor layer is explicitly not an approval assertion; all FIPS-facing APIs consume the closed registry.
- The Algorithm 21 adapter explicitly converts the internal `(PK, SK)` convenience result to the normative `(SK, PK)` external order.
- Verification maps every external-boundary error to `false`.
- Hash implementations remain inherited from G7; this PR does not fork or duplicate them.

## Compatibility and stack boundary

The generalized Algorithms 18--20 and canonical key/signature types remain unchanged. This PR adds the complete application-facing encoding/policy layer.

Efficient full execution is G9. ACVP corpus import and exact generated-byte comparisons are G10.

## Validation completed at `97337acdf3c65d62ba781328a3eaddd5bce4089f`

Passed locally at the exact pushed head:

- aggregate `HashSig` and `HashSigTest` build;
- all seven SLH-DSA regression executables;
- twelve name/OID/digest KATs and category-boundary checks;
- independent full-row registry coverage plus unknown, wrong-case, and trailing-byte name rejection;
- context `255/256`, context-before-digest, context-before-strength, and fail-closed digest-width canaries;
- generated library-import check;
- focused style lint;
- interop, extern, and PMF isolation;
- axiom fixture matrix;
- diff and changed-code trust scans.

Independent `review-lean-formalization` verdict: **PASS with no remaining findings**.

## Reviewer map

Suggested order:

1. `HashSig/SLHDSA/External.lean` — generic external semantics and rejection sequencing
2. `HashSig/SLHDSA/Concrete/Prehash.lean` — closed registry, OIDs, widths, strength policy
3. `HashSigTest/SLHDSA/External.lean` — KATs and falsifiable boundary cases
4. exports, executable registration, and lint integration
