### PR TITLE
feat(merkle): model payload hashing domains

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -89,6 +89,8 @@ public import VCVio.CryptoFoundations.MerkleTree.BatchExtractability
 public import VCVio.CryptoFoundations.MerkleTree.Extractability
 public import VCVio.CryptoFoundations.MerkleTree.ExtractionKernel
 public import VCVio.CryptoFoundations.MerkleTree.Extractor
+public import VCVio.CryptoFoundations.MerkleTree.Hashing.Binding
+public import VCVio.CryptoFoundations.MerkleTree.Hashing.Defs
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.Addressed
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.Completeness
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.Defs

--- a/VCVio/CryptoFoundations/MerkleTree/Hashing/Binding.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Hashing/Binding.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.MerkleTree.Hashing.Defs
+
+/-!
+# Binding failures for hashed Merkle leaves
+
+When two distinct payloads open to the same root at the same index, the failure can be attributed
+to at least one of three abstraction boundaries:
+
+1. the payload encoding is not injective on those payloads;
+2. two distinct encoded leaves collide under the leaf-domain query at that address; or
+3. two distinct ordered child pairs collide under a node-domain query.
+
+The theorem below exposes this trichotomy constructively.  It reuses the addressed collision walk
+for the third case and does not package the result as a probabilistic hash assumption.
+-/
+
+@[expose] public section
+
+namespace MerkleTreeHashing
+
+open BinaryTree
+
+universe u v w x y
+
+variable {LeafAddress : Type u} {NodeAddress : Type v}
+  {Payload : Type w} {EncodedLeaf : Type x} {Digest : Type y}
+
+/-- Two distinct payloads have the same committed leaf encoding. -/
+def EncodingCollision (encode : Payload → EncodedLeaf) (left right : Payload) : Prop :=
+  left ≠ right ∧ encode left = encode right
+
+/-- Two distinct payloads receive the same caller-provided digest. -/
+def DigestMapCollision (digest : Payload → Digest) (left right : Payload) : Prop :=
+  left ≠ right ∧ digest left = digest right
+
+/-- Two distinct encoded leaves have the same leaf-domain digest at one concrete address. -/
+def LeafHashCollision
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
+    (address : LeafAddress) (left right : EncodedLeaf) : Prop :=
+  left ≠ right ∧ answer (.leaf address left) = answer (.leaf address right)
+
+/-- An internal position at which two distinct ordered child pairs have the same node-domain
+digest.  The intrinsic position is retained as part of the witness and mapped to the concrete
+hash address by `addressing.node`. -/
+def NodeHashCollision {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
+    (witness : SkeletonInternalIndex s × Digest × Digest × Digest × Digest) : Prop :=
+  (witness.2.1, witness.2.2.1) ≠ (witness.2.2.2.1, witness.2.2.2.2) ∧
+    answer (.node (addressing.node witness.1) witness.2.1 witness.2.2.1) =
+      answer (.node (addressing.node witness.1) witness.2.2.2.1 witness.2.2.2.2)
+
+/-- Binding failures for encoded-and-hashed leaves split into encoding, leaf-hash, and
+internal-node collisions. -/
+theorem hashed_binding {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (encode : Payload → EncodedLeaf)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
+    (idx : SkeletonLeafIndex s) (proof₁ proof₂ : List.Vector Digest idx.depth)
+    (left right : Payload)
+    (hroot : getPutativeRootWithHash addressing (.hash encode) idx left proof₁ answer =
+      getPutativeRootWithHash addressing (.hash encode) idx right proof₂ answer)
+    (hne : left ≠ right) :
+    EncodingCollision encode left right ∨
+      LeafHashCollision answer (addressing.leaf idx) (encode left) (encode right) ∨
+      ∃ witness, NodeHashCollision addressing answer witness := by
+  let _ : DecidableEq EncodedLeaf := Classical.decEq _
+  let _ : DecidableEq Digest := Classical.decEq _
+  by_cases hencode : encode left = encode right
+  · exact Or.inl ⟨hne, hencode⟩
+  · right
+    by_cases hleaf :
+        answer (.leaf (addressing.leaf idx) (encode left)) =
+          answer (.leaf (addressing.leaf idx) (encode right))
+    · exact Or.inl ⟨hencode, hleaf⟩
+    · right
+      obtain ⟨witness, _, hcollision⟩ :=
+        AddressedMerkleTree.getPutativeRootAddressedWithHash_binding_collision
+          (fun i l r => answer (.node (addressing.node i) l r)) idx proof₁ proof₂
+          (answer (.leaf (addressing.leaf idx) (encode left)))
+          (answer (.leaf (addressing.leaf idx) (encode right))) (by simpa [
+            getPutativeRootWithHash, leafDigestWith, nodeDigestWith] using hroot) hleaf
+      exact ⟨witness, hcollision⟩
+
+/-- With an injective payload encoding, distinct openings yield either a leaf-domain collision or
+an internal-node collision. -/
+theorem hashed_binding_of_injective {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (encode : Payload → EncodedLeaf) (hencode : Function.Injective encode)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
+    (idx : SkeletonLeafIndex s) (proof₁ proof₂ : List.Vector Digest idx.depth)
+    (left right : Payload)
+    (hroot : getPutativeRootWithHash addressing (.hash encode) idx left proof₁ answer =
+      getPutativeRootWithHash addressing (.hash encode) idx right proof₂ answer)
+    (hne : left ≠ right) :
+    LeafHashCollision answer (addressing.leaf idx) (encode left) (encode right) ∨
+      ∃ witness, NodeHashCollision addressing answer witness := by
+  obtain hcollision | hcollision | hcollision :=
+    hashed_binding addressing encode answer idx proof₁ proof₂ left right hroot hne
+  · exact (hne (hencode hcollision.2)).elim
+  · exact Or.inl hcollision
+  · exact Or.inr hcollision
+
+/-- Equal roots for distinct payloads using a caller-provided digest map expose either a collision
+in that map or an internal-node collision. -/
+theorem providedDigest_binding {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (digest : Payload → Digest)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
+    (idx : SkeletonLeafIndex s) (proof₁ proof₂ : List.Vector Digest idx.depth)
+    (left right : Payload)
+    (hroot : getPutativeRootWithHash addressing (.providedDigest digest) idx left proof₁ answer =
+      getPutativeRootWithHash addressing (.providedDigest digest) idx right proof₂ answer)
+    (hne : left ≠ right) :
+    DigestMapCollision digest left right ∨
+      ∃ witness, NodeHashCollision addressing answer witness := by
+  let _ : DecidableEq Digest := Classical.decEq _
+  by_cases hdigest : digest left = digest right
+  · exact Or.inl ⟨hne, hdigest⟩
+  · right
+    obtain ⟨witness, _, hcollision⟩ :=
+      AddressedMerkleTree.getPutativeRootAddressedWithHash_binding_collision
+        (fun i l r => answer (.node (addressing.node i) l r)) idx proof₁ proof₂
+        (digest left) (digest right) (by simpa [getPutativeRootWithHash, leafDigestWith,
+          nodeDigestWith] using hroot) hdigest
+    exact ⟨witness, hcollision⟩
+
+/-- Distinct raw digest leaves opening to the same root expose an internal-node collision. -/
+theorem prehashed_binding {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
+    (idx : SkeletonLeafIndex s) (proof₁ proof₂ : List.Vector Digest idx.depth)
+    (left right : Digest)
+    (hroot : getPutativeRootWithHash addressing .prehashed idx left proof₁ answer =
+      getPutativeRootWithHash addressing .prehashed idx right proof₂ answer)
+    (hne : left ≠ right) :
+    ∃ witness, NodeHashCollision addressing answer witness := by
+  obtain hcollision | hcollision :=
+    providedDigest_binding addressing id answer idx proof₁ proof₂ left right hroot hne
+  · exact (hne hcollision.2).elim
+  · exact hcollision
+
+end MerkleTreeHashing

--- a/VCVio/CryptoFoundations/MerkleTree/Hashing/Binding.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Hashing/Binding.lean
@@ -18,11 +18,12 @@ to at least one of three abstraction boundaries:
 2. two distinct encoded leaves collide under the leaf-domain query at that address; or
 3. two distinct ordered child pairs collide under a node-domain query.
 
-The theorem below exposes this trichotomy constructively.  It reuses the addressed collision walk
-for the third case and does not package the result as a probabilistic hash assumption.
+The theorem below proves this trichotomy using classical equality decisions. It reuses the
+addressed collision walk for the third case and does not package the result as a probabilistic
+hash assumption.
 -/
 
-@[expose] public section
+public section
 
 namespace MerkleTreeHashing
 
@@ -34,14 +35,17 @@ variable {LeafAddress : Type u} {NodeAddress : Type v}
   {Payload : Type w} {EncodedLeaf : Type x} {Digest : Type y}
 
 /-- Two distinct payloads have the same committed leaf encoding. -/
+@[expose]
 def EncodingCollision (encode : Payload → EncodedLeaf) (left right : Payload) : Prop :=
   left ≠ right ∧ encode left = encode right
 
 /-- Two distinct payloads receive the same caller-provided digest. -/
+@[expose]
 def DigestMapCollision (digest : Payload → Digest) (left right : Payload) : Prop :=
   left ≠ right ∧ digest left = digest right
 
 /-- Two distinct encoded leaves have the same leaf-domain digest at one concrete address. -/
+@[expose]
 def LeafHashCollision
     (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
     (address : LeafAddress) (left right : EncodedLeaf) : Prop :=
@@ -50,6 +54,7 @@ def LeafHashCollision
 /-- An internal position at which two distinct ordered child pairs have the same node-domain
 digest.  The intrinsic position is retained as part of the witness and mapped to the concrete
 hash address by `addressing.node`. -/
+@[expose]
 def NodeHashCollision {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
     (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
     (witness : SkeletonInternalIndex s × Digest × Digest × Digest × Digest) : Prop :=

--- a/VCVio/CryptoFoundations/MerkleTree/Hashing/Defs.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Hashing/Defs.lean
@@ -1,0 +1,314 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.Monadic
+
+/-!
+# Merkle leaf encoding and hashing
+
+This module separates application payloads, their committed encodings, and Merkle digests.  A
+single tagged oracle domain distinguishes leaf hashes from internal-node hashes, while explicit
+address maps connect the tree's intrinsic positions to the concrete address types used by a hash
+instantiation.
+
+The `LeafHashing.prehashed` specialization retains the raw-digest behavior of
+`InductiveMerkleTree`: leaves are already Merkle labels and issue no leaf query.
+`LeafHashing.providedDigest` also permits a caller-owned payload-to-digest map, whose collisions
+must be accounted for separately.  The `LeafHashing.hash` case first applies an explicit payload
+encoding and then issues a leaf-domain query.  All cases reuse
+`AddressedMerkleTree` for tree construction and root reconstruction, so this layer adds no second
+Merkle-tree recursion.
+-/
+
+@[expose] public section
+
+namespace MerkleTreeHashing
+
+open BinaryTree InductiveMerkleTree OracleComp OracleSpec
+
+universe u v w x y
+
+/-- The disjoint hash domains used by a binary Merkle tree.
+
+Leaf queries commit to an encoded payload at a leaf address.  Node queries commit to an ordered
+pair of child digests at an internal-node address. -/
+inductive HashQuery (LeafAddress : Type u) (NodeAddress : Type v)
+    (EncodedLeaf : Type w) (Digest : Type x) where
+  | leaf (address : LeafAddress) (input : EncodedLeaf)
+  | node (address : NodeAddress) (left right : Digest)
+deriving DecidableEq
+
+/-- The homogeneous oracle specification for tagged Merkle hash queries. -/
+@[reducible]
+def spec (LeafAddress : Type u) (NodeAddress : Type v)
+    (EncodedLeaf : Type w) (Digest : Type x) :
+    OracleSpec (HashQuery LeafAddress NodeAddress EncodedLeaf Digest) :=
+  HashQuery LeafAddress NodeAddress EncodedLeaf Digest →ₒ Digest
+
+/-- How application payloads become the digest labels stored at Merkle leaves.
+
+`providedDigest` performs no query: the caller supplies and owns the payload-to-digest map and its
+collision behavior.  `hash` exposes the payload encoding and hashes the resulting value in the
+tagged leaf domain. -/
+inductive LeafHashing (Payload : Type u) (EncodedLeaf : Type v) (Digest : Type w) where
+  | providedDigest (digest : Payload → Digest)
+  | hash (encode : Payload → EncodedLeaf)
+
+namespace LeafHashing
+
+/-- Raw-digest leaves: the payload already is the Merkle leaf label, so no leaf query is issued. -/
+def prehashed {EncodedLeaf : Type v} {Digest : Type w} :
+    LeafHashing Digest EncodedLeaf Digest :=
+  .providedDigest id
+
+end LeafHashing
+
+/-- Concrete address keys for every leaf and internal node of a fixed tree skeleton. -/
+structure Addressing (s : Skeleton) (LeafAddress : Type u) (NodeAddress : Type v) where
+  /-- Concrete address used to hash each leaf. -/
+  leaf : SkeletonLeafIndex s → LeafAddress
+  /-- Concrete address used to hash each internal node. -/
+  node : SkeletonInternalIndex s → NodeAddress
+
+variable {LeafAddress : Type u} {NodeAddress : Type v}
+  {Payload : Type w} {EncodedLeaf : Type x} {Digest : Type y}
+
+/-- Interpret one leaf payload under a deterministic hash-query implementation. -/
+def leafDigestWith (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest) (address : LeafAddress)
+    (payload : Payload) : Digest :=
+  match leafHashing with
+  | .providedDigest digest => digest payload
+  | .hash encode => answer (.leaf address (encode payload))
+
+/-- Interpret one internal-node hash under a deterministic hash-query implementation. -/
+def nodeDigestWith (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
+    (address : NodeAddress) (left right : Digest) : Digest :=
+  answer (.node address left right)
+
+/-- Produce a leaf digest, issuing a query exactly in the encoded-and-hashed case. -/
+def leafDigest {m : Type y → Type*} [Monad m]
+    [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest) (address : LeafAddress)
+    (payload : Payload) : m Digest :=
+  match leafHashing with
+  | .providedDigest digest => pure (digest payload)
+  | .hash encode => HasQuery.query
+      (spec := spec LeafAddress NodeAddress EncodedLeaf Digest)
+      (HashQuery.leaf address (encode payload))
+
+/-- Hash an ordered pair of child digests in the internal-node domain. -/
+def nodeDigest {m : Type y → Type*} [Monad m]
+    [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
+    (address : NodeAddress) (left right : Digest) : m Digest :=
+  HasQuery.query (spec := spec LeafAddress NodeAddress EncodedLeaf Digest)
+    (HashQuery.node address left right)
+
+/-- Build a Merkle cache from payloads using explicit leaf hashing and address maps. -/
+def build {m : Type y → Type*} [Monad m]
+    [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
+    {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (payloads : LeafData Payload s) : m (FullData Digest s) :=
+  AddressedMerkleTree.buildMerkleTreeAddressedM
+    (fun i => leafDigest (LeafAddress := LeafAddress) (NodeAddress := NodeAddress)
+      leafHashing (addressing.leaf i) (payloads.get i))
+    (fun i left right => nodeDigest (LeafAddress := LeafAddress)
+      (EncodedLeaf := EncodedLeaf) (addressing.node i) left right)
+
+/-- Recompute a putative root from a payload and authentication path. -/
+def getPutativeRoot {m : Type y → Type*} [Monad m]
+    [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
+    {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (idx : SkeletonLeafIndex s) (payload : Payload)
+    (proof : List.Vector Digest idx.depth) : m Digest := do
+  let leaf ← leafDigest (LeafAddress := LeafAddress) (NodeAddress := NodeAddress)
+    leafHashing (addressing.leaf idx) payload
+  AddressedMerkleTree.getPutativeRootAddressedM
+    (fun i left right => nodeDigest (LeafAddress := LeafAddress)
+      (EncodedLeaf := EncodedLeaf) (addressing.node i) left right) idx leaf proof
+
+/-- Verify a payload opening while preserving the leaf and node oracle-query trace.
+
+The result type is `Bool`, so this operational wrapper is stated for ordinary `Type`-valued
+digests.  The underlying builder, root reconstruction, and deterministic verifier remain fully
+universe-polymorphic. -/
+def verify {LeafAddress : Type u} {NodeAddress : Type v} {Payload : Type w}
+    {EncodedLeaf : Type x} {Digest : Type} [DecidableEq Digest]
+    {m : Type → Type*} [Monad m]
+    [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
+    {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (idx : SkeletonLeafIndex s) (payload : Payload) (root : Digest)
+    (proof : List.Vector Digest idx.depth) : m Bool := do
+  return (← getPutativeRoot addressing leafHashing idx payload proof) == root
+
+/-- Deterministic interpretation of `build`. -/
+def buildWithHash {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (payloads : LeafData Payload s)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest) :
+    FullData Digest s :=
+  AddressedMerkleTree.buildMerkleTreeAddressedWithHash
+    (LeafData.ofFun s fun i =>
+      leafDigestWith answer leafHashing (addressing.leaf i) (payloads.get i))
+    (fun i left right => nodeDigestWith answer (addressing.node i) left right)
+
+/-- Deterministic interpretation of `getPutativeRoot`. -/
+def getPutativeRootWithHash {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (idx : SkeletonLeafIndex s) (payload : Payload)
+    (proof : List.Vector Digest idx.depth)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest) : Digest :=
+  AddressedMerkleTree.getPutativeRootAddressedWithHash
+    (fun i left right => nodeDigestWith answer (addressing.node i) left right) idx
+    (leafDigestWith answer leafHashing (addressing.leaf idx) payload) proof
+
+/-- Verify a payload opening under a deterministic hash-query implementation. -/
+def verifyWithHash [DecidableEq Digest] {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (idx : SkeletonLeafIndex s) (payload : Payload) (root : Digest)
+    (proof : List.Vector Digest idx.depth)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest) : Bool :=
+  getPutativeRootWithHash addressing leafHashing idx payload proof answer == root
+
+@[simp]
+theorem simulateQ_leafDigest
+    (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest) (address : LeafAddress)
+    (payload : Payload) :
+    simulateQ answer
+      (leafDigest (m := OracleComp (spec LeafAddress NodeAddress EncodedLeaf Digest))
+        (LeafAddress := LeafAddress) (NodeAddress := NodeAddress)
+        leafHashing address payload) =
+      leafDigestWith answer leafHashing address payload := by
+  cases leafHashing with
+  | providedDigest => rfl
+  | hash => simp [leafDigest, leafDigestWith]
+
+@[simp]
+theorem simulateQ_nodeDigest
+    (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
+    (address : NodeAddress) (left right : Digest) :
+    simulateQ answer
+      (nodeDigest (m := OracleComp (spec LeafAddress NodeAddress EncodedLeaf Digest))
+        (LeafAddress := LeafAddress) (EncodedLeaf := EncodedLeaf)
+        address left right) =
+      nodeDigestWith answer address left right := by
+  simp [nodeDigest, nodeDigestWith]
+
+@[simp]
+theorem simulateQ_build {s : Skeleton}
+    (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (payloads : LeafData Payload s) :
+    simulateQ answer
+      (build (m := OracleComp (spec LeafAddress NodeAddress EncodedLeaf Digest))
+        addressing leafHashing payloads) =
+      buildWithHash addressing leafHashing payloads answer := by
+  simp [build, buildWithHash]
+  rfl
+
+@[simp]
+theorem simulateQ_getPutativeRoot {s : Skeleton}
+    (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (idx : SkeletonLeafIndex s) (payload : Payload)
+    (proof : List.Vector Digest idx.depth) :
+    simulateQ answer
+      (getPutativeRoot (m := OracleComp (spec LeafAddress NodeAddress EncodedLeaf Digest))
+        addressing leafHashing idx payload proof) =
+      getPutativeRootWithHash addressing leafHashing idx payload proof answer := by
+  simp [getPutativeRoot, getPutativeRootWithHash]
+  rfl
+
+@[simp]
+theorem simulateQ_verify {LeafAddress : Type u} {NodeAddress : Type v}
+    {Payload : Type w} {EncodedLeaf : Type x} {Digest : Type} [DecidableEq Digest]
+    {s : Skeleton}
+    (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (idx : SkeletonLeafIndex s) (payload : Payload) (root : Digest)
+    (proof : List.Vector Digest idx.depth) :
+    simulateQ answer
+      (verify (m := OracleComp (spec LeafAddress NodeAddress EncodedLeaf Digest))
+        addressing leafHashing idx payload root proof) =
+      verifyWithHash addressing leafHashing idx payload root proof answer := by
+  unfold verify verifyWithHash
+  rw [simulateQ_bind, simulateQ_getPutativeRoot]
+  rfl
+
+/-- Honest openings recompute the root of a deterministically interpreted tree. -/
+theorem functional_completeness {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (payloads : LeafData Payload s) (idx : SkeletonLeafIndex s)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest) :
+    getPutativeRootWithHash addressing leafHashing idx (payloads.get idx)
+        (generateProof (buildWithHash addressing leafHashing payloads answer) idx) answer =
+      (buildWithHash addressing leafHashing payloads answer).getRootValue := by
+  simpa only [getPutativeRootWithHash, buildWithHash, LeafData.get_ofFun] using
+    AddressedMerkleTree.addressed_functional_completeness idx
+      (LeafData.ofFun s fun i =>
+        leafDigestWith answer leafHashing (addressing.leaf i) (payloads.get i))
+      (fun i left right => nodeDigestWith answer (addressing.node i) left right)
+
+/-- The deterministic verifier accepts every honestly generated opening. -/
+@[simp]
+theorem verifyWithHash_completeness [DecidableEq Digest] {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (payloads : LeafData Payload s) (idx : SkeletonLeafIndex s)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest) :
+    verifyWithHash addressing leafHashing idx (payloads.get idx)
+      (buildWithHash addressing leafHashing payloads answer).getRootValue
+      (generateProof (buildWithHash addressing leafHashing payloads answer) idx) answer = true := by
+  simp [verifyWithHash, functional_completeness]
+
+/-- The monadic verifier accepts an honest opening under every deterministic oracle handler. -/
+@[simp]
+theorem simulateQ_verify_completeness {LeafAddress : Type u} {NodeAddress : Type v}
+    {Payload : Type w} {EncodedLeaf : Type x} {Digest : Type} [DecidableEq Digest]
+    {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
+    (leafHashing : LeafHashing Payload EncodedLeaf Digest)
+    (payloads : LeafData Payload s) (idx : SkeletonLeafIndex s)
+    (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id) :
+    simulateQ answer
+      (verify (m := OracleComp (spec LeafAddress NodeAddress EncodedLeaf Digest))
+        addressing leafHashing idx (payloads.get idx)
+        (buildWithHash addressing leafHashing payloads answer).getRootValue
+        (generateProof (buildWithHash addressing leafHashing payloads answer) idx)) = true := by
+  simp
+
+/-- Prehashed identity leaves recover the existing addressed raw-digest builder. -/
+theorem buildWithHash_prehashed_id {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (leaves : LeafData Digest s)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest) :
+    buildWithHash addressing .prehashed leaves answer =
+      AddressedMerkleTree.buildMerkleTreeAddressedWithHash leaves
+        (fun i left right => answer (.node (addressing.node i) left right)) := by
+  simp [buildWithHash, LeafHashing.prehashed, leafDigestWith, nodeDigestWith]
+
+/-- Prehashed identity leaves recover the existing addressed raw-digest root reconstruction. -/
+theorem getPutativeRootWithHash_prehashed_id {s : Skeleton}
+    (addressing : Addressing s LeafAddress NodeAddress)
+    (idx : SkeletonLeafIndex s) (leaf : Digest) (proof : List.Vector Digest idx.depth)
+    (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest) :
+    getPutativeRootWithHash addressing .prehashed idx leaf proof answer =
+      AddressedMerkleTree.getPutativeRootAddressedWithHash
+        (fun i left right => answer (.node (addressing.node i) left right)) idx leaf proof := by
+  rfl
+
+end MerkleTreeHashing

--- a/VCVio/CryptoFoundations/MerkleTree/Hashing/Defs.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Hashing/Defs.lean
@@ -111,7 +111,7 @@ def leafDigest {m : Type y → Type*} [Monad m]
 
 /-- Hash an ordered pair of child digests in the internal-node domain. -/
 @[expose]
-def nodeDigest {m : Type y → Type*} [Monad m]
+def nodeDigest {m : Type y → Type*}
     [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
     (address : NodeAddress) (left right : Digest) : m Digest :=
   HasQuery.query (spec := spec LeafAddress NodeAddress EncodedLeaf Digest)
@@ -296,7 +296,6 @@ theorem verifyWithHash_completeness [DecidableEq Digest] {s : Skeleton}
   simp [verifyWithHash, functional_completeness]
 
 /-- The monadic verifier accepts an honest opening under every deterministic oracle handler. -/
-@[simp]
 theorem simulateQ_verify_completeness {LeafAddress : Type u} {NodeAddress : Type v}
     {Payload : Type w} {EncodedLeaf : Type x} {Digest : Type} [DecidableEq Digest]
     {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)

--- a/VCVio/CryptoFoundations/MerkleTree/Hashing/Defs.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Hashing/Defs.lean
@@ -23,9 +23,12 @@ must be accounted for separately.  The `LeafHashing.hash` case first applies an 
 encoding and then issues a leaf-domain query.  All cases reuse
 `AddressedMerkleTree` for tree construction and root reconstruction, so this layer adds no second
 Merkle-tree recursion.
+
+The query specification and computational entry points expose their bodies for ordinary-import
+execution checks and the hash-forest translation proofs. Exposure is selected per definition.
 -/
 
-@[expose] public section
+public section
 
 namespace MerkleTreeHashing
 
@@ -41,10 +44,10 @@ inductive HashQuery (LeafAddress : Type u) (NodeAddress : Type v)
     (EncodedLeaf : Type w) (Digest : Type x) where
   | leaf (address : LeafAddress) (input : EncodedLeaf)
   | node (address : NodeAddress) (left right : Digest)
-deriving DecidableEq
+deriving @[expose] DecidableEq
 
 /-- The homogeneous oracle specification for tagged Merkle hash queries. -/
-@[reducible]
+@[expose, reducible]
 def spec (LeafAddress : Type u) (NodeAddress : Type v)
     (EncodedLeaf : Type w) (Digest : Type x) :
     OracleSpec (HashQuery LeafAddress NodeAddress EncodedLeaf Digest) :=
@@ -62,6 +65,7 @@ inductive LeafHashing (Payload : Type u) (EncodedLeaf : Type v) (Digest : Type w
 namespace LeafHashing
 
 /-- Raw-digest leaves: the payload already is the Merkle leaf label, so no leaf query is issued. -/
+@[expose]
 def prehashed {EncodedLeaf : Type v} {Digest : Type w} :
     LeafHashing Digest EncodedLeaf Digest :=
   .providedDigest id
@@ -79,6 +83,7 @@ variable {LeafAddress : Type u} {NodeAddress : Type v}
   {Payload : Type w} {EncodedLeaf : Type x} {Digest : Type y}
 
 /-- Interpret one leaf payload under a deterministic hash-query implementation. -/
+@[expose]
 def leafDigestWith (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
     (leafHashing : LeafHashing Payload EncodedLeaf Digest) (address : LeafAddress)
     (payload : Payload) : Digest :=
@@ -87,11 +92,13 @@ def leafDigestWith (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Diges
   | .hash encode => answer (.leaf address (encode payload))
 
 /-- Interpret one internal-node hash under a deterministic hash-query implementation. -/
+@[expose]
 def nodeDigestWith (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest)
     (address : NodeAddress) (left right : Digest) : Digest :=
   answer (.node address left right)
 
 /-- Produce a leaf digest, issuing a query exactly in the encoded-and-hashed case. -/
+@[expose]
 def leafDigest {m : Type y → Type*} [Monad m]
     [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
     (leafHashing : LeafHashing Payload EncodedLeaf Digest) (address : LeafAddress)
@@ -103,6 +110,7 @@ def leafDigest {m : Type y → Type*} [Monad m]
       (HashQuery.leaf address (encode payload))
 
 /-- Hash an ordered pair of child digests in the internal-node domain. -/
+@[expose]
 def nodeDigest {m : Type y → Type*} [Monad m]
     [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
     (address : NodeAddress) (left right : Digest) : m Digest :=
@@ -110,6 +118,7 @@ def nodeDigest {m : Type y → Type*} [Monad m]
     (HashQuery.node address left right)
 
 /-- Build a Merkle cache from payloads using explicit leaf hashing and address maps. -/
+@[expose]
 def build {m : Type y → Type*} [Monad m]
     [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
     {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
@@ -122,6 +131,7 @@ def build {m : Type y → Type*} [Monad m]
       (EncodedLeaf := EncodedLeaf) (addressing.node i) left right)
 
 /-- Recompute a putative root from a payload and authentication path. -/
+@[expose]
 def getPutativeRoot {m : Type y → Type*} [Monad m]
     [HasQuery (spec LeafAddress NodeAddress EncodedLeaf Digest) m]
     {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
@@ -139,6 +149,7 @@ def getPutativeRoot {m : Type y → Type*} [Monad m]
 The result type is `Bool`, so this operational wrapper is stated for ordinary `Type`-valued
 digests.  The underlying builder, root reconstruction, and deterministic verifier remain fully
 universe-polymorphic. -/
+@[expose]
 def verify {LeafAddress : Type u} {NodeAddress : Type v} {Payload : Type w}
     {EncodedLeaf : Type x} {Digest : Type} [DecidableEq Digest]
     {m : Type → Type*} [Monad m]
@@ -150,6 +161,7 @@ def verify {LeafAddress : Type u} {NodeAddress : Type v} {Payload : Type w}
   return (← getPutativeRoot addressing leafHashing idx payload proof) == root
 
 /-- Deterministic interpretation of `build`. -/
+@[expose]
 def buildWithHash {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddress)
     (leafHashing : LeafHashing Payload EncodedLeaf Digest)
     (payloads : LeafData Payload s)
@@ -161,6 +173,7 @@ def buildWithHash {s : Skeleton} (addressing : Addressing s LeafAddress NodeAddr
     (fun i left right => nodeDigestWith answer (addressing.node i) left right)
 
 /-- Deterministic interpretation of `getPutativeRoot`. -/
+@[expose]
 def getPutativeRootWithHash {s : Skeleton}
     (addressing : Addressing s LeafAddress NodeAddress)
     (leafHashing : LeafHashing Payload EncodedLeaf Digest)
@@ -172,6 +185,7 @@ def getPutativeRootWithHash {s : Skeleton}
     (leafDigestWith answer leafHashing (addressing.leaf idx) payload) proof
 
 /-- Verify a payload opening under a deterministic hash-query implementation. -/
+@[expose]
 def verifyWithHash [DecidableEq Digest] {s : Skeleton}
     (addressing : Addressing s LeafAddress NodeAddress)
     (leafHashing : LeafHashing Payload EncodedLeaf Digest)
@@ -180,6 +194,7 @@ def verifyWithHash [DecidableEq Digest] {s : Skeleton}
     (answer : HashQuery LeafAddress NodeAddress EncodedLeaf Digest → Digest) : Bool :=
   getPutativeRootWithHash addressing leafHashing idx payload proof answer == root
 
+/-- Deterministic simulation agrees with the selected leaf interpretation. -/
 @[simp]
 theorem simulateQ_leafDigest
     (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
@@ -194,6 +209,7 @@ theorem simulateQ_leafDigest
   | providedDigest => rfl
   | hash => simp [leafDigest, leafDigestWith]
 
+/-- Deterministic simulation preserves the tagged, ordered internal-node query. -/
 @[simp]
 theorem simulateQ_nodeDigest
     (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
@@ -205,6 +221,7 @@ theorem simulateQ_nodeDigest
       nodeDigestWith answer address left right := by
   simp [nodeDigest, nodeDigestWith]
 
+/-- Deterministic simulation of the builder produces the deterministic Merkle cache. -/
 @[simp]
 theorem simulateQ_build {s : Skeleton}
     (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
@@ -218,6 +235,7 @@ theorem simulateQ_build {s : Skeleton}
   simp [build, buildWithHash]
   rfl
 
+/-- Deterministic simulation agrees with root reconstruction under the same hash. -/
 @[simp]
 theorem simulateQ_getPutativeRoot {s : Skeleton}
     (answer : QueryImpl (spec LeafAddress NodeAddress EncodedLeaf Digest) Id)
@@ -232,6 +250,7 @@ theorem simulateQ_getPutativeRoot {s : Skeleton}
   simp [getPutativeRoot, getPutativeRootWithHash]
   rfl
 
+/-- Deterministic simulation preserves the verifier result. -/
 @[simp]
 theorem simulateQ_verify {LeafAddress : Type u} {NodeAddress : Type v}
     {Payload : Type w} {EncodedLeaf : Type x} {Digest : Type} [DecidableEq Digest]
@@ -289,7 +308,8 @@ theorem simulateQ_verify_completeness {LeafAddress : Type u} {NodeAddress : Type
         addressing leafHashing idx (payloads.get idx)
         (buildWithHash addressing leafHashing payloads answer).getRootValue
         (generateProof (buildWithHash addressing leafHashing payloads answer) idx)) = true := by
-  simp
+  rw [simulateQ_verify]
+  exact verifyWithHash_completeness addressing leafHashing payloads idx answer
 
 /-- Prehashed identity leaves recover the existing addressed raw-digest builder. -/
 theorem buildWithHash_prehashed_id {s : Skeleton}

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -20,6 +20,7 @@ public import VCVioTest.LongChainPrograms
 public import VCVioTest.MeasureSemantics
 public import VCVioTest.MerkleTreeBatch
 public import VCVioTest.MerkleTreeExtractability
+public import VCVioTest.MerkleTreeHashing
 public import VCVioTest.MerkleTreeMonadic
 public import VCVioTest.MerkleTreeMultiExtractability
 public import VCVioTest.MonadProbability

--- a/VCVioTest/MerkleTreeHashing.lean
+++ b/VCVioTest/MerkleTreeHashing.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.MerkleTree.Hashing.Binding
+
+/-!
+# Canary tests for Merkle payload hashing
+
+These examples pin the executable distinction between leaf and node hash domains, concrete leaf
+addresses, ordered child digests, and the query-free prehashed-leaf specialization.
+-/
+
+@[expose] public section
+
+namespace VCVioTest.MerkleTreeHashingCanary
+
+open BinaryTree MerkleTreeHashing
+
+def twoLeaves : Skeleton := .internal .leaf .leaf
+
+def addressing : Addressing twoLeaves Bool Unit where
+  leaf
+    | .ofLeft .ofLeaf => false
+    | .ofRight .ofLeaf => true
+  node
+    | .ofInternal => ()
+
+def payloads : LeafData Nat twoLeaves := .internal (.leaf 3) (.leaf 5)
+
+/-- Branch-distinguishing leaf hashes and a noncommutative node hash. -/
+def answer : HashQuery Bool Unit Nat Nat → Nat
+  | .leaf false input => 100 + input
+  | .leaf true input => 200 + input
+  | .node () left right => 10 * left + right
+
+abbrev TraceM := StateM (List (HashQuery Bool Unit Nat Nat))
+
+instance : HasQuery (spec Bool Unit Nat Nat) TraceM where
+  query query := fun trace => (answer query, trace ++ [query])
+
+def hashedBuildRun := Id.run ((build (m := TraceM)
+    (LeafAddress := Bool) (NodeAddress := Unit) (Payload := Nat)
+    (EncodedLeaf := Nat) (Digest := Nat)
+    addressing (.hash fun payload => payload + 1) payloads).run [])
+
+def prehashedBuildRun := Id.run ((build (m := TraceM)
+    (LeafAddress := Bool) (NodeAddress := Unit) (Payload := Nat)
+    (EncodedLeaf := Nat) (Digest := Nat) addressing .prehashed payloads).run [])
+
+def verifyRun := Id.run ((verify (m := TraceM)
+    (LeafAddress := Bool) (NodeAddress := Unit) (Payload := Nat)
+    (EncodedLeaf := Nat) (Digest := Nat) addressing
+    (.hash fun payload => payload + 1) (.ofLeft .ofLeaf) 3 1246
+      (List.Vector.cons 206 .nil)).run [])
+
+/-- Encoded leaves use both the leaf-domain tag and the concrete leaf address. -/
+example : (buildWithHash addressing (.hash fun payload => payload + 1) payloads answer).getRootValue
+    = 1246 := by
+  decide
+
+/-- Root reconstruction hashes the encoded payload at the opened leaf before climbing the path. -/
+example : getPutativeRootWithHash addressing (.hash fun payload => payload + 1)
+    (.ofLeft .ofLeaf) 3 (List.Vector.cons 206 .nil) answer = 1246 := by
+  decide
+
+/-- The verifier accepts the same addressed, encoded opening. -/
+example : verifyWithHash addressing (.hash fun payload => payload + 1)
+    (.ofLeft .ofLeaf) 3 1246 (List.Vector.cons 206 .nil) answer = true := by
+  decide
+
+/-- Prehashed leaves bypass the leaf domain and retain their supplied digest labels. -/
+example : (buildWithHash addressing .prehashed payloads answer).getRootValue = 35 := by
+  decide
+
+/-- A two-leaf build queries the left leaf, the right leaf, then their ordered parent. -/
+example : hashedBuildRun.2 =
+    [HashQuery.leaf false 4, HashQuery.leaf true 6, HashQuery.node () 104 206] := by
+  decide
+
+/-- Raw digest leaves issue no leaf queries; only their ordered parent is hashed. -/
+example : prehashedBuildRun.2 = [HashQuery.node () 3 5] := by
+  decide
+
+/-- The operational verifier preserves its leaf-then-parent query trace. -/
+example : (verifyRun.1, verifyRun.2) =
+    (true, [HashQuery.leaf false 4, HashQuery.node () 104 206]) := by
+  decide
+
+/-- Encoded leaves and digests may inhabit different universes. -/
+example {LargeEncoding : Type 1} (encode : Nat → LargeEncoding)
+    (largeAnswer : HashQuery Bool Unit LargeEncoding Nat → Nat) :
+    FullData Nat twoLeaves :=
+  buildWithHash addressing (.hash encode) payloads largeAnswer
+
+/-- The provided-digest mode names its caller-owned transformation explicitly. -/
+example : (buildWithHash addressing (.providedDigest fun payload => payload + 7)
+    payloads answer).getRootValue = 112 := by
+  decide
+
+end VCVioTest.MerkleTreeHashingCanary

--- a/VCVioTest/MerkleTreeHashing.lean
+++ b/VCVioTest/MerkleTreeHashing.lean
@@ -15,7 +15,7 @@ These examples pin the executable distinction between leaf and node hash domains
 addresses, ordered child digests, and the query-free prehashed-leaf specialization.
 -/
 
-@[expose] public section
+public section
 
 namespace VCVioTest.MerkleTreeHashingCanary
 
@@ -73,6 +73,11 @@ example : verifyWithHash addressing (.hash fun payload => payload + 1)
     (.ofLeft .ofLeaf) 3 1246 (List.Vector.cons 206 .nil) answer = true := by
   decide
 
+/-- A wrong root is rejected rather than accepted after the same reconstruction. -/
+example : verifyWithHash addressing (.hash fun payload => payload + 1)
+    (.ofLeft .ofLeaf) 3 1247 (List.Vector.cons 206 .nil) answer = false := by
+  decide
+
 /-- Prehashed leaves bypass the leaf domain and retain their supplied digest labels. -/
 example : (buildWithHash addressing .prehashed payloads answer).getRootValue = 35 := by
   decide
@@ -101,5 +106,90 @@ example {LargeEncoding : Type 1} (encode : Nat → LargeEncoding)
 example : (buildWithHash addressing (.providedDigest fun payload => payload + 7)
     payloads answer).getRootValue = 112 := by
   decide
+
+/-! ## Internal-node addressing -/
+
+private def threeLeaves : Skeleton := .internal (.internal .leaf .leaf) .leaf
+
+private inductive DeepNodeAddress where
+  | root
+  | left
+deriving DecidableEq
+
+private def deepAddressing : Addressing threeLeaves (Fin 3) DeepNodeAddress where
+  leaf
+    | .ofLeft (.ofLeft .ofLeaf) => 0
+    | .ofLeft (.ofRight .ofLeaf) => 1
+    | .ofRight .ofLeaf => 2
+  node
+    | .ofInternal => .root
+    | .ofLeft .ofInternal => .left
+
+private def deepPayloads : LeafData Nat threeLeaves :=
+  .internal (.internal (.leaf 1) (.leaf 2)) (.leaf 3)
+
+private def deepAnswer : HashQuery (Fin 3) DeepNodeAddress Nat Nat → Nat
+  | .leaf address input => 10 * address.val + input
+  | .node .left left right => 100 + 10 * left + right
+  | .node .root left right => 1000 + 10 * left + right
+
+private abbrev DeepTraceM :=
+  StateM (List (HashQuery (Fin 3) DeepNodeAddress Nat Nat))
+
+private instance : HasQuery (spec (Fin 3) DeepNodeAddress Nat Nat) DeepTraceM where
+  query query := fun trace => (deepAnswer query, trace ++ [query])
+
+private def deepBuildRun := Id.run ((build (m := DeepTraceM)
+    (LeafAddress := Fin 3) (NodeAddress := DeepNodeAddress) (Payload := Nat)
+    (EncodedLeaf := Nat) (Digest := Nat) deepAddressing (.hash id) deepPayloads).run [])
+
+/-- A depth-two build forwards distinct internal addresses and retains postorder query order. -/
+example : (deepBuildRun.1.getRootValue, deepBuildRun.2) =
+    (2243,
+      [HashQuery.leaf 0 1, HashQuery.leaf 1 2, HashQuery.node .left 1 12,
+       HashQuery.leaf 2 3, HashQuery.node .root 122 23]) := by
+  decide
+
+/-! ## Degenerate collision boundaries -/
+
+private def leafCollisionAnswer : HashQuery Bool Unit Nat Nat → Nat
+  | .leaf _ _ => 7
+  | .node _ left right => 10 * left + right
+
+private def nodeCollisionAnswer : HashQuery Bool Unit Nat Nat → Nat
+  | .leaf _ input => input
+  | .node _ _ _ => 0
+
+/-- A constant encoding is reported at the caller-owned encoding boundary. -/
+example : EncodingCollision (fun _ : Bool => 0) false true := by
+  unfold EncodingCollision
+  decide
+
+/-- A constant caller-provided digest is reported at the digest-map boundary. -/
+example : DigestMapCollision (fun _ : Bool => 7) false true := by
+  unfold DigestMapCollision
+  decide
+
+/-- Distinct encoded leaves can collide within one concrete leaf domain. -/
+example : LeafHashCollision leafCollisionAnswer false 1 2 := by
+  unfold LeafHashCollision
+  decide
+
+/-- Distinct ordered pairs can collide within one concrete internal-node domain. -/
+example : NodeHashCollision addressing nodeCollisionAnswer
+    ((.ofInternal, 1, 9, 2, 8) :
+      SkeletonInternalIndex twoLeaves × Nat × Nat × Nat × Nat) := by
+  unfold NodeHashCollision
+  decide
+
+/-- The public binding theorem reaches the node-collision branch in a concrete model where
+encoding is injective and leaf hashing is collision-free on the two openings. -/
+example : ∃ witness, NodeHashCollision addressing nodeCollisionAnswer witness := by
+  obtain leafCollision | nodeCollision :=
+    hashed_binding_of_injective addressing id Function.injective_id nodeCollisionAnswer
+      (.ofLeft .ofLeaf) (List.Vector.cons 9 .nil) (List.Vector.cons 8 .nil)
+      1 2 (by decide) (by decide)
+  · simp [LeafHashCollision, nodeCollisionAnswer] at leafCollision
+  · exact nodeCollision
 
 end VCVioTest.MerkleTreeHashingCanary

--- a/VCVioTest/MerkleTreeHashing.lean
+++ b/VCVioTest/MerkleTreeHashing.lean
@@ -107,6 +107,16 @@ example : (buildWithHash addressing (.providedDigest fun payload => payload + 7)
     payloads answer).getRootValue = 112 := by
   decide
 
+/-- Ordinary imports simplify honest verification through the general simulation and
+completeness rules, without a separate overlapping simp rule. -/
+example {s : Skeleton} (a : Addressing s Bool Unit) (p : LeafData Nat s)
+    (i : SkeletonLeafIndex s) (impl : QueryImpl (spec Bool Unit Nat Nat) Id) :
+    simulateQ impl
+      (verify (m := OracleComp (spec Bool Unit Nat Nat)) a (.hash id) i (p.get i)
+        (buildWithHash a (.hash id) p impl).getRootValue
+        (InductiveMerkleTree.generateProof (buildWithHash a (.hash id) p impl) i)) = true := by
+  simp only [simulateQ_verify, verifyWithHash_completeness]
+
 /-! ## Internal-node addressing -/
 
 private def threeLeaves : Skeleton := .internal (.internal .leaf .leaf) .leaf


### PR DESCRIPTION
## Summary

Separate application payloads, encoded leaves, and Merkle digests. Tagged leaf/node queries retain concrete addresses and ordered child digests; build, root reconstruction, and verification reuse the addressed binary Merkle engine.

The binding theorems identify the boundary responsible when distinct payloads reconstruct the same root at the same index: encoding collision, leaf-hash collision, or internal-node collision. Caller-provided digest maps have their own collision case; identity prehashed leaves issue no leaf query.

## Scope and reviewer map

- `Hashing/Defs.lean`: query domains, leaf modes, addressing, effectful/deterministic APIs, simulation and honest-opening completeness, raw-digest compatibility.
- `Hashing/Binding.lean`: four collision predicates and binding theorem families. These use classical equality decisions and provide existential witnesses; they are not an executable collision finder or a probabilistic security reduction.
- `VCVioTest/MerkleTreeHashing.lean`: exact roots and query traces, wrong-root rejection, depth-two distinct internal addresses, collision-boundary models, prehashed query bypass, universe separation, and ordinary-import simplification.
- `VCVio.lean` and `VCVioTest.lean`: register the modules.

Address maps need not be injective. The binding claim uses the same intrinsic leaf index and addressing on both openings. Byte serialization, canonical application encodings, cross-index layout binding, and probabilistic reductions remain outside this slice.

## Stack

Prerequisite #616 has merged. This PR targets current `main`; #621 builds on this branch.

## Review repairs

- Selected per-definition and derived-equality exposure preserves public execution and the forest translation proofs while meeting the current module boundary policy.
- Documented the simulation laws, removed an unused monad assumption from `nodeDigest`, and retained the honest-verification theorem without a redundant simp registration.
- Added discriminating rejection, addressing, and collision tests. Independent source review found no mathematical correctness defect.

## Verification

Final head: `5b3af7ed524a58ef108a30937a8dfebd2a76fa4b`, based on merged main `a042dcde` (#673). The PR changes five files (+696 lines) relative to that main.

- Full `./scripts/validate.sh --lint --test --axioms`: PASS on repaired Merkle candidate `c3841d3a`, including all seven library linters and registered executable tests. 18,333 declarations / 591 modules; no new axiom or sorry taint.
- Merkle source and tests are byte-for-byte unchanged by the main integration.
- Final combined #618 → #621 stack (`d9e78f0d`) on main `a042dcde`: `lake build VCVioTest` and `./scripts/validate.sh --lint --axioms` PASS. This includes the runtime and both Merkle test modules. 18,553 declarations / 595 modules, 40 existing sorry-tainted declarations, zero nonstandard-axiom taint, no new debt.
- All 14 principal hashing/binding theorem axiom probes use only standard Lean axioms. Lint and trust baselines unchanged.
- Fresh hosted CI is running. Native FFI executable tests are outside the standard PR validation command.
