### PR TITLE
refactor(LatticeCrypto): adopt valMinAbs, reduce_mod_char, and AdjoinRoot in the ring layer

### DIFF
--- a/Extern/MLDSA/Laws.lean
+++ b/Extern/MLDSA/Laws.lean
@@ -233,8 +233,9 @@ theorem concrete_sampleInBall_smul_bound
 /-! ## `Primitives.Laws` status for `concretePrimitives` (no full witness — by design)
 
 Thirteen `Primitives.Laws` fields are proven for the concrete instance at any approved parameter
-set. The transform field inherits the repository's disclosed `native_decide` certificate for
-the concrete NTT matrix inversion; the remaining proofs introduce no additional project-specific
+set. The transform field is proved from the structural butterfly stages of
+`LatticeCrypto/Ring/NTTCert.lean` (no `native_decide`; the runtime loop kernels remain an
+`implemented_by` refinement boundary); the remaining proofs introduce no additional project-specific
 trust assumptions. These fields are: the eight algebraic fields (`concrete_transform`,
 `concrete_high_low_decomp`, `concrete_lowBits_bound`, `concrete_hide_low`,
 `concrete_highBitsShift_injective`, `concrete_useHint_makeHint`, `concrete_power2Round_decomp`,

--- a/Extern/MLDSA/NonVacuity.lean
+++ b/Extern/MLDSA/NonVacuity.lean
@@ -32,14 +32,16 @@ makes the published seed-component injective (matching `ρ` forces the same seed
 `t₀`).  Injectivity of the published seed-component is precisely the structural feature that makes
 `keyVector_t0_determined` satisfiable by a deterministic bundle.
 
-**Trust surface.**  `mldsa_laws_inhabited` depends on `propext`, `Classical.choice`, `Quot.sound`,
-**and** the `native_decide` certificate for the concrete `256×256` NTT matrix inversion
-(`MLDSA.Concrete.invNTTMatrix_nttMatrix_entry`, routed in through `concrete_transform`).  That
-`native_decide` axiom is carried by every concrete ML-DSA fact (e.g. `concrete_transform` itself),
-since `concreteNTTRingOps` is the only `NTTRingLaws` instance in the tree.  The *abstract*
-`Laws`-gated theorems (quantified over `nttOps`) are themselves axiom-clean
-`[propext, Classical.choice, Quot.sound]`; this certificate only witnesses that their `Laws`
-hypothesis can be met by the concrete layer (whose NTT-correctness trust assumption it inherits).
+**Trust surface.**  `mldsa_laws_inhabited` depends only on `propext`, `Classical.choice`, and
+`Quot.sound`; no `native_decide` remains in the proof libraries (the dense `256×256` NTT
+certificate was retired in favour of the structural butterfly stages of
+`LatticeCrypto/Ring/NTTCert.lean`, whose round-trip laws are proved from per-stage twiddle
+identities).  What is still trusted is not an axiom but the `@[implemented_by]` refinement
+boundary: the imperative `loopNTT`/`loopInvNTT` kernels are rebound at runtime and are not proved
+extensionally equal to the structural stages, and `multiplyNTTs` is defined through
+`invNTT`/`ntt` rather than verified pointwise.  The *abstract* `Laws`-gated theorems (quantified
+over `nttOps`) are unaffected; this witness only shows that their `Laws` hypothesis can be met by
+the concrete layer.
 -/
 
 @[expose] public section
@@ -95,7 +97,7 @@ theorem seedRevealingPrims_laws (p : Params) (hp : p.isApproved) :
 bundle whose `Primitives.Laws` is inhabited — so the `Laws`-gated ML-DSA theorems
 (`MLDSA.idsWithAbort_complete`, `MLDSA.idsWithAbort_hvzk`, `MLDSA.fipsSign_fipsVerify_correct`,
 `MLDSA.keyGenFromSeed_wApprox_eq`, `MLDSA.recoverT0_eq`) are not true-but-vacuous.  (See the
-trust-surface note in the module docstring on the inherited concrete NTT `native_decide` axiom.) -/
+trust-surface note in the module docstring on the `implemented_by` refinement boundary.) -/
 theorem mldsa_laws_inhabited :
     ∃ (p : Params) (prims : MLDSA.Primitives p),
       Nonempty (MLDSA.Primitives.Laws prims MLDSA.Concrete.concreteNTTRingOps) :=

--- a/Extern/MLDSA/NonVacuity.lean
+++ b/Extern/MLDSA/NonVacuity.lean
@@ -33,11 +33,10 @@ makes the published seed-component injective (matching `ρ` forces the same seed
 `keyVector_t0_determined` satisfiable by a deterministic bundle.
 
 **Trust surface.**  `mldsa_laws_inhabited` depends only on `propext`, `Classical.choice`, and
-`Quot.sound`; no `native_decide` remains in the proof libraries (the dense `256×256` NTT
-certificate was retired in favour of the structural butterfly stages of
-`LatticeCrypto/Ring/NTTCert.lean`, whose round-trip laws are proved from per-stage twiddle
-identities).  What is still trusted is not an axiom but the `@[implemented_by]` refinement
-boundary: the imperative `loopNTT`/`loopInvNTT` kernels are rebound at runtime and are not proved
+`Quot.sound`. The structural butterfly stages in `LatticeCrypto/Ring/NTTCert.lean` have
+round-trip laws proved from per-stage twiddle identities. The executable implementation has
+an `@[implemented_by]` refinement boundary: the imperative `loopNTT`/`loopInvNTT` kernels are
+rebound at runtime and are not proved
 extensionally equal to the structural stages, and `multiplyNTTs` is defined through
 `invNTT`/`ntt` rather than verified pointwise.  The *abstract* `Laws`-gated theorems (quantified
 over `nttOps`) are unaffected; this witness only shows that their `Laws` hypothesis can be met by

--- a/LatticeCrypto/Falcon/Concrete/NTT.lean
+++ b/LatticeCrypto/Falcon/Concrete/NTT.lean
@@ -5,7 +5,9 @@ Authors: Quang Dao
 -/
 
 module
+import Mathlib.Tactic.ReduceModChar
 public import LatticeCrypto.Falcon.Arithmetic
+public import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
 # Concrete NTT for Falcon
@@ -33,6 +35,31 @@ open Falcon
 
 private def primitiveRoot2N (logn : ℕ) : Coeff :=
   (11 : Coeff) ^ ((modulus - 1) / (2 * (2 ^ logn)))
+
+/-- `primitiveRoot2N 10 = 11 ^ 6` is a primitive `2048`-th root of unity in `ℤ_q` (`n = 1024`): the
+twiddle half of an NTT correctness argument for the concrete backend. -/
+private theorem primitiveRoot2N_isPrimitiveRoot_1024 :
+    IsPrimitiveRoot (primitiveRoot2N 10) 2048 := by
+  change IsPrimitiveRoot ((11 : ZMod 12289) ^ 6) 2048
+  rw [IsPrimitiveRoot.iff_orderOf]
+  refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num) (by reduce_mod_char) ?_
+  intro p hp hdvd
+  obtain rfl : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp
+    (hp.dvd_of_dvd_pow (show p ∣ 2 ^ 11 by simpa using hdvd))
+  reduce_mod_char
+  decide
+
+/-- `primitiveRoot2N 9 = 11 ^ 12` is a primitive `1024`-th root of unity in `ℤ_q` (`n = 512`). -/
+private theorem primitiveRoot2N_isPrimitiveRoot_512 :
+    IsPrimitiveRoot (primitiveRoot2N 9) 1024 := by
+  change IsPrimitiveRoot ((11 : ZMod 12289) ^ 12) 1024
+  rw [IsPrimitiveRoot.iff_orderOf]
+  refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num) (by reduce_mod_char) ?_
+  intro p hp hdvd
+  obtain rfl : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp
+    (hp.dvd_of_dvd_pow (show p ∣ 2 ^ 10 by simpa using hdvd))
+  reduce_mod_char
+  decide
 
 private def bitRevN (logn : ℕ) (i : Nat) : Nat := Id.run do
   let mut r := 0

--- a/LatticeCrypto/MLDSA/Concrete/NTT.lean
+++ b/LatticeCrypto/MLDSA/Concrete/NTT.lean
@@ -8,12 +8,14 @@ module
 import all Init.Data.Array.Basic
 import all Init.Data.Vector.Algebra
 import all LatticeCrypto.MLDSA.Arithmetic
+import Mathlib.Tactic.ReduceModChar
 public meta import LatticeCrypto.MLDSA.Arithmetic
 public meta import Mathlib.Data.Fintype.Defs
 public meta import Mathlib.Data.ZMod.Defs
 public import LatticeCrypto.MLDSA.Arithmetic
 public import LatticeCrypto.Ring.NTTCert
 public import Mathlib.Algebra.BigOperators.Ring.Finset
+public import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
 # Concrete NTT for ML-DSA
@@ -73,59 +75,21 @@ private theorem getZ_zetaTable (i : Nat) (hi : i < 256) :
     getZ zetaTable i = zeta ^ bitRev8 i := by
   simp [getZ, zetaTable, hi]
 
-private theorem square_mod (a b : Nat) (h : a ^ 2 % modulus = b) (hb : b < modulus) :
-    (a : Coeff) ^ 2 = b := by
-  rw [← Nat.cast_pow, ZMod.natCast_eq_natCast_iff']
-  simpa [Nat.mod_eq_of_lt hb] using h
-
 private theorem zeta_pow_256 : (zeta : Coeff) ^ 256 = -1 := by
-  have h2 : (zeta : Coeff) ^ 2 = 3073009 := by
-    change (1753 : Coeff) ^ 2 = 3073009
-    exact square_mod 1753 3073009 (by norm_num [modulus]) (by norm_num [modulus])
-  have h4 : (zeta : Coeff) ^ 4 = 3602218 := by
-    calc
-      zeta ^ 4 = (zeta ^ 2) ^ 2 := by ring
-      _ = (3073009 : Coeff) ^ 2 := by rw [h2]
-      _ = 3602218 := square_mod 3073009 3602218
-        (by norm_num [modulus]) (by norm_num [modulus])
-  have h8 : (zeta : Coeff) ^ 8 = 5010068 := by
-    calc
-      zeta ^ 8 = (zeta ^ 4) ^ 2 := by ring
-      _ = (3602218 : Coeff) ^ 2 := by rw [h4]
-      _ = 5010068 := square_mod 3602218 5010068
-        (by norm_num [modulus]) (by norm_num [modulus])
-  have h16 : (zeta : Coeff) ^ 16 = 7778734 := by
-    calc
-      zeta ^ 16 = (zeta ^ 8) ^ 2 := by ring
-      _ = (5010068 : Coeff) ^ 2 := by rw [h8]
-      _ = 7778734 := square_mod 5010068 7778734
-        (by norm_num [modulus]) (by norm_num [modulus])
-  have h32 : (zeta : Coeff) ^ 32 = 5178923 := by
-    calc
-      zeta ^ 32 = (zeta ^ 16) ^ 2 := by ring
-      _ = (7778734 : Coeff) ^ 2 := by rw [h16]
-      _ = 5178923 := square_mod 7778734 5178923
-        (by norm_num [modulus]) (by norm_num [modulus])
-  have h64 : (zeta : Coeff) ^ 64 = 3765607 := by
-    calc
-      zeta ^ 64 = (zeta ^ 32) ^ 2 := by ring
-      _ = (5178923 : Coeff) ^ 2 := by rw [h32]
-      _ = 3765607 := square_mod 5178923 3765607
-        (by norm_num [modulus]) (by norm_num [modulus])
-  have h128 : (zeta : Coeff) ^ 128 = 4808194 := by
-    calc
-      zeta ^ 128 = (zeta ^ 64) ^ 2 := by ring
-      _ = (3765607 : Coeff) ^ 2 := by rw [h64]
-      _ = 4808194 := square_mod 3765607 4808194
-        (by norm_num [modulus]) (by norm_num [modulus])
-  calc
-    zeta ^ 256 = (zeta ^ 128) ^ 2 := by ring
-    _ = (4808194 : Coeff) ^ 2 := by rw [h128]
-    _ = -1 := by
-      rw [eq_neg_iff_add_eq_zero]
-      change (((4808194 ^ 2 + 1 : Nat) : ZMod modulus)) = 0
-      rw [ZMod.natCast_eq_zero_iff]
-      norm_num [modulus]
+  change (1753 : ZMod 8380417) ^ 256 = -1
+  reduce_mod_char
+
+/-- `ζ = 1753` is a primitive `512`-th root of unity in `ℤ_q` (FIPS 204 §7.5): the twiddle half
+of the NTT correctness argument. -/
+theorem zeta_isPrimitiveRoot : IsPrimitiveRoot (zeta : Coeff) 512 := by
+  change IsPrimitiveRoot (1753 : ZMod 8380417) 512
+  rw [IsPrimitiveRoot.iff_orderOf]
+  refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num) (by reduce_mod_char) ?_
+  intro p hp hdvd
+  obtain rfl : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp
+    (hp.dvd_of_dvd_pow (show p ∣ 2 ^ 9 by simpa using hdvd))
+  reduce_mod_char
+  decide
 
 /-- Forward and complementary inverse-table twiddles in one layer multiply to `-1`. -/
 private theorem zetaTable_layer_partner :

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -446,22 +446,14 @@ private theorem alpha_le_natAbs_centeredRepr_mul
     have hz : (z : Coeff) = ((z.toNat : ℕ) : Coeff) := by
       rw [← Int.cast_natCast (R := Coeff), Int.toNat_of_nonneg hznn]
     rw [hz, ← Nat.cast_mul]
-  rw [hcoeff_eq]
-  have hlt : alpha * z.toNat < modulus :=
-    calc alpha * z.toNat < alpha * m := Nat.mul_lt_mul_of_pos_left hzm ctx.hα
-      _ = modulus - 1 := ctx.hqm1
-      _ < modulus := Nat.sub_lt (by decide) one_pos
-  by_cases hle : (((alpha * z.toNat : ℕ) : Coeff).val : ℤ) ≤ (modulus : ℤ) / 2
-  · rw [centeredRepr_of_le hle, ZMod.val_natCast_of_lt hlt, Int.natAbs_natCast]
-    exact Nat.le_mul_of_pos_right alpha (by have := Int.toNat_of_nonneg hznn; omega)
-  · push Not at hle
-    have hq : modulus = alpha * m + 1 := by have := ctx.hsmall; have := ctx.hqm1; omega
-    rw [centeredRepr_of_gt hle, ZMod.val_natCast_of_lt hlt,
-      Int.natAbs_natCast_sub_natCast_of_le hlt.le, Nat.le_sub_iff_add_le hlt.le, hq]
-    calc alpha + alpha * z.toNat
-        = alpha * (z.toNat + 1) := by ring
-      _ ≤ alpha * m             := Nat.mul_le_mul_left alpha (Nat.succ_le_of_lt hzm)
-      _ ≤ alpha * m + 1         := Nat.le_succ _
+  have hq : modulus = alpha * m + 1 := by have := ctx.hsmall; have := ctx.hqm1; omega
+  have hle : alpha * z.toNat + alpha ≤ alpha * m := by
+    have := Nat.mul_le_mul_left alpha hzm; rwa [Nat.mul_succ] at this
+  have hpos : alpha ≤ alpha * z.toNat :=
+    Nat.le_mul_of_pos_right alpha (by have := Int.toNat_of_nonneg hznn; omega)
+  rw [hcoeff_eq, centeredRepr_eq_valMinAbs, ZMod.valMinAbs_natAbs_eq_min,
+    ZMod.val_natCast_of_lt (by omega)]
+  omega
 
 private theorem highBitsCoeff_add_eq_of_centeredRepr_lt
     {alpha m b : ℕ} (ctx : BalancedDecomp alpha m) (r s : Coeff)

--- a/LatticeCrypto/MLDSA/SecurityNMA.lean
+++ b/LatticeCrypto/MLDSA/SecurityNMA.lean
@@ -164,9 +164,7 @@ lemma polyVecBounded_zero (k b : ℕ) : polyVecBounded (0 : RqVec k) b := by
     have hci : Vector.get (0 : Rq) i = (0 : Coeff) :=
       LatticeCrypto.NegacyclicRing.coeff_zero coeffRing i
     rw [hci]
-    simp only [LatticeCrypto.zmodCenteredCoeffView, LatticeCrypto.centeredRepr, ZMod.val_zero,
-      Int.natCast_zero]
-    split <;> omega
+    simp [LatticeCrypto.zmodCenteredCoeffView, LatticeCrypto.centeredRepr]
   calc normOps.cInfNorm (0 : Rq) = polyNorm (0 : Rq) := rfl
     _ = 0 := h0
     _ ≤ b := Nat.zero_le b

--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -509,16 +509,11 @@ private def byteDecode12VecPoly {k : Nat} (bytes : ByteArray) (poly : Fin k) : T
 
 private theorem decode12Pair_fst {a b : Nat} (ha : a < 4096) :
     a % 256 + 256 * ((a / 256 + 16 * (b % 16)) % 16) = a := by
-  have hdiv : a / 256 < 16 := by omega
-  rw [Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hdiv]
-  exact Nat.mod_add_div a 256
+  omega
 
 private theorem decode12Pair_snd {a b : Nat} (ha : a < 4096) :
     (a / 256 + 16 * (b % 16)) / 16 + 16 * (b / 16) = b := by
-  have hdiv : a / 256 < 16 := by omega
-  rw [Nat.mul_comm 16, Nat.add_mul_div_right _ _ (by decide), Nat.div_eq_of_lt hdiv,
-    zero_add]
-  exact Nat.mod_add_div b 16
+  omega
 
 private theorem getByteD_eq_getElem {bytes : ByteArray} {i : Nat} (hi : i < bytes.size) :
     getByteD bytes i = bytes[i] := by

--- a/LatticeCrypto/MLKEM/Concrete/NTT.lean
+++ b/LatticeCrypto/MLKEM/Concrete/NTT.lean
@@ -8,6 +8,7 @@ module
 import all Init.Data.Array.Basic
 import all Init.Data.Vector.Algebra
 import all LatticeCrypto.MLKEM.Arithmetic
+import Mathlib.Tactic.ReduceModChar
 public meta import LatticeCrypto.MLKEM.Arithmetic
 public meta import LatticeCrypto.MLKEM.Params
 public meta import Mathlib.Data.Fintype.Defs
@@ -15,6 +16,7 @@ public meta import Mathlib.Data.ZMod.Defs
 public import LatticeCrypto.MLKEM.Arithmetic
 public import LatticeCrypto.Ring.NTTCert
 public import Mathlib.Algebra.BigOperators.Ring.Finset
+public import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
 # Concrete NTT for ML-KEM
@@ -103,56 +105,20 @@ private theorem getZ_zetaArray (i : Nat) (hi : i < 128) :
   simp [getZ, zetaArray, hi]
 
 private theorem zeta_pow_128 : (zeta : Coeff) ^ 128 = -1 := by
-  have h2 : (zeta : Coeff) ^ 2 = 289 := by
-    norm_num [MLKEM.zeta, MLKEM.modulus]
-  have h4 : (zeta : Coeff) ^ 4 = 296 := by
-    calc
-      zeta ^ 4 = (zeta ^ 2) ^ 2 := by ring
-      _ = (289 : Coeff) ^ 2 := by rw [h2]
-      _ = 296 := by
-        change ((289 ^ 2 : Nat) : ZMod 3329) = ((296 : Nat) : ZMod 3329)
-        rw [ZMod.natCast_eq_natCast_iff']
-        norm_num
-  have h8 : (zeta : Coeff) ^ 8 = 1062 := by
-    calc
-      zeta ^ 8 = (zeta ^ 4) ^ 2 := by ring
-      _ = (296 : Coeff) ^ 2 := by rw [h4]
-      _ = 1062 := by
-        change ((296 ^ 2 : Nat) : ZMod 3329) = ((1062 : Nat) : ZMod 3329)
-        rw [ZMod.natCast_eq_natCast_iff']
-        norm_num
-  have h16 : (zeta : Coeff) ^ 16 = 2642 := by
-    calc
-      zeta ^ 16 = (zeta ^ 8) ^ 2 := by ring
-      _ = (1062 : Coeff) ^ 2 := by rw [h8]
-      _ = 2642 := by
-        change ((1062 ^ 2 : Nat) : ZMod 3329) = ((2642 : Nat) : ZMod 3329)
-        rw [ZMod.natCast_eq_natCast_iff']
-        norm_num
-  have h32 : (zeta : Coeff) ^ 32 = 2580 := by
-    calc
-      zeta ^ 32 = (zeta ^ 16) ^ 2 := by ring
-      _ = (2642 : Coeff) ^ 2 := by rw [h16]
-      _ = 2580 := by
-        change ((2642 ^ 2 : Nat) : ZMod 3329) = ((2580 : Nat) : ZMod 3329)
-        rw [ZMod.natCast_eq_natCast_iff']
-        norm_num
-  have h64 : (zeta : Coeff) ^ 64 = 1729 := by
-    calc
-      zeta ^ 64 = (zeta ^ 32) ^ 2 := by ring
-      _ = (2580 : Coeff) ^ 2 := by rw [h32]
-      _ = 1729 := by
-        change ((2580 ^ 2 : Nat) : ZMod 3329) = ((1729 : Nat) : ZMod 3329)
-        rw [ZMod.natCast_eq_natCast_iff']
-        norm_num
-  calc
-    zeta ^ 128 = (zeta ^ 64) ^ 2 := by ring
-    _ = (1729 : Coeff) ^ 2 := by rw [h64]
-    _ = -1 := by
-      rw [eq_neg_iff_add_eq_zero]
-      change (((1729 ^ 2 + 1 : Nat) : ZMod 3329)) = 0
-      rw [ZMod.natCast_eq_zero_iff]
-      norm_num
+  change (17 : ZMod 3329) ^ 128 = -1
+  reduce_mod_char
+
+/-- `ζ = 17` is a primitive `256`-th root of unity in `ℤ_q` (FIPS 203 §4.3): the twiddle half of
+the NTT correctness argument. -/
+theorem zeta_isPrimitiveRoot : IsPrimitiveRoot (zeta : Coeff) 256 := by
+  change IsPrimitiveRoot (17 : ZMod 3329) 256
+  rw [IsPrimitiveRoot.iff_orderOf]
+  refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num) (by reduce_mod_char) ?_
+  intro p hp hdvd
+  obtain rfl : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp
+    (hp.dvd_of_dvd_pow (show p ∣ 2 ^ 8 by simpa using hdvd))
+  reduce_mod_char
+  decide
 
 /-- The twiddle used by a forward butterfly and the complementary twiddle
 used by its matching inverse butterfly multiply to `-1`. -/

--- a/LatticeCrypto/Ring/Core.lean
+++ b/LatticeCrypto/Ring/Core.lean
@@ -7,6 +7,7 @@ Authors: Quang Dao
 module
 public import Init.Data.Vector.Basic
 public import Mathlib.LinearAlgebra.Matrix.Defs
+public import Mathlib.RingTheory.AdjoinRoot
 public import Mathlib.RingTheory.Ideal.Operations
 public import Mathlib.RingTheory.Ideal.Quotient.Basic
 public import Mathlib.RingTheory.Polynomial.Basic
@@ -178,7 +179,10 @@ noncomputable def negacyclicModulus (R : Type u) [Semiring R] (n : Nat) : Polyno
 
 This is the mathematical ring that executable `NegacyclicRing` operations are
 sound with respect to. The soundness bridge is provided by
-`NegacyclicRingSemantics` in `LatticeCrypto.Ring.Kernel`. -/
+`NegacyclicRingSemantics` in `LatticeCrypto.Ring.Kernel`.
+
+It is definitionally `AdjoinRoot (negacyclicModulus R n)`, so Mathlib's `AdjoinRoot` API
+(`AdjoinRoot.mk`, `modByMonicHom`, `powerBasis'`) applies to it directly. -/
 abbrev NegacyclicQuotient (R : Type u) [CommRing R] (n : Nat) :=
   Polynomial R ⧸ (Ideal.span ({negacyclicModulus R n} : Set (Polynomial R)))
 
@@ -197,17 +201,6 @@ noncomputable def ofBackend (backend : PolyBackend R) (p : backend.Poly) :
 
 /-! ### Injectivity of `ofBackend` -/
 
-/-- Pushing `Polynomial.coeff n` inside a `Finset.sum` of polynomials.
-This is `AddMonoidHom.map_sum` for `Polynomial.lcoeff`, stated in a form that
-avoids dot-notation on `LinearMap` (which is not a structure field). -/
-private theorem polyCoeffFinsetSum {R : Type u} [CommRing R] {ι : Type*}
-    (s : Finset ι) (f : ι → Polynomial R) (n : ℕ) :
-    (∑ x ∈ s, f x).coeff n = ∑ x ∈ s, (f x).coeff n := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp
-  | @insert a s ha ih => simp [Finset.sum_insert ha, ih]
-
 /-- `toPolynomial` is injective: distinct coefficient arrays yield
 distinct polynomials. -/
 theorem PolyBackend.toPolynomial_injective {R : Type u} [CommRing R]
@@ -217,10 +210,8 @@ theorem PolyBackend.toPolynomial_injective {R : Type u} [CommRing R]
   intro i
   have extract : ∀ x : backend.Poly,
       (backend.toPolynomial x).coeff i.val = backend.coeff x i := fun x => by
-    simp only [PolyBackend.toPolynomial]
-    rw [polyCoeffFinsetSum]
-    simp only [Polynomial.coeff_monomial, Fin.val_inj,
-               Finset.sum_ite_eq', Finset.mem_univ, if_true]
+    simp only [PolyBackend.toPolynomial, Polynomial.finsetSum_coeff, Polynomial.coeff_monomial,
+      Fin.val_inj, Finset.sum_ite_eq', Finset.mem_univ, if_true]
   rw [← extract p, ← extract q, h]
 
 /-- Coefficients of `toPolynomial x` at indices `≥ backend.degree` are zero. -/
@@ -228,8 +219,7 @@ private theorem PolyBackend.toPolynomial_coeff_high {R : Type u} [CommRing R]
     (backend : PolyBackend R) (x : backend.Poly) {j : Nat}
     (hj : backend.degree ≤ j) :
     (backend.toPolynomial x).coeff j = 0 := by
-  simp only [PolyBackend.toPolynomial]
-  rw [polyCoeffFinsetSum]
+  simp only [PolyBackend.toPolynomial, Polynomial.finsetSum_coeff]
   apply Finset.sum_eq_zero
   intro i _
   simp only [Polynomial.coeff_monomial]
@@ -242,37 +232,25 @@ theorem ofBackend_injective
     Function.Injective (NegacyclicQuotient.ofBackend backend) := by
   intro p q heq
   apply PolyBackend.toPolynomial_injective
-  simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial] at heq
+  rcases subsingleton_or_nontrivial R with hR | hR
+  · exact Subsingleton.elim _ _
   rcases Nat.eq_zero_or_pos backend.degree with hn | hn
   · have : IsEmpty (Fin backend.degree) := hn ▸ inferInstance
     simp [PolyBackend.toPolynomial]
-  have hmem : backend.toPolynomial p - backend.toPolynomial q ∈
-      Ideal.span ({negacyclicModulus R backend.degree} : Set (Polynomial R)) := by
-    have hzero : Ideal.Quotient.mk
-        (Ideal.span ({negacyclicModulus R backend.degree} : Set (Polynomial R)))
-        (backend.toPolynomial p - backend.toPolynomial q) = 0 := by
-      simp [map_sub, heq]
-    rwa [Ideal.Quotient.eq_zero_iff_mem] at hzero
-  rw [Ideal.mem_span_singleton] at hmem
-  obtain ⟨c, hc⟩ := hmem
-  suffices hc0 : c = 0 by
-    have : backend.toPolynomial p - backend.toPolynomial q = 0 := by
-      rw [hc, hc0, mul_zero]
-    exact sub_eq_zero.mp this
-  by_contra hcne
-  have hzero : (backend.toPolynomial p - backend.toPolynomial q).coeff
-      (c.natDegree + backend.degree) = 0 := by
-    simp only [Polynomial.coeff_sub,
-      PolyBackend.toPolynomial_coeff_high backend p (Nat.le_add_left _ _),
-      PolyBackend.toPolynomial_coeff_high backend q (Nat.le_add_left _ _), sub_self]
-  have hnonzero : (negacyclicModulus R backend.degree * c).coeff
-      (c.natDegree + backend.degree) ≠ 0 := by
-    have hdeg : c.natDegree < c.natDegree + backend.degree := by omega
-    simp only [negacyclicModulus, add_mul, one_mul, Polynomial.coeff_add,
-               mul_comm (Polynomial.X ^ backend.degree) c, Polynomial.coeff_mul_X_pow,
-               Polynomial.coeff_eq_zero_of_natDegree_lt hdeg, add_zero]
-    exact Polynomial.leadingCoeff_ne_zero.mpr hcne
-  exact hnonzero (hc ▸ hzero)
+  have hmonic : (negacyclicModulus R backend.degree).Monic := by
+    simpa [negacyclicModulus] using Polynomial.monic_X_pow_add_C (a := (1 : R)) hn.ne'
+  have hdeg : (negacyclicModulus R backend.degree).degree = backend.degree := by
+    simpa [negacyclicModulus] using Polynomial.degree_X_pow_add_C hn (1 : R)
+  have hlt : ∀ x : backend.Poly,
+      (backend.toPolynomial x).degree < (negacyclicModulus R backend.degree).degree := fun x => by
+    rw [hdeg, Polynomial.degree_lt_iff_coeff_zero]
+    exact fun m hm => PolyBackend.toPolynomial_coeff_high backend x hm
+  have key : ∀ x : backend.Poly,
+      AdjoinRoot.modByMonicHom hmonic (NegacyclicQuotient.ofBackend backend x) =
+        backend.toPolynomial x := fun x => by
+    change AdjoinRoot.modByMonicHom hmonic (AdjoinRoot.mk _ (backend.toPolynomial x)) = _
+    rw [AdjoinRoot.modByMonicHom_mk, (Polynomial.modByMonic_eq_self_iff hmonic).2 (hlt x)]
+  rw [← key p, ← key q, heq]
 
 end NegacyclicQuotient
 

--- a/LatticeCrypto/Ring/Norms.lean
+++ b/LatticeCrypto/Ring/Norms.lean
@@ -68,84 +68,56 @@ section CenteredRepr
 
 variable {q : ℕ} [NeZero q]
 
-/-- The centered representative of `x : ZMod q`, mapping to the unique integer in
-`[-(q-1)/2, (q-1)/2]` congruent to `x` mod `q`. -/
-def centeredRepr (x : ZMod q) : ℤ :=
-  if (x.val : ℤ) ≤ (q : ℤ) / 2 then (x.val : ℤ) else (x.val : ℤ) - q
+/-- The centered representative of `x : ZMod q`, the unique integer in `(-q/2, q/2]` congruent to
+`x`. This is `ZMod.valMinAbs`; the name is kept because it is the FIPS-facing vocabulary of the
+rounding and norm layers, and the lemmas below are its API restated on that name. -/
+def centeredRepr (x : ZMod q) : ℤ := x.valMinAbs
 
-omit [NeZero q] in
 @[simp] theorem centeredRepr_of_le {x : ZMod q} (h : (x.val : ℤ) ≤ (q : ℤ) / 2) :
     centeredRepr x = x.val := by
-  unfold centeredRepr
-  exact if_pos h
+  rw [centeredRepr, ZMod.valMinAbs_def_pos, if_pos (by omega)]
 
-omit [NeZero q] in
 @[simp] theorem centeredRepr_of_gt {x : ZMod q} (h : (q : ℤ) / 2 < (x.val : ℤ)) :
     centeredRepr x = (x.val : ℤ) - q := by
-  unfold centeredRepr
-  exact if_neg (not_le.mpr h)
+  rw [centeredRepr, ZMod.valMinAbs_def_pos, if_neg (by omega)]
 
 /-- The centered representative is always at most `q / 2`. -/
 theorem centeredRepr_upper_bound (x : ZMod q) : centeredRepr x ≤ (q : ℤ) / 2 := by
-  simp only [centeredRepr]
-  split_ifs with h
-  · exact h
-  · push Not at h
-    have hval := ZMod.val_lt x
-    omega
+  have := (ZMod.valMinAbs_mem_Ioc x).2
+  unfold centeredRepr
+  omega
 
 /-- The centered representative has absolute value at most `q / 2`. -/
-theorem centeredRepr_abs_le (x : ZMod q) : (centeredRepr x).natAbs ≤ q / 2 := by
-  simp only [centeredRepr]
-  have hval := ZMod.val_lt x
-  split_ifs with h <;> omega
+theorem centeredRepr_abs_le (x : ZMod q) : (centeredRepr x).natAbs ≤ q / 2 :=
+  ZMod.natAbs_valMinAbs_le x
 
+omit [NeZero q] in
 /-- Negation preserves the absolute value of the centered representative. -/
 theorem centeredRepr_natAbs_neg (x : ZMod q) :
-    (centeredRepr (-x)).natAbs = (centeredRepr x).natAbs := by
-  by_cases hx : x = 0
-  · simp [hx]
-  · have : NeZero x := ⟨hx⟩
-    simp only [centeredRepr, ZMod.val_neg_of_ne_zero]
-    have hval := ZMod.val_lt x
-    have hpos : 0 < x.val := Nat.pos_of_ne_zero ((ZMod.val_ne_zero x).mpr hx)
-    split_ifs <;> omega
+    (centeredRepr (-x)).natAbs = (centeredRepr x).natAbs :=
+  ZMod.natAbs_valMinAbs_neg x
 
+omit [NeZero q] in
 /-- Casting the centered representative back into `ZMod q` recovers the original element. -/
 theorem centeredRepr_intCast (x : ZMod q) :
-    (x : ZMod q) = ((centeredRepr x : ℤ) : ZMod q) := by
-  by_cases h : (x.val : ℤ) ≤ (q : ℤ) / 2
-  · rw [centeredRepr_of_le h, Int.cast_natCast, ZMod.natCast_zmod_val]
-  · have hgt : (q : ℤ) / 2 < x.val := lt_of_not_ge h
-    rw [centeredRepr_of_gt hgt, Int.cast_sub, Int.cast_natCast,
-      Int.cast_natCast, ZMod.natCast_zmod_val, ZMod.natCast_self]
-    simp
+    (x : ZMod q) = ((centeredRepr x : ℤ) : ZMod q) :=
+  (ZMod.coe_valMinAbs x).symm
 
 /-- Twice the centered representative lies in the interval used by `ZMod.valMinAbs`. -/
 theorem centeredRepr_mem_Ioc (x : ZMod q) :
-    centeredRepr x * 2 ∈ Set.Ioc (-(q : ℤ)) q := by
-  by_cases h : (x.val : ℤ) ≤ (q : ℤ) / 2
-  · rw [centeredRepr_of_le h]
-    have hx : 0 ≤ (x.val : ℤ) := by positivity
-    have hmod : (0 : ℤ) < q := by exact_mod_cast NeZero.pos q
-    constructor <;> omega
-  · have hgt : (q : ℤ) / 2 < x.val := lt_of_not_ge h
-    rw [centeredRepr_of_gt hgt]
-    have hval := ZMod.val_lt x
-    constructor <;> omega
+    centeredRepr x * 2 ∈ Set.Ioc (-(q : ℤ)) q :=
+  ZMod.valMinAbs_mem_Ioc x
 
-/-- The centered representative agrees with `ZMod.valMinAbs`. -/
+omit [NeZero q] in
+/-- The centered representative is `ZMod.valMinAbs` by definition. -/
 theorem centeredRepr_eq_valMinAbs (x : ZMod q) :
-    centeredRepr x = x.valMinAbs := by
-  simpa using ((ZMod.valMinAbs_spec x (centeredRepr x)).2
-    ⟨centeredRepr_intCast x, centeredRepr_mem_Ioc x⟩).symm
+    centeredRepr x = x.valMinAbs := rfl
 
 /-- Casting an integer already in the centered interval preserves that integer. -/
 theorem centeredRepr_intCast_eq (z : ℤ)
     (hzlo : -(q : ℤ) < z * 2) (hzhi : z * 2 ≤ q) :
-    centeredRepr ((z : ZMod q)) = z := by
-  rw [centeredRepr_eq_valMinAbs]
-  exact (ZMod.valMinAbs_spec ((z : ZMod q)) z).2 ⟨rfl, ⟨hzlo, hzhi⟩⟩
+    centeredRepr ((z : ZMod q)) = z :=
+  (ZMod.valMinAbs_spec ((z : ZMod q)) z).2 ⟨rfl, ⟨hzlo, hzhi⟩⟩
 
 /-- A small-enough integer is unchanged by casting into `ZMod q` and taking `centeredRepr`. -/
 theorem centeredRepr_intCast_eq_of_natAbs_le (z : ℤ) {b : ℕ}
@@ -284,6 +256,7 @@ private def intConvCoeff (f g : Fin n → ZMod q) (k : Fin n) : ℤ :=
       else -(centeredRepr (f ij.1) * centeredRepr (g ij.2))
     else 0
 
+omit [NeZero q] in
 /-- `negacyclicConvCoeff` is the `ZMod q` reduction of the integer convolution `intConvCoeff`
 of the centered lifts. -/
 private theorem negacyclicConvCoeff_eq_intCast (f g : Fin n → ZMod q) (k : Fin n) :

--- a/LatticeCrypto/Ring/Norms.lean
+++ b/LatticeCrypto/Ring/Norms.lean
@@ -68,9 +68,10 @@ section CenteredRepr
 
 variable {q : ℕ} [NeZero q]
 
-/-- The centered representative of `x : ZMod q`, the unique integer in `(-q/2, q/2]` congruent to
-`x`. This is `ZMod.valMinAbs`; the name is kept because it is the FIPS-facing vocabulary of the
-rounding and norm layers, and the lemmas below are its API restated on that name. -/
+/-- The centered representative of `x : ZMod q` in the FIPS-facing rounding and norm API.
+For nonzero `q`, this is the unique integer congruent to `x` whose double lies in `(-q, q]`. An even
+modulus uses the positive representative at the midpoint. For `q = 0`, `ZMod 0` is `ℤ` and this
+returns the integer itself, following `ZMod.valMinAbs`. -/
 def centeredRepr (x : ZMod q) : ℤ := x.valMinAbs
 
 @[simp] theorem centeredRepr_of_le {x : ZMod q} (h : (x.val : ℤ) ≤ (q : ℤ) / 2) :

--- a/LatticeCryptoTest.lean
+++ b/LatticeCryptoTest.lean
@@ -11,3 +11,4 @@ public import LatticeCryptoTest.MLDSA.ACVPVectors
 public import LatticeCryptoTest.MLDSA.Helpers
 public import LatticeCryptoTest.MLKEM.ACVPVectors
 public import LatticeCryptoTest.MLKEM.Helpers
+public import LatticeCryptoTest.Ring.CenteredRepr

--- a/LatticeCryptoTest/Ring/CenteredRepr.lean
+++ b/LatticeCryptoTest/Ring/CenteredRepr.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import LatticeCrypto.Ring.Norms
+import Mathlib.Tactic.ReduceModChar
+
+/-!
+# Gate for the centered representative and modular numerals
+
+`centeredRepr` is `ZMod.valMinAbs` under the FIPS-facing name, so Mathlib's `valMinAbs` API
+applies to it directly: closed values by `decide`, the absolute value as a `min` through
+`ZMod.valMinAbs_natAbs_eq_min`, and casts of small naturals by `valMinAbs_natCast_of_le_half`.
+Numeral identities in `ZMod q` for a literal `q` close by `reduce_mod_char`.
+-/
+
+public section
+
+open LatticeCrypto
+
+namespace LatticeCryptoTest.CenteredRepr
+
+example : centeredRepr (12 : ZMod 17) = -5 := by decide
+example : centeredRepr (3 : ZMod 17) = 3 := by decide
+
+example : (centeredRepr (12 : ZMod 17)).natAbs = 5 := by
+  rw [centeredRepr_eq_valMinAbs, ZMod.valMinAbs_natAbs_eq_min]
+  decide
+
+example (a : ℕ) (h : a ≤ 17 / 2) : centeredRepr (a : ZMod 17) = a :=
+  ZMod.valMinAbs_natCast_of_le_half h
+
+example (x : ZMod 17) : (centeredRepr x).natAbs ≤ 8 := centeredRepr_abs_le x
+
+example : ((8380416 : ℕ) : ZMod 8380417) = -1 := by reduce_mod_char
+example : (1753 : ZMod 8380417) ^ 256 = -1 := by reduce_mod_char
+example : (17 : ZMod 3329) ^ 128 = -1 := by reduce_mod_char
+
+end LatticeCryptoTest.CenteredRepr

--- a/LatticeCryptoTest/Ring/CenteredRepr.lean
+++ b/LatticeCryptoTest/Ring/CenteredRepr.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma
 -/
-module
 
+module
 public import LatticeCrypto.Ring.Norms
 import Mathlib.Tactic.ReduceModChar
 
@@ -25,6 +25,15 @@ namespace LatticeCryptoTest.CenteredRepr
 
 example : centeredRepr (12 : ZMod 17) = -5 := by decide
 example : centeredRepr (3 : ZMod 17) = 3 := by decide
+
+-- The even-modulus midpoint uses the positive representative, including after negation.
+example : centeredRepr (4 : ZMod 8) = 4 := by decide
+example : centeredRepr (-4 : ZMod 8) = 4 := by decide
+example : centeredRepr (5 : ZMod 8) = -3 := by decide
+example : centeredRepr (0 : ZMod 1) = 0 := by decide
+
+-- Modulus zero follows the signed integer interpretation of ZMod 0.
+example (z : ℤ) : centeredRepr (q := 0) (z : ZMod 0) = z := rfl
 
 example : (centeredRepr (12 : ZMod 17)).natAbs = 5 := by
   rw [centeredRepr_eq_valMinAbs, ZMod.valMinAbs_natAbs_eq_min]


### PR DESCRIPTION
Adopt Mathlib's centered representatives, polynomial quotient normal forms, and modular arithmetic automation in the lattice ring layer. Existing nonzero-modulus values and theorem conclusions are preserved, while repeated proofs become direct uses of the upstream API.

- Define `centeredRepr` through `ZMod.valMinAbs` and reuse its bounds, cast, and absolute-value lemmas. Simplify the ML-DSA rounding bound through `valMinAbs_natAbs_eq_min`.
- Prove `ofBackend_injective` using `AdjoinRoot.modByMonicHom_mk` and `Polynomial.modByMonic_eq_self_iff`, retaining the general `CommRing` statement and the degree-zero/subsingleton cases. Use `Polynomial.finsetSum_coeff` directly.
- Replace manual modular squaring chains with `reduce_mod_char`; prove primitive-root orders for ML-DSA, ML-KEM, and both supported Falcon parameter sets. These establish root orders, not a full pointwise NTT multiplication proof.
- Use `omega` for the two ML-KEM byte-decoding identities.
- Describe the concrete NTT's kernel axioms and its separate `implemented_by` runtime refinement boundary accurately.

Compatibility:

- For every nonzero modulus, centered-representative values agree with the old conditional definition, including the positive midpoint for an even modulus.
- At modulus zero (`ZMod 0 = ℤ`), `centeredRepr` now preserves the signed integer rather than returning its absolute value: `-3` produces `-3`, previously `3`. No existing modulus-zero callers were found.
- `centeredRepr_of_le` and `centeredRepr_of_gt` now require `[NeZero q]`; their old branch descriptions do not describe the signed modulus-zero interpretation.

Validation on `0651efaf`:

- All seven production and three test libraries build (4,115 jobs), with no non-sorry source warnings or test warnings.
- Centered-representative canaries cover odd moduli, the even midpoint and its negation, modulus one, signed modulus zero, absolute-value bounds, and modular numerals.
- A separate compatibility proof checks the old conditional formula for every nonzero modulus. `#print axioms MLDSA.mldsa_laws_inhabited` confirms only `propext`, `Classical.choice`, and `Quot.sound`.
- Axiom sweep passes: 17,849 declarations across 549 modules, 40 existing sorry-tainted declarations, zero nonstandard axiom taint; baseline unchanged.
- Touched-module style, documentation/fragments, all five boundary gates, umbrella regeneration, and whitespace checks pass.
- Integration build after #651 merged also passes all ten libraries (4,115 jobs), warning gates, and the exposure gate. Local integration `5e89a7cc` applies the same reviewed patches to main `08ef8170`; no additional source changes.
- Fresh CI runs on the published head before queueing.
