### PR TITLE
feat(Asymptotics): bridge negligible to SuperpolynomialDecay over ℝ

### DIFF
--- a/Examples/PRFTagReader/Asymptotic.lean
+++ b/Examples/PRFTagReader/Asymptotic.lean
@@ -24,7 +24,7 @@ The concrete unlinkability quantities (`unlinkabilityAdvantage`, `PRFScheme.prfA
 `VCVio.CryptoFoundations.Asymptotics.{Negligible,Security}` is phrased over `ℕ → ℝ≥0∞`. We bridge
 the two exactly as the rest of the repository does (see `VCVio/Interaction/UC/Computational.lean`):
 an `ℝ`-valued error family `ε : ℕ → ℝ` is *negligible* when `fun λ => ENNReal.ofReal (ε λ)` is
-`negligible`, and sums are split with `ENNReal.ofReal_add_le` combined with `negligible_add`. No
+`negligible`, and sums of such families are handled by `negligible_ofReal_add`. No
 parallel framework is introduced; the headline is a plain `negligible` statement over a `ℕ`-indexed
 instance family.
 
@@ -57,31 +57,6 @@ negation.
 open OracleComp OracleSpec ENNReal Filter
 
 namespace PRFTagReader
-
-/-! ## Negligibility helpers -/
-
-/-- A natural-number family bounded by a polynomial times a negligible family is negligible.
-The basic closure used to absorb polynomial query / cardinality numerators into a negligible
-reciprocal-cardinality factor. -/
-theorem negligible_natMul_of_poly_bound {f : ℕ → ℝ≥0∞} (hf : negligible f)
-    {g : ℕ → ℕ} {p : Polynomial ℕ} (hg : ∀ n, g n ≤ p.eval n) :
-    negligible (fun n => (g n : ℝ≥0∞) * f n) :=
-  negligible_of_le (g := fun n => ((p.eval n : ℕ) : ℝ≥0∞) * f n)
-    (fun n => mul_le_mul' (by exact_mod_cast hg n) le_rfl)
-    (negligible_polynomial_mul hf p)
-
-/-- A slack term `numerator / cardinality` is negligible when the numerator is polynomially bounded
-and the reciprocal cardinality is negligible. The `ENNReal.ofReal` wrapper is the framework idiom
-for treating an `ℝ`-valued nonnegative error family asymptotically. -/
-theorem negligible_ofReal_natDiv_of_poly_bound {C : ℕ → ℕ}
-    (hC : negligible (fun n => (C n : ℝ≥0∞)⁻¹))
-    {g : ℕ → ℕ} {p : Polynomial ℕ} (hg : ∀ n, g n ≤ p.eval n) :
-    negligible (fun n => ENNReal.ofReal ((g n : ℝ) / (C n : ℝ))) :=
-  negligible_of_le (g := fun n => (g n : ℝ≥0∞) * (C n : ℝ≥0∞)⁻¹)
-    (fun n => by
-      refine (ENNReal.ofReal_div_le (by positivity)).trans ?_
-      rw [div_eq_mul_inv, ENNReal.ofReal_natCast, ENNReal.ofReal_natCast])
-    (negligible_natMul_of_poly_bound hC hg)
 
 section AbsReductions
 
@@ -273,44 +248,14 @@ theorem negligible_abs_unlinkabilityAdvantage
         rw [Polynomial.eval_mul, Polynomial.eval_mul]
         exact Nat.mul_le_mul (Nat.mul_le_mul (hpReader lam) (hpTagId lam)) (hpSessions lam))
   -- The pointwise abs bound, transported through `ENNReal.ofReal`.
-  refine negligible_of_le (g := fun lam =>
-    ENNReal.ofReal (PRFScheme.prfAdvantage (inst.prfs lam).multiplePRFScheme
-        (unlinkToMultiplePRFReduction (sessionsPerTag := sessionsPerTag lam) (adversary lam))) +
-      ENNReal.ofReal (PRFScheme.prfAdvantage (inst.prfs lam).singlePRFScheme
-        (unlinkToSinglePRFReduction (sessionsPerTag := sessionsPerTag lam) (adversary lam))) +
-      ENNReal.ofReal (PRFScheme.prfAdvantage (inst.prfs lam).multiplePRFScheme
-        (unlinkToMultiplePRFReduction (sessionsPerTag := sessionsPerTag lam)
-          (adversary lam >>= fun b => pure (!b) :
-            OracleComp (UnlinkOracleSpec (TagId lam) (Nonce lam) (Digest lam)) Bool))) +
-      ENNReal.ofReal (PRFScheme.prfAdvantage (inst.prfs lam).singlePRFScheme
-        (unlinkToSinglePRFReduction (sessionsPerTag := sessionsPerTag lam)
-          (adversary lam >>= fun b => pure (!b) :
-            OracleComp (UnlinkOracleSpec (TagId lam) (Nonce lam) (Digest lam)) Bool))) +
-      ENNReal.ofReal (Pr[fun z : Bool ×
-            MultipleBadState (TagId lam) (Nonce lam) (Digest lam) (sessionsPerTag lam) =>
-          z.2.2.bad |
-        (simulateQ (multipleBadQueryImpl (TagId := TagId lam) (Nonce := Nonce lam)
-          (Digest := Digest lam) (sessionsPerTag := sessionsPerTag lam)) (adversary lam)).run
-          ((UnlinkState.init, ∅), UnlinkBadState.init)]).toReal +
-      ENNReal.ofReal (((qReader lam * Fintype.card (TagId lam) : ℕ) : ℝ) /
-        (Fintype.card (Digest lam) : ℝ)) +
-      ENNReal.ofReal (((qReader lam * qTag lam : ℕ) : ℝ) / (Fintype.card (Nonce lam) : ℝ)) +
-      ENNReal.ofReal (((qReader lam * Fintype.card (TagId lam) * sessionsPerTag lam : ℕ) : ℝ) /
-        (Fintype.card (Digest lam) : ℝ))) (fun lam => ?_) ?_
-  · -- Pointwise: `ofReal |unlink| ≤ Σ ofReal(termᵢ)`, by the abs bound + `ofReal_add_le`.
-    refine (ENNReal.ofReal_le_ofReal (abs_unlinkabilityAdvantage_reductions (inst.prfs lam)
-      (adversary lam) (qReader lam) (qTag lam) (hqReader lam) (hqTag lam) (hMnf lam)
-      (hSnf lam))).trans ?_
-    refine (ENNReal.ofReal_add_le).trans (add_le_add ?_ le_rfl)
-    refine (ENNReal.ofReal_add_le).trans (add_le_add ?_ le_rfl)
-    refine (ENNReal.ofReal_add_le).trans (add_le_add ?_ le_rfl)
-    refine (ENNReal.ofReal_add_le).trans (add_le_add ?_ le_rfl)
-    refine (ENNReal.ofReal_add_le).trans (add_le_add ?_ le_rfl)
-    refine (ENNReal.ofReal_add_le).trans (add_le_add ?_ le_rfl)
-    exact ENNReal.ofReal_add_le
-  · -- The bounding sum is negligible: nine negligible summands combined additively.
-    exact (((((((hPRFmulti.add hPRFsingle).add hPRFmulti').add hPRFsingle').add
-      hCollision).add hSlack1).add hSlack2).add hSlack3)
+  -- Pointwise `ofReal |unlink| ≤ ofReal (Σ termᵢ)` by the abs bound; the bounding family is
+  -- negligible as an `ofReal` of eight negligible real summands.
+  exact negligible_of_le
+    (fun lam => ENNReal.ofReal_le_ofReal (abs_unlinkabilityAdvantage_reductions (inst.prfs lam)
+      (adversary lam) (qReader lam) (qTag lam) (hqReader lam) (hqTag lam) (hMnf lam) (hSnf lam)))
+    (negligible_ofReal_add (negligible_ofReal_add (negligible_ofReal_add (negligible_ofReal_add
+      (negligible_ofReal_add (negligible_ofReal_add (negligible_ofReal_add hPRFmulti hPRFsingle)
+        hPRFmulti') hPRFsingle') hCollision) hSlack1) hSlack2) hSlack3)
 
 end AsymptoticInstance
 

--- a/VCVio/CryptoFoundations/Asymptotics/Negligible.lean
+++ b/VCVio/CryptoFoundations/Asymptotics/Negligible.lean
@@ -7,6 +7,7 @@ Authors: Devon Tuma
 module
 public import Mathlib.Algebra.Polynomial.Eval.Degree
 public import Mathlib.Analysis.Asymptotics.SuperpolynomialDecay
+public import Mathlib.Order.Filter.AtTopBot.Archimedean
 
 /-!
 # Negligible Functions
@@ -17,10 +18,17 @@ as this is usually the situation for cryptographic reductions.
 ## Main Results
 
 - `negligible_zero`, `negligible_of_zero`: The zero function is negligible.
-- `negligible_of_le`: Monotonicity — bounded by negligible is negligible.
-- `negligible_add`: Sum of negligible functions is negligible.
-- `negligible_sum`: Finite sum of negligible functions is negligible.
-- `negligible_const_mul`: Constant multiple of negligible is negligible.
+- `negligible_of_le`, `negligible_of_eventuallyLE`: Monotonicity — (eventually) bounded by
+  negligible is negligible.
+- `negligible_add`, `negligible_sum`: Finite sums of negligible functions are negligible;
+  `negligible_ofReal_add`, `negligible_ofReal_sum` are the same through `ENNReal.ofReal`.
+- `negligible_const_mul`, `negligible_pow_mul`, `negligible_polynomial_mul`: Polynomial factors
+  are absorbed.
+- `negligible_natMul_of_poly_bound`, `negligible_ofReal_natDiv_of_poly_bound`: Polynomially
+  bounded numerators over negligible reciprocals.
+- `negligible_iff_superpolynomialDecay_toReal`, `negligible_ofReal_iff`: The bridge to Mathlib's
+  real-valued `SuperpolynomialDecay`, through which `negligible_iff_isBigO_toReal` and
+  `negligible_iff_isLittleO_toReal` give the `O`/`o` characterizations.
 -/
 
 @[expose] public section
@@ -39,16 +47,41 @@ lemma negligible_zero : negligible 0 := superpolynomialDecay_zero _ _
 lemma negligible_of_zero {f : ℕ → ℝ≥0∞} (hf : ∀ n, f n = 0) : negligible f :=
   funext hf ▸ negligible_zero
 
+/-- Negligibility is monotone under eventual domination: if `f ≤ g` for all large `n` and `g` is
+negligible, then `f` is. This is Mathlib's `SuperpolynomialDecay.trans_eventuallyLE` with `f`
+squeezed between `0` and `g`. -/
+theorem negligible_of_eventuallyLE {f g : ℕ → ℝ≥0∞} (hfg : ∀ᶠ n in atTop, f n ≤ g n)
+    (hg : negligible g) : negligible f :=
+  SuperpolynomialDecay.trans_eventuallyLE (Eventually.of_forall fun _ => zero_le)
+    (superpolynomialDecay_zero _ _) hg (Eventually.of_forall fun _ => zero_le) hfg
+
 /-- Negligibility is monotone: if `f ≤ g` pointwise and `g` is negligible, then `f` is. -/
 theorem negligible_of_le {f g : ℕ → ℝ≥0∞} (hfg : ∀ n, f n ≤ g n) (hg : negligible g) :
-    negligible f := fun p =>
-  tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds (hg p)
-    (fun _ => zero_le) (fun n => mul_le_mul_of_nonneg_left (hfg n) zero_le)
+    negligible f :=
+  negligible_of_eventuallyLE (Eventually.of_forall hfg) hg
 
 /-- Sum of two negligible functions is negligible. -/
 theorem negligible_add {f g : ℕ → ℝ≥0∞} (hf : negligible f) (hg : negligible g) :
     negligible (f + g) :=
   hf.add hg
+
+/-- `ENNReal.ofReal` of a sum of two real error families is negligible when each is. -/
+theorem negligible_ofReal_add {a b : ℕ → ℝ} (ha : negligible fun n => ENNReal.ofReal (a n))
+    (hb : negligible fun n => ENNReal.ofReal (b n)) :
+    negligible fun n => ENNReal.ofReal (a n + b n) :=
+  negligible_of_le (fun _ => ENNReal.ofReal_add_le) (negligible_add ha hb)
+
+/-- `ENNReal.ofReal` of a finite sum of real error families is negligible when each is. -/
+theorem negligible_ofReal_sum {ι : Type*} {s : Finset ι} {ε : ι → ℕ → ℝ}
+    (h : ∀ i ∈ s, negligible fun n => ENNReal.ofReal (ε i n)) :
+    negligible fun n => ENNReal.ofReal (∑ i ∈ s, ε i n) := by
+  classical
+  induction s using Finset.induction with
+  | empty => exact negligible_of_zero fun n => by simp
+  | insert _ _ hnotin ih =>
+    simp_rw [Finset.sum_insert hnotin]
+    exact negligible_ofReal_add (h _ (Finset.mem_insert_self _ _))
+      (ih fun i hi => h i (Finset.mem_insert_of_mem hi))
 
 /-- Constant multiple of a negligible function is negligible (requires `c ≠ ⊤`
 because multiplication by `⊤` is discontinuous at `0` in `ℝ≥0∞`). -/
@@ -91,3 +124,62 @@ theorem negligible_polynomial_mul {f : ℕ → ℝ≥0∞} (hf : negligible f)
   simp_rw [heq]
   exact negligible_sum fun i _ =>
     negligible_const_mul (negligible_pow_mul hf i) (ENNReal.natCast_ne_top _)
+
+/-- A natural-number family bounded by a polynomial times a negligible family is negligible.
+The basic closure used to absorb polynomial query / cardinality numerators into a negligible
+reciprocal-cardinality factor. -/
+theorem negligible_natMul_of_poly_bound {f : ℕ → ℝ≥0∞} (hf : negligible f)
+    {g : ℕ → ℕ} {p : Polynomial ℕ} (hg : ∀ n, g n ≤ p.eval n) :
+    negligible (fun n => (g n : ℝ≥0∞) * f n) :=
+  negligible_of_le (g := fun n => ((p.eval n : ℕ) : ℝ≥0∞) * f n)
+    (fun n => mul_le_mul' (by exact_mod_cast hg n) le_rfl)
+    (negligible_polynomial_mul hf p)
+
+/-- A slack term `numerator / cardinality` is negligible when the numerator is polynomially bounded
+and the reciprocal cardinality is negligible. The `ENNReal.ofReal` wrapper is the framework idiom
+for treating an `ℝ`-valued nonnegative error family asymptotically. -/
+theorem negligible_ofReal_natDiv_of_poly_bound {C : ℕ → ℕ}
+    (hC : negligible (fun n => (C n : ℝ≥0∞)⁻¹))
+    {g : ℕ → ℕ} {p : Polynomial ℕ} (hg : ∀ n, g n ≤ p.eval n) :
+    negligible (fun n => ENNReal.ofReal ((g n : ℝ) / (C n : ℝ))) :=
+  negligible_of_le (g := fun n => (g n : ℝ≥0∞) * (C n : ℝ≥0∞)⁻¹)
+    (fun n => by
+      refine (ENNReal.ofReal_div_le (by positivity)).trans ?_
+      rw [div_eq_mul_inv, ENNReal.ofReal_natCast, ENNReal.ofReal_natCast])
+    (negligible_natMul_of_poly_bound hC hg)
+
+/-! ## Bridge to real-valued asymptotics
+
+Mathlib's `SuperpolynomialDecay` API is stratified by typeclass, and its `O`/`o`
+characterizations need a normed field, which `ℝ≥0∞` is not. For `⊤`-free families the two
+lemmas below move the statement to `ℝ` through `ENNReal.toReal`, after which Mathlib's real
+asymptotics apply verbatim. -/
+
+/-- A `⊤`-free family is negligible iff its `toReal` image has superpolynomial decay in `ℝ`. -/
+theorem negligible_iff_superpolynomialDecay_toReal {f : ℕ → ℝ≥0∞} (hf : ∀ n, f n ≠ ⊤) :
+    negligible f ↔ SuperpolynomialDecay atTop (Nat.cast : ℕ → ℝ) fun n => (f n).toReal := by
+  simp only [negligible, SuperpolynomialDecay]
+  refine forall_congr' fun k => ?_
+  rw [← ENNReal.tendsto_toReal_zero_iff fun n =>
+    ENNReal.mul_ne_top (ENNReal.pow_ne_top (ENNReal.natCast_ne_top n)) (hf n)]
+  simp only [ENNReal.toReal_mul, ENNReal.toReal_pow, ENNReal.toReal_natCast]
+
+/-- A nonnegative real error family is negligible (through `ENNReal.ofReal`) iff it has
+superpolynomial decay in `ℝ`. -/
+theorem negligible_ofReal_iff {ε : ℕ → ℝ} (hε : ∀ n, 0 ≤ ε n) :
+    negligible (fun n => ENNReal.ofReal (ε n)) ↔
+      SuperpolynomialDecay atTop (Nat.cast : ℕ → ℝ) ε := by
+  rw [negligible_iff_superpolynomialDecay_toReal fun n => ENNReal.ofReal_ne_top]
+  simp only [ENNReal.toReal_ofReal (hε _)]
+
+/-- Negligibility as big-`O` against every integer power, on the `toReal` side. -/
+theorem negligible_iff_isBigO_toReal {f : ℕ → ℝ≥0∞} (hf : ∀ n, f n ≠ ⊤) :
+    negligible f ↔ ∀ z : ℤ, (fun n => (f n).toReal) =O[atTop] fun n : ℕ => (n : ℝ) ^ z :=
+  (negligible_iff_superpolynomialDecay_toReal hf).trans
+    (superpolynomialDecay_iff_isBigO _ tendsto_natCast_atTop_atTop)
+
+/-- Negligibility as little-`o` against every integer power, on the `toReal` side. -/
+theorem negligible_iff_isLittleO_toReal {f : ℕ → ℝ≥0∞} (hf : ∀ n, f n ≠ ⊤) :
+    negligible f ↔ ∀ z : ℤ, (fun n => (f n).toReal) =o[atTop] fun n : ℕ => (n : ℝ) ^ z :=
+  (negligible_iff_superpolynomialDecay_toReal hf).trans
+    (superpolynomialDecay_iff_isLittleO _ tendsto_natCast_atTop_atTop)

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -1,5 +1,6 @@
 module  -- shake: keep-all --deprecated_module: ignore
 
+public import VCVioTest.Asymptotics.Negligible
 public import VCVioTest.Computability
 public import VCVioTest.CryptoFoundations.ComplexityAdapters
 public import VCVioTest.CryptoFoundations.ComplexityTactics

--- a/VCVioTest/Asymptotics/Negligible.lean
+++ b/VCVioTest/Asymptotics/Negligible.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.CryptoFoundations.Asymptotics.Negligible
+public import Mathlib.Analysis.SpecificLimits.Normed
+
+/-!
+# Negligible-function bridge canaries
+
+Checks that `negligible` connects to Mathlib's real-valued `SuperpolynomialDecay`: a concrete
+geometric family is shown negligible from Mathlib's `tendsto_pow_const_mul_const_pow_of_lt_one`,
+its little-`o` form is read off the bridge, and eventual domination suffices.
+-/
+
+public section
+
+open ENNReal Asymptotics Filter
+
+namespace VCVioTest.Negligible
+
+/-- `(1/2)^n` decays superpolynomially in `ℝ`, by Mathlib. -/
+theorem superpolynomialDecay_half_pow :
+    SuperpolynomialDecay atTop (Nat.cast : ℕ → ℝ) fun n => (1 / 2 : ℝ) ^ n := fun k =>
+  tendsto_pow_const_mul_const_pow_of_lt_one k (by norm_num) (by norm_num)
+
+example : negligible fun n => ENNReal.ofReal ((1 / 2 : ℝ) ^ n) :=
+  (negligible_ofReal_iff fun n => by positivity).2 superpolynomialDecay_half_pow
+
+example : ∀ z : ℤ, (fun n : ℕ => (ENNReal.ofReal ((1 / 2 : ℝ) ^ n)).toReal) =o[atTop]
+    fun n : ℕ => (n : ℝ) ^ z :=
+  (negligible_iff_isLittleO_toReal fun _ => ENNReal.ofReal_ne_top).1 <|
+    (negligible_ofReal_iff fun n => by positivity).2 superpolynomialDecay_half_pow
+
+example {f g : ℕ → ℝ≥0∞} (hg : negligible g) (h : ∀ n ≥ 5, f n ≤ g n) : negligible f :=
+  negligible_of_eventuallyLE (Filter.eventually_atTop.2 ⟨5, h⟩) hg
+
+end VCVioTest.Negligible


### PR DESCRIPTION
## Summary

`negligible f` is definitionally Mathlib's `SuperpolynomialDecay atTop Nat.cast f` on `ℕ → ℝ≥0∞`, but Mathlib's `SuperpolynomialDecay` file is stratified by typeclass and its `O`/`o` characterizations need a normed field, which `ℝ≥0∞` is not (ledger #632, "`ℝ≥0∞`, infinite sums, and asymptotics"). Until now every consumer re-crossed `ℝ → ℝ≥0∞` by hand.

- **Bridge.** `negligible_iff_superpolynomialDecay_toReal` (for `⊤`-free families) and `negligible_ofReal_iff` (for nonnegative real families) move the statement to `ℝ` through `ENNReal.toReal`; `negligible_iff_isBigO_toReal` and `negligible_iff_isLittleO_toReal` then read off Mathlib's `superpolynomialDecay_iff_isBigO`/`_isLittleO` with `tendsto_natCast_atTop_atTop`.
- **Monotonicity.** `negligible_of_le` is now a corollary of `SuperpolynomialDecay.trans_eventuallyLE`, which also gives `negligible_of_eventuallyLE`.
- **`ofReal` idiom.** `negligible_ofReal_add` and `negligible_ofReal_sum` handle sums of real error families under `ENNReal.ofReal` (the shape every real-valued advantage takes); the two generic `_of_poly_bound` closure lemmas move here from the PRF tag/reader example.
- **Example.** The tag/reader unlinkability bound's seven-fold `ENNReal.ofReal_add_le` chain and its explicit eight-term bounding family collapse to `negligible_of_le` on the abs bound with nested `negligible_ofReal_add` (−55 lines).
- **Canary.** `VCVioTest/Asymptotics/Negligible.lean` shows a geometric family negligible from Mathlib's `tendsto_pow_const_mul_const_pow_of_lt_one` through the bridge, and reads its little-`o` form back.

## Verification

- `lake build VCVio Examples VCVioTest` clean.
- `lake exe axiomsweep --check`: baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVfC71YUdB39wUWfC2MBUH
