### PR TITLE
feat(Falcon): prove the codec round-trips and kernel equalities; discharge the verify bridge

### DIFF
--- a/Extern.lean
+++ b/Extern.lean
@@ -9,6 +9,7 @@ public import Extern.Falcon.KeyGen
 public import Extern.Falcon.SamplerZ
 public import Extern.Falcon.Sampling
 public import Extern.Falcon.Sign
+public import Extern.Falcon.VerifyBridge
 public import Extern.Hashing
 public import Extern.MLDSA.FFI
 public import Extern.MLDSA.Instance

--- a/Extern/Falcon/Instance.lean
+++ b/Extern/Falcon/Instance.lean
@@ -34,6 +34,13 @@ function for testing.
    concrete implementations for the executable fields and a concrete FXR-backed
    bridge for the FFT conversion fields. Used to connect the proof-level Falcon
    interface to the concrete packed FFT representation.
+
+## Kernel correctness
+
+The fast `UInt32`/`Int64` kernels used by `concreteVerify` compute exactly their
+specification-level counterparts: `negacyclicMulU32_eq_negacyclicMul` at every degree, and
+`pairL2NormSqU32_eq_pairL2NormSq` under the `UInt64` no-overflow bound
+`2 · n · (q/2)² < 2⁶⁴`, which holds with vast headroom for every Falcon degree.
 -/
 
 public section
@@ -106,6 +113,599 @@ def concreteVerify (p : Params) (pk : ByteArray) (msg : List Byte)
     (p : Params) (pk : ByteArray) (salt : Bytes 40) (msg : List Byte) :
     concreteVerify p pk msg (sigEncode salt [] p.logn) = false := by
   simp [concreteVerify]
+
+/-! ## Kernel correctness
+
+The standalone executable verifier `concreteVerify` uses the `UInt32`/`Int64`
+fast kernels `negacyclicMulU32` and `pairL2NormSqU32`. These theorems certify
+that the fast kernels compute exactly the abstract specification-level
+`negacyclicMul` and `pairL2NormSq`, discharging the `hmul`/`hnorm` hypotheses of
+`Falcon.Concrete.FPRBridge.concrete_verify_eq_verify`. -/
+
+/-! ### Negacyclic multiplier correctness
+
+The `negacyclicMulU32` kernel folds an imperative `O(n²)` double loop over a
+`UInt32` accumulator array. The helpers below characterize that loop by a
+`Finset`-sum invariant in `ZMod modulus` and bridge it to the
+specification-level coefficient `LatticeCrypto.negacyclicConvCoeff`. Each output
+cell stays in `[0, modulus)` for every degree, so no degree bound is required. -/
+private theorem q_toNat : (modulus.toUInt32).toNat = 12289 := by
+  change (UInt32.ofNat modulus).toNat = 12289
+  rw [UInt32.toNat_ofNat']; rfl
+
+private theorem cast_natSub {a b : ℕ} (h : b ≤ a) :
+    ((a - b : ℕ) : ZMod modulus) = (a : ZMod modulus) - (b : ZMod modulus) := by
+  rw [eq_sub_iff_add_eq, ← Nat.cast_add, Nat.sub_add_cancel h]
+
+private theorem prodU32 (a b : UInt32) (ha : a.toNat < modulus) (hb : b.toNat < modulus) :
+    (a * b % modulus.toUInt32).toNat < modulus ∧
+      ((a * b % modulus.toUInt32).toNat : ZMod modulus)
+        = (a.toNat : ZMod modulus) * (b.toNat : ZMod modulus) := by
+  have hq : (modulus.toUInt32).toNat = 12289 := q_toNat
+  have hmul : (a * b).toNat = a.toNat * b.toNat := by
+    rw [UInt32.toNat_mul, Nat.mod_eq_of_lt]
+    have hlt : a.toNat * b.toNat < 12289 * 12289 := by
+      apply Nat.mul_lt_mul'' <;> simpa [modulus] using ‹_›
+    calc a.toNat * b.toNat < 12289 * 12289 := hlt
+      _ < 2^32 := by norm_num
+  have hmod : (a * b % modulus.toUInt32).toNat = (a.toNat * b.toNat) % 12289 := by
+    rw [UInt32.toNat_mod, hmul, hq]
+  refine ⟨?_, ?_⟩
+  · rw [hmod]; simpa [modulus] using Nat.mod_lt _ (by norm_num)
+  · rw [hmod, show (12289 : ℕ) = modulus from rfl]
+    push_cast [ZMod.natCast_mod, Nat.cast_mul]; ring
+
+private theorem addCellU32 (cur prod : UInt32) (hc : cur.toNat < modulus)
+    (hp : prod.toNat < modulus) :
+    (if cur + prod ≥ modulus.toUInt32 then cur + prod - modulus.toUInt32 else cur + prod).toNat
+        < modulus
+    ∧ ((if cur + prod ≥ modulus.toUInt32 then cur + prod - modulus.toUInt32 else cur + prod).toNat
+        : ZMod modulus) = (cur.toNat : ZMod modulus) + (prod.toNat : ZMod modulus) := by
+  have hq : (modulus.toUInt32).toNat = 12289 := q_toNat
+  have hmm : (modulus : ℕ) = 12289 := rfl
+  have hpow : (2:ℕ)^32 = 4294967296 := by norm_num
+  rw [hmm] at hc hp
+  have hadd : (cur + prod).toNat = cur.toNat + prod.toNat := by
+    rw [UInt32.toNat_add, hpow, Nat.mod_eq_of_lt]; omega
+  simp only [ge_iff_le, UInt32.le_iff_toNat_le, hq, hadd]
+  by_cases h : 12289 ≤ cur.toNat + prod.toNat
+  · rw [if_pos h]
+    have hsub : (cur + prod - modulus.toUInt32).toNat = cur.toNat + prod.toNat - 12289 := by
+      rw [UInt32.toNat_sub, hq, hadd, hpow]; omega
+    rw [hsub]
+    refine ⟨by rw [hmm]; omega, ?_⟩
+    rw [cast_natSub h]; push_cast
+    rw [show (12289 : ZMod modulus) = ((modulus:ℕ):ZMod modulus) from rfl, ZMod.natCast_self]; ring
+  · rw [if_neg h, hadd]
+    exact ⟨by rw [hmm]; omega, by push_cast; ring⟩
+
+private theorem subCellU32 (cur prod : UInt32) (hc : cur.toNat < modulus)
+    (hp : prod.toNat < modulus) :
+    (if cur ≥ prod then cur - prod else cur + modulus.toUInt32 - prod).toNat < modulus
+    ∧ ((if cur ≥ prod then cur - prod else cur + modulus.toUInt32 - prod).toNat : ZMod modulus)
+        = (cur.toNat : ZMod modulus) - (prod.toNat : ZMod modulus) := by
+  have hq : (modulus.toUInt32).toNat = 12289 := q_toNat
+  have hmm : (modulus : ℕ) = 12289 := rfl
+  have hpow : (2:ℕ)^32 = 4294967296 := by norm_num
+  rw [hmm] at hc hp
+  simp only [ge_iff_le, UInt32.le_iff_toNat_le]
+  by_cases h : prod.toNat ≤ cur.toNat
+  · rw [if_pos h]
+    have hsub : (cur - prod).toNat = cur.toNat - prod.toNat := by rw [UInt32.toNat_sub, hpow]; omega
+    rw [hsub]; exact ⟨by rw [hmm]; omega, by rw [cast_natSub h]⟩
+  · rw [if_neg h]
+    have hcadd : (cur + modulus.toUInt32).toNat = cur.toNat + 12289 := by
+      rw [UInt32.toNat_add, hq, hpow]; omega
+    have hsub : (cur + modulus.toUInt32 - prod).toNat = cur.toNat + 12289 - prod.toNat := by
+      rw [UInt32.toNat_sub, hcadd, hpow]; omega
+    rw [hsub]
+    refine ⟨by rw [hmm]; omega, ?_⟩
+    rw [cast_natSub (by omega : prod.toNat ≤ cur.toNat + 12289)]
+    push_cast
+    rw [show (12289 : ZMod modulus) = ((modulus:ℕ):ZMod modulus) from rfl, ZMod.natCast_self]; ring
+
+private def innerStep {n : ℕ} (fa ga : Array UInt32) (i : ℕ) (r : Array UInt32) (j : ℕ) :
+    Array UInt32 :=
+  let prod := fa.getD i 0 * ga.getD j 0 % modulus.toUInt32
+  let kk := (i + j) % n
+  let cur := r.getD kk 0
+  if i + j < n then r.set! kk (if cur + prod ≥ modulus.toUInt32 then cur + prod - modulus.toUInt32
+                                else cur + prod)
+  else r.set! kk (if cur ≥ prod then cur - prod else cur + modulus.toUInt32 - prod)
+
+private theorem getD_set!_self (out : Array UInt32) (k : ℕ) (v : UInt32) (h : k < out.size) :
+    (out.set! k v).getD k 0 = v := by
+  simp only [Array.set!, Array.getD_eq_getD_getElem?, Array.getElem?_setIfInBounds]; simp [h]
+
+private theorem getD_set!_ne (out : Array UInt32) (k k' : ℕ) (v : UInt32) (h : k ≠ k') :
+    (out.set! k v).getD k' 0 = out.getD k' 0 := by
+  simp only [Array.set!, Array.getD_eq_getD_getElem?, Array.getElem?_setIfInBounds]; simp [h]
+
+private theorem foldl_range_succ {α} (fn : α → ℕ → α) (x : α) (m : ℕ) :
+    List.foldl fn x (List.range (m+1)) = fn (List.foldl fn x (List.range m)) m := by
+  rw [List.range_succ, List.foldl_append]; simp
+
+-- innerStep preserves size
+
+private theorem innerStep_size {n : ℕ} (fa ga : Array UInt32) (i : ℕ) (r : Array UInt32) (j : ℕ) :
+    (@innerStep n fa ga i r j).size = r.size := by
+  unfold innerStep
+  split <;> simp
+
+-- the per-cell summand value (in ZMod) for column j landing
+
+private def colVal (n : ℕ) (fa ga : Array UInt32) (i j : ℕ) : ZMod modulus :=
+  if i + j < n then ((fa.getD i 0).toNat : ZMod modulus) * ((ga.getD j 0).toNat : ZMod modulus)
+  else -(((fa.getD i 0).toNat : ZMod modulus) * ((ga.getD j 0).toNat : ZMod modulus))
+
+-- inner loop invariant: by induction on J
+
+private theorem inner_invariant {n : ℕ} (fa ga : Array UInt32) (i : ℕ) (hi : i < n)
+    (hfi : (fa.getD i 0).toNat < modulus) (hgaB : ∀ j, (ga.getD j 0).toNat < modulus)
+    (r0 : Array UInt32) (hsz0 : r0.size = n)
+    (hb0 : ∀ k, k < n → (r0.getD k 0).toNat < modulus) :
+    ∀ J, J ≤ n →
+      (List.foldl (fun r j => @innerStep n fa ga i r j) r0 (List.range J)).size = n ∧
+      (∀ k, k < n →
+        ((List.foldl (fun r j => @innerStep n fa ga i r j) r0 (List.range J)).getD k 0).toNat
+          < modulus) ∧
+      (∀ k, k < n →
+        (((List.foldl (fun r j => @innerStep n fa ga i r j) r0 (List.range J)).getD k 0).toNat
+            : ZMod modulus)
+          = ((r0.getD k 0).toNat : ZMod modulus)
+            + ∑ j ∈ (Finset.range J).filter (fun j => (i + j) % n = k), colVal n fa ga i j) := by
+  intro J
+  induction J with
+  | zero =>
+    intro _
+    refine ⟨hsz0, ?_, ?_⟩
+    · simpa using hb0
+    · intro k hk; simp
+  | succ J ih =>
+    intro hJ
+    have hJ' : J ≤ n := Nat.le_of_succ_le hJ
+    obtain ⟨ihsz, ihb, ihv⟩ := ih hJ'
+    set r := List.foldl (fun r j => @innerStep n fa ga i r j) r0 (List.range J) with hr
+    rw [foldl_range_succ]
+    -- the new array
+    set r' := @innerStep n fa ga i r J with hr'
+    have hJn : J < n := Nat.lt_of_succ_le hJ
+    have hkk : (i + J) % n < n := Nat.mod_lt _ (by omega)
+    have hprod := prodU32 (fa.getD i 0) (ga.getD J 0) hfi (hgaB J)
+    -- size of r'
+    have hszr' : r'.size = n := by rw [hr', innerStep_size, ihsz]
+    refine ⟨hszr', ?_, ?_⟩
+    · -- bound
+      intro k hk
+      by_cases hkeq : (i + J) % n = k
+      · subst hkeq
+        rw [hr']
+        unfold innerStep
+        by_cases hlt : i + J < n
+        · rw [if_pos hlt, getD_set!_self _ _ _ (by rw [ihsz]; exact hkk)]
+          exact (addCellU32 (r.getD ((i+J)%n) 0) _ (ihb _ hkk) hprod.1).1
+        · rw [if_neg hlt, getD_set!_self _ _ _ (by rw [ihsz]; exact hkk)]
+          exact (subCellU32 (r.getD ((i+J)%n) 0) _ (ihb _ hkk) hprod.1).1
+      · rw [hr']
+        unfold innerStep
+        rw [show (if i + J < n then r.set! ((i+J)%n) _ else r.set! ((i+J)%n) _)
+              = r.set! ((i+J)%n) (if i + J < n then _ else _) from by split <;> rfl]
+        rw [getD_set!_ne _ _ _ _ hkeq]
+        exact ihb k hk
+    · -- value
+      intro k hk
+      have hfilt : (Finset.range (J+1)).filter (fun j => (i + j) % n = k)
+          = if (i + J) % n = k then insert J ((Finset.range J).filter (fun j => (i + j) % n = k))
+            else (Finset.range J).filter (fun j => (i + j) % n = k) := by
+        rw [Finset.range_add_one, Finset.filter_insert]
+      by_cases hkeq : (i + J) % n = k
+      · subst hkeq
+        rw [hr']
+        unfold innerStep
+        have hJnotmem : J ∉ (Finset.range J).filter (fun j => (i + j) % n = (i + J) % n) := by
+          simp
+        rw [hfilt, if_pos rfl, Finset.sum_insert hJnotmem]
+        by_cases hlt : i + J < n
+        · rw [if_pos hlt, getD_set!_self _ _ _ (by rw [ihsz]; exact hkk)]
+          rw [(addCellU32 (r.getD ((i+J)%n) 0) _ (ihb _ hkk) hprod.1).2]
+          rw [ihv _ hkk, hprod.2]
+          unfold colVal
+          rw [if_pos hlt]; ring
+        · rw [if_neg hlt, getD_set!_self _ _ _ (by rw [ihsz]; exact hkk)]
+          rw [(subCellU32 (r.getD ((i+J)%n) 0) _ (ihb _ hkk) hprod.1).2]
+          rw [ihv _ hkk, hprod.2]
+          unfold colVal
+          rw [if_neg hlt]; ring
+      · rw [hfilt, if_neg hkeq]
+        rw [hr']
+        unfold innerStep
+        rw [show (if i + J < n then r.set! ((i+J)%n) _ else r.set! ((i+J)%n) _)
+              = r.set! ((i+J)%n) (if i + J < n then _ else _) from by split <;> rfl]
+        rw [getD_set!_ne _ _ _ _ hkeq]
+        exact ihv k hk
+
+private def outerStep {n : ℕ} (fa ga : Array UInt32) (r : Array UInt32) (i : ℕ) :
+    Array UInt32 :=
+  List.foldl (fun r j => @innerStep n fa ga i r j) r (List.range n)
+
+-- outerStep effect: specialize inner_invariant to J = n
+
+private theorem outerStep_spec {n : ℕ} (fa ga : Array UInt32) (i : ℕ) (hi : i < n)
+    (hfi : (fa.getD i 0).toNat < modulus) (hgaB : ∀ j, (ga.getD j 0).toNat < modulus)
+    (r0 : Array UInt32) (hsz0 : r0.size = n)
+    (hb0 : ∀ k, k < n → (r0.getD k 0).toNat < modulus) :
+    (@outerStep n fa ga r0 i).size = n ∧
+    (∀ k, k < n → ((@outerStep n fa ga r0 i).getD k 0).toNat < modulus) ∧
+    (∀ k, k < n →
+      (((@outerStep n fa ga r0 i).getD k 0).toNat : ZMod modulus)
+        = ((r0.getD k 0).toNat : ZMod modulus)
+          + ∑ j ∈ (Finset.range n).filter (fun j => (i + j) % n = k), colVal n fa ga i j) := by
+  have := inner_invariant fa ga i hi hfi hgaB r0 hsz0 hb0 n (le_refl n)
+  exact this
+
+-- outer invariant: by induction on I
+
+private theorem outer_invariant {n : ℕ} (fa ga : Array UInt32)
+    (hfaB : ∀ i, i < n → (fa.getD i 0).toNat < modulus)
+    (hgaB : ∀ j, (ga.getD j 0).toNat < modulus) :
+    ∀ I, I ≤ n →
+      (List.foldl (fun r i => @outerStep n fa ga r i) (Array.replicate n 0) (List.range I)).size = n
+      ∧ (∀ k, k < n →
+          ((List.foldl (fun r i => @outerStep n fa ga r i)
+            (Array.replicate n 0) (List.range I)).getD k 0).toNat < modulus)
+      ∧ (∀ k, k < n →
+          (((List.foldl (fun r i => @outerStep n fa ga r i)
+            (Array.replicate n 0) (List.range I)).getD k 0).toNat : ZMod modulus)
+            = ∑ ij ∈ (Finset.range I ×ˢ Finset.range n).filter (fun ij => (ij.1 + ij.2) % n = k),
+                colVal n fa ga ij.1 ij.2) := by
+  intro I
+  induction I with
+  | zero =>
+    intro _
+    have hrep0 : ∀ k, k < n → (Array.replicate n (0:UInt32)).getD k 0 = 0 := by
+      intro k hk
+      rw [Array.getD, dif_pos (by rw [Array.size_replicate]; exact hk)]; simp
+    simp only [List.range_zero, List.foldl_nil]
+    refine ⟨by simp, ?_, ?_⟩
+    · intro k hk; rw [hrep0 k hk]; simp [modulus]
+    · intro k hk
+      simp only [Finset.range_zero, Finset.empty_product, Finset.filter_empty,
+        Finset.sum_empty]
+      rw [hrep0 k hk]; simp
+  | succ I ih =>
+    intro hI
+    have hI' : I ≤ n := Nat.le_of_succ_le hI
+    have hIn : I < n := Nat.lt_of_succ_le hI
+    obtain ⟨ihsz, ihb, ihv⟩ := ih hI'
+    set r := List.foldl (fun r i => @outerStep n fa ga r i)
+      (Array.replicate n 0) (List.range I) with hr
+    rw [foldl_range_succ]
+    obtain ⟨ospz, ospb, ospv⟩ :=
+      outerStep_spec fa ga I hIn (hfaB I hIn) hgaB r ihsz ihb
+    refine ⟨ospz, ospb, ?_⟩
+    intro k hk
+    rw [ospv k hk, ihv k hk]
+    -- split the product index set range (I+1) ×ˢ range n into range I and row {I}
+    have hsplit : (Finset.range (I+1) ×ˢ Finset.range n).filter (fun ij => (ij.1 + ij.2) % n = k)
+        = ((Finset.range I ×ˢ Finset.range n).filter (fun ij => (ij.1 + ij.2) % n = k))
+          ∪ (({I} ×ˢ Finset.range n).filter (fun ij => (ij.1 + ij.2) % n = k)) := by
+      ext ij
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range, Finset.mem_union,
+        Finset.mem_singleton, Finset.range_add_one, Finset.mem_insert]
+      constructor
+      · rintro ⟨⟨h1 | h1, h2⟩, h3⟩
+        · exact Or.inr ⟨⟨h1, h2⟩, h3⟩
+        · exact Or.inl ⟨⟨h1, h2⟩, h3⟩
+      · rintro (⟨⟨h1, h2⟩, h3⟩ | ⟨⟨h1, h2⟩, h3⟩)
+        · exact ⟨⟨Or.inr h1, h2⟩, h3⟩
+        · exact ⟨⟨Or.inl h1, h2⟩, h3⟩
+    rw [hsplit, Finset.sum_union]
+    · congr 1
+      -- second sum over {I} ×ˢ range n filtered = ∑ j ∈ (range n).filter, colVal
+      rw [Finset.singleton_product, Finset.filter_map, Finset.sum_map]
+      apply Finset.sum_congr
+      · ext j; simp
+      · intro j hj; rfl
+    · -- disjointness
+      rw [Finset.disjoint_left]
+      rintro ij hij1 hij2
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range,
+        Finset.mem_singleton] at hij1 hij2
+      omega
+
+private theorem mulU32_eq_foldl {n : ℕ} (f g : Rq n) :
+    negacyclicMulU32 f g
+      = Vector.ofFn (fun x : Fin n =>
+          (Nat.cast ((List.foldl
+            (fun r i => @outerStep n (f.toArray.map (fun c => (ZMod.val c).toUInt32))
+                  (g.toArray.map (fun c => (ZMod.val c).toUInt32)) r i)
+              (Array.replicate n 0) (List.range n)).getD x.val 0).toNat : ZMod modulus)) := by
+  unfold negacyclicMulU32 outerStep innerStep
+  simp only [Id.run, bind_pure_comp, Std.Legacy.Range.forIn_eq_forIn_range',
+    Std.Legacy.Range.size, Nat.sub_zero, Nat.div_one, List.range_eq_range', Nat.add_sub_cancel]
+  simp only [← apply_ite (f := fun a => pure (f := Id) (ForInStep.yield a))]
+  simp only [List.forIn_pure_yield_eq_foldl, map_pure]
+  rfl
+
+private theorem fa_getD {n : ℕ} (f : Rq n) (i : ℕ) (hi : i < n) :
+    (f.toArray.map (fun c => (ZMod.val c).toUInt32)).getD i 0
+      = (ZMod.val (f.get ⟨i, hi⟩)).toUInt32 := by
+  have hsz : i < (f.toArray.map (fun c => (ZMod.val c).toUInt32)).size := by
+    rw [Array.size_map, f.size_toArray]; exact hi
+  rw [← Array.getElem_eq_getD (xs := f.toArray.map (fun c => (ZMod.val c).toUInt32))
+      (i := i) (fallback := 0) (h := hsz), Array.getElem_map]
+  rfl
+
+private theorem fa_cast {n : ℕ} (f : Rq n) (i : ℕ) (hi : i < n) :
+    (((f.toArray.map (fun c => (ZMod.val c).toUInt32)).getD i 0).toNat : ZMod modulus)
+      = f.get ⟨i, hi⟩ := by
+  rw [fa_getD f i hi]
+  have : (ZMod.val (f.get ⟨i, hi⟩)).toUInt32.toNat = ZMod.val (f.get ⟨i, hi⟩) := by
+    have hval : ZMod.val (f.get ⟨i,hi⟩) < 12289 := ZMod.val_lt _
+    change (UInt32.ofNat _).toNat = _
+    rw [UInt32.toNat_ofNat']; exact Nat.mod_eq_of_lt (by omega)
+  rw [this, ZMod.natCast_zmod_val]
+
+private theorem fa_bound {n : ℕ} (f : Rq n) (i : ℕ) (hi : i < n) :
+    ((f.toArray.map (fun c => (ZMod.val c).toUInt32)).getD i 0).toNat < modulus := by
+  rw [fa_getD f i hi]
+  have hval : ZMod.val (f.get ⟨i,hi⟩) < 12289 := ZMod.val_lt _
+  change (UInt32.ofNat _).toNat < _
+  rw [UInt32.toNat_ofNat']; rw [Nat.mod_eq_of_lt (by omega)]; exact hval
+
+/-- The `UInt32` fast negacyclic multiplier agrees with the abstract `negacyclicMul`. -/
+theorem negacyclicMulU32_eq_negacyclicMul {n : ℕ} (f g : Rq n) :
+    negacyclicMulU32 f g = Falcon.negacyclicMul f g := by
+  apply LatticeCrypto.Poly.ext_get_eq
+  intro k
+  -- RHS coefficient
+  have hrhs : (Falcon.negacyclicMul f g).get k
+      = LatticeCrypto.negacyclicConvCoeff (fun i => f.get i) (fun i => g.get i) k := by
+    change ((LatticeCrypto.vectorNegacyclicRing Coeff n).mul f g).get k = _
+    rw [LatticeCrypto.vectorNegacyclicRing_mul]
+    exact LatticeCrypto.negacyclicMulPure_coeff (LatticeCrypto.vectorKernel Coeff n) f g k
+  rw [hrhs]
+  -- LHS coefficient
+  rw [mulU32_eq_foldl]
+  simp only [Vector.get_ofFn]
+  set fa := f.toArray.map (fun c => (ZMod.val c).toUInt32) with hfa
+  set ga := g.toArray.map (fun c => (ZMod.val c).toUInt32) with hga
+  obtain ⟨_, _, hval⟩ := outer_invariant fa ga
+    (fun i hi => by rw [hfa]; exact fa_bound f i hi)
+    (fun j => by
+      by_cases hj : j < n
+      · rw [hga]; exact fa_bound g j hj
+      · rw [hga]; rw [Array.getD]; rw [dif_neg (by rw [Array.size_map, g.size_toArray]; omega)]
+        simp [modulus])
+    n (le_refl n)
+  rw [hval k.val k.isLt]
+  -- bridge the colVal sum to negacyclicConvCoeff
+  rw [LatticeCrypto.negacyclicConvCoeff, Finset.sum_filter, Fintype.sum_prod_type]
+  -- turn the LHS range×range sum into an iterated Fin sum to match the RHS
+  rw [Finset.sum_product]
+  rw [← Fin.sum_univ_eq_sum_range
+    (fun i => ∑ j ∈ Finset.range n,
+      if (i + j) % n = (k:ℕ) then colVal n fa ga i j else 0) n]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [← Fin.sum_univ_eq_sum_range
+    (fun j => if (i.val + j) % n = (k:ℕ) then colVal n fa ga i.val j else 0) n]
+  apply Finset.sum_congr rfl
+  intro j _
+  -- termwise: colVal matches the spec summand via fa_cast
+  by_cases hc : (i.val + j.val) % n = (k:ℕ)
+  · rw [if_pos hc, if_pos hc]
+    unfold colVal
+    rw [hfa, hga, fa_cast f i.val i.isLt, fa_cast g j.val j.isLt]
+  · rw [if_neg hc, if_neg hc]
+
+/-- The `UInt64` accumulator of `pairL2NormSqU32` never overflows: folding a list of
+nonnegative summands whose every prefix stays below `2 ^ 64` commutes with `UInt64.toNat`. -/
+private theorem foldl_uint64_add_toNat {α : Type*} (g : α → UInt64) (l : List α)
+    (init : UInt64)
+    (hbound : ∀ pre, pre <+: l →
+      init.toNat + (pre.map (fun a => (g a).toNat)).sum < 2 ^ 64) :
+    (l.foldl (fun b a => b + g a) init).toNat
+      = init.toNat + (l.map (fun a => (g a).toNat)).sum := by
+  induction l generalizing init with
+  | nil => simp
+  | cons x xs ih =>
+    simp only [List.foldl_cons, List.map_cons, List.sum_cons]
+    have hx : (init + g x).toNat = init.toNat + (g x).toNat := by
+      rw [UInt64.toNat_add, Nat.mod_eq_of_lt]
+      have := hbound [x] (by simp [List.prefix_cons_iff])
+      simpa using this
+    rw [ih (init + g x)]
+    · rw [hx]; ring
+    · intro pre hpre
+      rw [hx]
+      have := hbound (x :: pre) (by
+        rcases hpre with ⟨t, rfl⟩
+        exact ⟨t, by simp⟩)
+      simp only [List.map_cons, List.sum_cons] at this
+      omega
+
+/-- An integer of magnitude below `2 ^ 63` is fixed by balanced reduction modulo `2 ^ 64`. -/
+private theorem bmod_two_pow_64_eq_self (z : ℤ) (hlo : -(2 ^ 63) < z) (hhi : z < 2 ^ 63) :
+    z.bmod (2 ^ 64) = z := by
+  rw [Int.bmod_def]; push_cast; split_ifs <;> omega
+
+/-- Widening a small `UInt32` to `Int64` preserves its value as an integer. -/
+private theorem toInt_uint32_toInt64 (v : UInt32) (h : v.toNat < 12289) :
+    v.toUInt64.toInt64.toInt = (v.toNat : ℤ) := by
+  rw [Int64.toInt, UInt64.toBitVec_toInt64, BitVec.toInt_eq_toNat_bmod,
+    UInt64.toNat_toBitVec, UInt32.toNat_toUInt64]
+  rw [Int.bmod_eq_emod_of_lt]
+  · exact Int.emod_eq_of_lt (by positivity) (by omega)
+  · rw [Int.emod_eq_of_lt (by positivity) (by omega)]; omega
+
+/-- The modulus widened to `Int64` reads back as the integer `modulus`. -/
+private theorem toInt_modulus : modulus.toUInt64.toInt64.toInt = (modulus : ℤ) := by
+  decide +kernel
+
+/-- The `UInt32` packing of a residue's value round-trips to its `ZMod.val`. -/
+private theorem val_toUInt32_toNat (x : ZMod modulus) :
+    (ZMod.val x).toUInt32.toNat = ZMod.val x := by
+  have hval : ZMod.val x < 12289 := ZMod.val_lt x
+  change (UInt32.ofNat (ZMod.val x)).toNat = ZMod.val x
+  rw [UInt32.toNat_ofNat']; exact Nat.mod_eq_of_lt (by omega)
+
+/-- The centering branch in `pairL2NormSqU32` computes the integer `centeredRepr`. -/
+private theorem kernelC_toInt (x : ZMod modulus) :
+    (if (ZMod.val x).toUInt32 ≤ (modulus / 2).toUInt32 then
+        (ZMod.val x).toUInt32.toUInt64.toInt64
+      else (ZMod.val x).toUInt32.toUInt64.toInt64 - modulus.toUInt64.toInt64).toInt
+      = LatticeCrypto.centeredRepr x := by
+  have hval : ZMod.val x < 12289 := ZMod.val_lt x
+  have hvn : (ZMod.val x).toUInt32.toNat = ZMod.val x := val_toUInt32_toNat x
+  have hpos : (ZMod.val x).toUInt32.toUInt64.toInt64.toInt = (ZMod.val x : ℤ) := by
+    rw [toInt_uint32_toInt64 _ (by omega), hvn]
+  have hmod2 : (modulus : ℤ) / 2 = 6144 := by norm_num [modulus]
+  have hcmp : ((ZMod.val x).toUInt32 ≤ (modulus / 2).toUInt32)
+      ↔ ZMod.val x ≤ 6144 := by
+    rw [UInt32.le_iff_toNat_le, hvn]
+    have h2 : ((modulus / 2 : ℕ).toUInt32).toNat = 6144 := by
+      change (UInt32.ofNat (modulus / 2)).toNat = 6144
+      rw [UInt32.toNat_ofNat']; rfl
+    rw [h2]
+  by_cases h : ZMod.val x ≤ 6144
+  · rw [if_pos (hcmp.mpr h), hpos, LatticeCrypto.centeredRepr_of_le (by omega)]
+  · rw [if_neg (fun hc => h (hcmp.mp hc)), Int64.toInt_sub, hpos, toInt_modulus]
+    have hgt : 6144 < ZMod.val x := by omega
+    rw [LatticeCrypto.centeredRepr_of_gt (by omega),
+      bmod_two_pow_64_eq_self _ (by omega) (by omega)]
+
+/-- The per-coefficient `UInt64` summand contributed by index `a` of `s`. -/
+private def loopG {n : ℕ} (s : Rq n) (a : ℕ) : UInt64 :=
+  (let v := (ZMod.val (s.getD a 0)).toUInt32
+   (if v ≤ (modulus / 2).toUInt32 then v.toUInt64.toInt64
+    else v.toUInt64.toInt64 - modulus.toUInt64.toInt64) *
+   (if v ≤ (modulus / 2).toUInt32 then v.toUInt64.toInt64
+    else v.toUInt64.toInt64 - modulus.toUInt64.toInt64)).toUInt64
+
+/-- In-range indexing through `Vector.getD` agrees with `Vector.get`. -/
+private theorem getD_eq_get {n : ℕ} (s : Rq n) (i : ℕ) (hi : i < n) :
+    Vector.getD s i 0 = s.get ⟨i, hi⟩ := by
+  simp only [Vector.getD, Vector.get, Array.getD]
+  have h2 : i < s.toArray.size := by rw [s.size_toArray]; exact hi
+  rw [dif_pos h2]; rfl
+
+/-- The per-coefficient summand equals the squared absolute centered representative. -/
+private theorem loopG_toNat {n : ℕ} (s : Rq n) (a : ℕ) (ha : a < n) :
+    (loopG s a).toNat = (LatticeCrypto.centeredRepr (s.get ⟨a, ha⟩)).natAbs ^ 2 := by
+  rw [loopG, getD_eq_get s a ha]
+  set x : ZMod modulus := s.get ⟨a, ha⟩
+  set c : Int64 := if (ZMod.val x).toUInt32 ≤ (modulus / 2).toUInt32 then
+      (ZMod.val x).toUInt32.toUInt64.toInt64
+    else (ZMod.val x).toUInt32.toUInt64.toInt64 - modulus.toUInt64.toInt64 with hcdef
+  have hcr : c.toInt = LatticeCrypto.centeredRepr x := kernelC_toInt x
+  have habs : (LatticeCrypto.centeredRepr x).natAbs ≤ 6144 := by
+    have := LatticeCrypto.centeredRepr_abs_le (q := modulus) x
+    simpa [show modulus / 2 = 6144 from by norm_num [modulus]] using this
+  have hbnd : -(6144 : ℤ) ≤ c.toInt ∧ c.toInt ≤ 6144 := by rw [hcr]; omega
+  have hsq : (c * c).toInt = c.toInt * c.toInt := by
+    rw [Int64.toInt_mul, bmod_two_pow_64_eq_self]
+    · nlinarith [hbnd.1, hbnd.2]
+    · nlinarith [hbnd.1, hbnd.2]
+  have hle : (0 : Int64) ≤ c * c := by
+    rw [Int64.le_iff_toInt_le, hsq]; exact mul_self_nonneg _
+  rw [Int64.toNat_toUInt64_of_le hle, Int64.toNatClampNeg, hsq, hcr,
+    ← Int.natAbs_mul_self, Int.toNat_natCast, ← sq]
+
+/-- Each per-coefficient summand is bounded by `(modulus / 2) ^ 2 = 6144 ^ 2`. -/
+private theorem loopG_toNat_le {n : ℕ} (s : Rq n) (a : ℕ) (ha : a < n) :
+    (loopG s a).toNat ≤ 6144 ^ 2 := by
+  rw [loopG_toNat s a ha]
+  have := LatticeCrypto.centeredRepr_abs_le (q := modulus) (s.get ⟨a, ha⟩)
+  have h6 : (LatticeCrypto.centeredRepr (s.get ⟨a, ha⟩)).natAbs ≤ 6144 := by
+    simpa [show modulus / 2 = 6144 from by norm_num [modulus]] using this
+  exact Nat.pow_le_pow_left h6 2
+
+/-- Every prefix sum of one loop's summands stays below `n * 6144 ^ 2`. -/
+private theorem loopG_prefix_sum_le {n : ℕ} (s : Rq n) (pre : List ℕ)
+    (hpre : pre <+: List.range n) :
+    (pre.map (fun a => (loopG s a).toNat)).sum ≤ n * 6144 ^ 2 := by
+  have hlen : pre.length ≤ n := by simpa using hpre.length_le
+  have hsub : ∀ a ∈ pre, a < n := fun a ha => by simpa using hpre.mem ha
+  calc (pre.map (fun a => (loopG s a).toNat)).sum
+      ≤ (pre.map (fun _ => 6144 ^ 2)).sum :=
+        List.sum_le_sum (fun a ha => loopG_toNat_le s a (hsub a ha))
+    _ = pre.length * 6144 ^ 2 := by rw [List.map_const']; simp [List.sum_replicate]
+    _ ≤ n * 6144 ^ 2 := Nat.mul_le_mul_right _ hlen
+
+/-- A sum of `f` over `List.range n` rewrites as a `Finset` sum over `Fin n`. -/
+private theorem sum_map_range_eq_sum_fin {n : ℕ} (f : ℕ → ℕ) :
+    ((List.range n).map f).sum = ∑ i : Fin n, f i.val := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [List.range_succ, List.map_append, List.sum_append, ih, Fin.sum_univ_castSucc]
+    simp
+
+set_option maxHeartbeats 1000000 in
+-- The two-loop unfolding plus the nested no-overflow accumulator rewrites push elaboration
+-- past the default heartbeat budget.
+/-- The `Int64`/`UInt64` fast squared-ℓ₂ norm agrees with the abstract `pairL2NormSq`.
+
+The hypothesis `2 * n * (modulus / 2) ^ 2 < 2 ^ 64` rules out `UInt64` wraparound in the
+accumulator: the kernel sums `2 * n` centered squares, each at most `(modulus / 2) ^ 2`, so the
+bound guarantees the running total stays below `2 ^ 64`. It holds with vast headroom for every
+Falcon degree (`n ∈ {512, 1024}`). -/
+theorem pairL2NormSqU32_eq_pairL2NormSq {n : ℕ} (hn : 2 * n * (modulus / 2) ^ 2 < 2 ^ 64)
+    (s₁ s₂ : Rq n) :
+    pairL2NormSqU32 s₁ s₂ = Falcon.pairL2NormSq s₁ s₂ := by
+  have hrhs : Falcon.pairL2NormSq s₁ s₂ =
+      (∑ i : Fin n, (LatticeCrypto.centeredRepr (s₁.get i)).natAbs ^ 2)
+      + (∑ i : Fin n, (LatticeCrypto.centeredRepr (s₂.get i)).natAbs ^ 2) := by
+    unfold Falcon.pairL2NormSq Falcon.normOps LatticeCrypto.NormOps.pairL2NormSq
+      LatticeCrypto.zmodPolyNormOps LatticeCrypto.normOpsOfCenteredView
+    simp only [LatticeCrypto.l2NormSqOf]; rfl
+  rw [hrhs]
+  unfold pairL2NormSqU32
+  simp only [Id.run, bind_pure_comp, Std.Legacy.Range.forIn_eq_forIn_range',
+    Std.Legacy.Range.size, Nat.sub_zero, Nat.div_one,
+    map_pure, List.forIn_pure_yield_eq_foldl, Nat.add_sub_cancel,
+    ← List.range_eq_range']
+  change (List.foldl (fun b a => b + loopG s₂ a)
+        (List.foldl (fun b a => b + loopG s₁ a) 0 (List.range n)) (List.range n)).toNat = _
+  have hbnd : n * 6144 ^ 2 + n * 6144 ^ 2 < 2 ^ 64 := by
+    have h6 : (modulus / 2) ^ 2 = 6144 ^ 2 := by norm_num [modulus]
+    rw [h6] at hn
+    calc n * 6144 ^ 2 + n * 6144 ^ 2 = 2 * n * 6144 ^ 2 := by ring
+      _ < 2 ^ 64 := hn
+  have hi0 : (0 : UInt64).toNat = 0 := by simp
+  have hpre1 : ∀ pre : List ℕ, pre <+: List.range n →
+      (0 : UInt64).toNat + (pre.map (fun a => (loopG s₁ a).toNat)).sum < 2 ^ 64 := by
+    intro pre hpre
+    have hle := loopG_prefix_sum_le s₁ pre hpre
+    rw [hi0]
+    calc 0 + (pre.map (fun a => (loopG s₁ a).toNat)).sum
+        = (pre.map (fun a => (loopG s₁ a).toNat)).sum := by ring
+      _ ≤ n * 6144 ^ 2 := hle
+      _ ≤ n * 6144 ^ 2 + n * 6144 ^ 2 := Nat.le_add_right _ _
+      _ < 2 ^ 64 := hbnd
+  have hi1 : (List.foldl (fun b a => b + loopG s₁ a) 0 (List.range n)).toNat
+      ≤ n * 6144 ^ 2 := by
+    rw [foldl_uint64_add_toNat (loopG s₁) (List.range n) 0 hpre1, hi0, Nat.zero_add]
+    simpa using loopG_prefix_sum_le s₁ (List.range n) (List.prefix_refl _)
+  have hpre2 : ∀ pre : List ℕ, pre <+: List.range n →
+      (List.foldl (fun b a => b + loopG s₁ a) 0 (List.range n)).toNat
+        + (pre.map (fun a => (loopG s₂ a).toNat)).sum < 2 ^ 64 := by
+    intro pre hpre
+    have h2 := loopG_prefix_sum_le s₂ pre hpre
+    calc (List.foldl (fun b a => b + loopG s₁ a) 0 (List.range n)).toNat
+          + (pre.map (fun a => (loopG s₂ a).toNat)).sum
+        ≤ n * 6144 ^ 2 + n * 6144 ^ 2 := Nat.add_le_add hi1 h2
+      _ < 2 ^ 64 := hbnd
+  rw [foldl_uint64_add_toNat (loopG s₂) (List.range n) _ hpre2]
+  rw [foldl_uint64_add_toNat (loopG s₁) (List.range n) 0 hpre1]
+  rw [hi0, Nat.zero_add]
+  rw [sum_map_range_eq_sum_fin, sum_map_range_eq_sum_fin]
+  congr 1
+  · apply Finset.sum_congr rfl
+    intro i _; rw [loopG_toNat _ i.val i.isLt]
+  · apply Finset.sum_congr rfl
+    intro i _; rw [loopG_toNat _ i.val i.isLt]
 
 /-! ## Abstract primitives instance -/
 

--- a/Extern/Falcon/VerifyBridge.lean
+++ b/Extern/Falcon/VerifyBridge.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oleksandr Vovkotrub
+-/
+
+module
+public import Extern.Falcon.FPRBridge
+
+/-!
+# The concrete Falcon verifier agrees with the abstract one
+
+`Falcon.Concrete.FPRBridge.concrete_verify_eq_verify` relates the standalone executable verifier
+`concreteVerify` to the abstract `Falcon.verify` under four side conditions: the signature and
+public-key codecs round-trip, and the `UInt32`/`Int64` arithmetic kernels compute the
+specification-level `negacyclicMul` and `pairL2NormSq`. All four are now theorems
+(`sigDecode_sigEncode`, `publicKeyBytes_extract` with `pkDecode_pkEncode`,
+`negacyclicMulU32_eq_negacyclicMul`, `pairL2NormSqU32_eq_pairL2NormSq`), so the bridge holds
+outright at every Falcon degree: `4 ∣ n` for the public-key packing and the `UInt64`
+no-overflow bound `2 · n · (q/2)² < 2⁶⁴` for the norm accumulator, which holds with vast headroom
+for `n ≤ 1024`.
+-/
+
+public section
+
+namespace Falcon.Concrete.FPRBridge
+
+/-- The verify bridge with its codec and kernel side conditions discharged. -/
+theorem concrete_verify_eq_verify_of_dvd
+    (p : Falcon.Params) (hn : p.n = 2 ^ p.logn) (hsbytelen : 0 < p.sbytelen)
+    (hn_ovf : 2 * p.n * (Falcon.modulus / 2) ^ 2 < 2 ^ 64) (hn4 : 4 ∣ p.n)
+    (pk : Falcon.PublicKey p) (msg : List Falcon.Byte) (sig : Falcon.Signature) :
+    let prims := verifyPrimitives p hn;
+    Falcon.Concrete.concreteVerify p (prims.publicKeyBytes pk.h) msg
+      (Falcon.Concrete.sigEncode sig.salt sig.compressedS2 p.logn) =
+        Falcon.verify p prims pk msg sig :=
+  concrete_verify_eq_verify p hn hsbytelen
+    (fun salt compSig hne => Falcon.Concrete.sigDecode_sigEncode salt compSig p.logn hne)
+    (fun h => by
+      rw [Falcon.Concrete.publicKeyBytes_extract, Falcon.Concrete.pkDecode_pkEncode p.n h hn4])
+    (fun s2 h => Falcon.Concrete.negacyclicMulU32_eq_negacyclicMul s2 h)
+    (fun s1 s2 => Falcon.Concrete.pairL2NormSqU32_eq_pairL2NormSq hn_ovf s1 s2) pk msg sig
+
+/-- At every Falcon degree `n = 2 ^ logn` with `2 ≤ logn ≤ 10`, both side conditions of
+`concrete_verify_eq_verify_of_dvd` hold, so the concrete and abstract verifiers agree. -/
+theorem concrete_verify_eq_verify_of_logn
+    (p : Falcon.Params) (hn : p.n = 2 ^ p.logn) (hsbytelen : 0 < p.sbytelen)
+    (hlo : 2 ≤ p.logn) (hhi : p.logn ≤ 10)
+    (pk : Falcon.PublicKey p) (msg : List Falcon.Byte) (sig : Falcon.Signature) :
+    let prims := verifyPrimitives p hn;
+    Falcon.Concrete.concreteVerify p (prims.publicKeyBytes pk.h) msg
+      (Falcon.Concrete.sigEncode sig.salt sig.compressedS2 p.logn) =
+        Falcon.verify p prims pk msg sig := by
+  have hle : p.n ≤ 1024 := by
+    rw [hn]
+    calc 2 ^ p.logn ≤ 2 ^ 10 := Nat.pow_le_pow_right (by norm_num) hhi
+      _ = 1024 := by norm_num
+  have hn_ovf : 2 * p.n * (Falcon.modulus / 2) ^ 2 < 2 ^ 64 := by
+    have : (Falcon.modulus / 2) ^ 2 = 6144 ^ 2 := by norm_num [Falcon.modulus]
+    rw [this]
+    calc 2 * p.n * 6144 ^ 2 ≤ 2 * 1024 * 6144 ^ 2 := by gcongr
+      _ < 2 ^ 64 := by norm_num
+  have hn4 : 4 ∣ p.n := by
+    rw [hn]
+    exact (pow_dvd_pow 2 hlo).trans (by norm_num)
+  exact concrete_verify_eq_verify_of_dvd p hn hsbytelen hn_ovf hn4 pk msg sig
+
+end Falcon.Concrete.FPRBridge
+
+end

--- a/LatticeCrypto/Falcon/Concrete/Encoding.lean
+++ b/LatticeCrypto/Falcon/Concrete/Encoding.lean
@@ -29,6 +29,14 @@ This is a variable-length code: small coefficients use ~9 bits, larger ones up t
 Each coefficient of `h ∈ R_q` takes exactly 14 bits (since `q = 12289 < 2^14`),
 packed 4 coefficients into 7 bytes.
 
+## Round-trip theorems
+
+`sigDecode_sigEncode` recovers the salt and the compressed payload of any nonempty encoded
+signature, `publicKeyBytes_extract` strips the one-byte public-key header back to the packed
+coefficients, and `pkDecode_pkEncode` recovers the polynomial from its packed encoding whenever
+`4 ∣ n`, the case of every Falcon degree. These are what the concrete verifier's agreement with
+the abstract one (`Falcon.Concrete.FPRBridge.concrete_verify_eq_verify`) needs from the codec.
+
 ## References
 
 - c-fn-dsa: `codec.c` (comp_encode, comp_decode, mqpoly_encode, mqpoly_decode)
@@ -133,8 +141,8 @@ def pkEncode (n : ℕ) (h : Rq n) : ByteArray := Id.run do
   if n % 4 != 0 then
     panic! s!"Falcon public-key encoding requires n divisible by 4, got {n}"
   let mut out := ByteArray.empty
-  let mut i := 0
-  while i + 3 < n do
+  for b in [0:n / 4] do
+    let i := 4 * b
     let h0 := (h[i]!).val
     let h1 := (h[i+1]!).val
     let h2 := (h[i+2]!).val
@@ -146,7 +154,6 @@ def pkEncode (n : ℕ) (h : Rq n) : ByteArray := Id.run do
     out := out.push (h2 >>> 2).toUInt8
     out := out.push ((h2 <<< 6) ||| (h3 >>> 8)).toUInt8
     out := out.push h3.toUInt8
-    i := i + 4
   return out
 
 /-- Decode a Falcon public key polynomial from the packed 14-bit coefficient format. -/
@@ -155,9 +162,9 @@ def pkDecode (n : ℕ) (d : ByteArray) : Option (Rq n) := Id.run do
   let needed := 7 * n / 4
   if d.size < needed then return none
   let mut result : Array Coeff := Array.replicate n 0
-  let mut i := 0
-  let mut j := 0
-  while i + 3 < n do
+  for b in [0:n / 4] do
+    let i := 4 * b
+    let j := 7 * b
     let d0 := d[j]!.toNat
     let d1 := d[j+1]!.toNat
     let d2 := d[j+2]!.toNat
@@ -165,7 +172,6 @@ def pkDecode (n : ℕ) (d : ByteArray) : Option (Rq n) := Id.run do
     let d4 := d[j+4]!.toNat
     let d5 := d[j+5]!.toNat
     let d6 := d[j+6]!.toNat
-    j := j + 7
     let h0 := (d0 <<< 6) ||| (d1 >>> 2)
     let h1 := ((d1 <<< 12) ||| (d2 <<< 4) ||| (d3 >>> 4)) &&& 0x3FFF
     let h2 := ((d3 <<< 10) ||| (d4 <<< 2) ||| (d5 >>> 6)) &&& 0x3FFF
@@ -176,13 +182,197 @@ def pkDecode (n : ℕ) (d : ByteArray) : Option (Rq n) := Id.run do
     result := result.set! (i+1) (h1 : Coeff)
     result := result.set! (i+2) (h2 : Coeff)
     result := result.set! (i+3) (h3 : Coeff)
-    i := i + 4
   return some (Vector.ofFn fun ⟨i, _⟩ => result.getD i 0)
 
 /-- External public-key bytes used by FN-DSA verification and raw-message hashing:
 one header byte followed by the packed 14-bit coefficient encoding. -/
 def publicKeyBytes (logn : Nat) {n : ℕ} (h : Rq n) : ByteArray :=
   ByteArray.mk #[publicKeyHeader logn] ++ pkEncode n h
+
+/-! ## Public key codec round-trip
+
+The packing identity is per-group: four 14-bit coefficients pack into seven bytes and unpack
+back to the same four values. `group_roundtrip` certifies the bit-twiddling identity, `gblock`
+isolates the seven bytes of one group, and `E` reconstructs the encoder output as a foldl whose
+per-byte values are characterized by `E_getElem` + `gblock_byte`. `pkDecode_pkEncode` then runs
+the decoder loop invariant against those bytes, using `group_roundtrip` (and `ZMod.val_lt`) to
+rule out the `≥ modulus` reject branch. -/
+
+private theorem toU8 (a : Nat) : a.toUInt8.toNat = a % 256 := by
+  simp [Nat.toUInt8, Nat.toUInt8.eq_1]
+
+private theorem lor_add (a b k : Nat) (hb : b < 2 ^ k) (hd : 2 ^ k ∣ a) : a ||| b = a + b := by
+  obtain ⟨c, rfl⟩ := hd
+  rw [mul_comm, ← Nat.shiftLeft_eq, ← Nat.shiftLeft_add_eq_or_of_lt hb, Nat.shiftLeft_eq, mul_comm]
+
+private theorem and3fff (a : Nat) : a &&& 0x3FFF = a % 2^14 := by
+  have := Nat.and_two_pow_sub_one_eq_mod a 14
+  norm_num at this ⊢; exact this
+
+set_option maxHeartbeats 1000000 in
+-- The four bit-packing identities are discharged by a single `omega`/`norm_num` sweep over the
+-- expanded shift/mask arithmetic, which exceeds the default heartbeat budget.
+private theorem group_roundtrip (c0 c1 c2 c3 : Nat)
+    (b0 : c0 < modulus) (b1 : c1 < modulus) (b2 : c2 < modulus) (b3 : c3 < modulus) :
+    let d0 := (c0 >>> 6).toUInt8.toNat
+    let d1 := ((c0 <<< 2) ||| (c1 >>> 12)).toUInt8.toNat
+    let d2 := (c1 >>> 4).toUInt8.toNat
+    let d3 := ((c1 <<< 4) ||| (c2 >>> 10)).toUInt8.toNat
+    let d4 := (c2 >>> 2).toUInt8.toNat
+    let d5 := ((c2 <<< 6) ||| (c3 >>> 8)).toUInt8.toNat
+    let d6 := c3.toUInt8.toNat
+    ((d0 <<< 6) ||| (d1 >>> 2)) = c0 ∧
+    (((d1 <<< 12) ||| (d2 <<< 4) ||| (d3 >>> 4)) &&& 0x3FFF) = c1 ∧
+    (((d3 <<< 10) ||| (d4 <<< 2) ||| (d5 >>> 6)) &&& 0x3FFF) = c2 ∧
+    (((d5 <<< 8) ||| d6) &&& 0x3FFF) = c3 := by
+  simp only [modulus] at b0 b1 b2 b3
+  intro d0 d1 d2 d3 d4 d5 d6
+  have hd0 : d0 = c0 / 64 := by
+    change (c0 >>> 6).toUInt8.toNat = _; rw [toU8, Nat.shiftRight_eq_div_pow]; norm_num; omega
+  have hd1 : d1 = (c0 * 4 + c1 / 4096) % 256 := by
+    change ((c0 <<< 2) ||| (c1 >>> 12)).toUInt8.toNat = _
+    rw [toU8, lor_add _ _ 2 (by rw [Nat.shiftRight_eq_div_pow]; omega)
+        ⟨c0, by rw [Nat.shiftLeft_eq]; ring⟩, Nat.shiftLeft_eq, Nat.shiftRight_eq_div_pow]
+  have hd2 : d2 = (c1 / 16) % 256 := by
+    change (c1 >>> 4).toUInt8.toNat = _; rw [toU8, Nat.shiftRight_eq_div_pow]
+  have hd3 : d3 = (c1 * 16 + c2 / 1024) % 256 := by
+    change ((c1 <<< 4) ||| (c2 >>> 10)).toUInt8.toNat = _
+    rw [toU8, lor_add _ _ 4 (by rw [Nat.shiftRight_eq_div_pow]; omega)
+        ⟨c1, by rw [Nat.shiftLeft_eq]; ring⟩, Nat.shiftLeft_eq, Nat.shiftRight_eq_div_pow]
+  have hd4 : d4 = (c2 / 4) % 256 := by
+    change (c2 >>> 2).toUInt8.toNat = _; rw [toU8, Nat.shiftRight_eq_div_pow]
+  have hd5 : d5 = (c2 * 64 + c3 / 256) % 256 := by
+    change ((c2 <<< 6) ||| (c3 >>> 8)).toUInt8.toNat = _
+    rw [toU8, lor_add _ _ 6 (by rw [Nat.shiftRight_eq_div_pow]; omega)
+        ⟨c2, by rw [Nat.shiftLeft_eq]; ring⟩, Nat.shiftLeft_eq, Nat.shiftRight_eq_div_pow]
+  have hd6 : d6 = c3 % 256 := by change c3.toUInt8.toNat = _; rw [toU8]
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [hd0, hd1, lor_add _ _ 6 (by rw [Nat.shiftRight_eq_div_pow]; omega)
+        ⟨c0/64, by rw [Nat.shiftLeft_eq]; ring⟩, Nat.shiftLeft_eq, Nat.shiftRight_eq_div_pow]
+    norm_num; omega
+  · set e1 := (c0 * 4 + c1 / 4096) % 256 with he1
+    set e2 := (c1 / 16) % 256 with he2
+    set e3 := (c1 * 16 + c2 / 1024) % 256 with he3
+    rw [hd1, hd2, hd3,
+      lor_add (e1 <<< 12) (e2 <<< 4) 12 (by rw [Nat.shiftLeft_eq]; show e2 * 2^4 < 2^12; omega)
+        ⟨e1, by rw [Nat.shiftLeft_eq]; ring⟩,
+      lor_add (e1 <<< 12 + e2 <<< 4) (e3 >>> 4) 4 (by rw [Nat.shiftRight_eq_div_pow]; omega)
+        ⟨e1 * 2^8 + e2, by rw [Nat.shiftLeft_eq, Nat.shiftLeft_eq]; ring⟩,
+      and3fff, Nat.shiftLeft_eq, Nat.shiftLeft_eq, Nat.shiftRight_eq_div_pow]
+    simp only [he1, he2, he3]; norm_num; omega
+  · set e3 := (c1 * 16 + c2 / 1024) % 256 with he3
+    set e4 := (c2 / 4) % 256 with he4
+    set e5 := (c2 * 64 + c3 / 256) % 256 with he5
+    rw [hd3, hd4, hd5,
+      lor_add (e3 <<< 10) (e4 <<< 2) 10 (by rw [Nat.shiftLeft_eq]; show e4 * 2^2 < 2^10; omega)
+        ⟨e3, by rw [Nat.shiftLeft_eq]; ring⟩,
+      lor_add (e3 <<< 10 + e4 <<< 2) (e5 >>> 6) 2 (by rw [Nat.shiftRight_eq_div_pow]; omega)
+        ⟨e3 * 2^8 + e4, by rw [Nat.shiftLeft_eq, Nat.shiftLeft_eq]; ring⟩,
+      and3fff, Nat.shiftLeft_eq, Nat.shiftLeft_eq, Nat.shiftRight_eq_div_pow]
+    simp only [he3, he4, he5]; norm_num; omega
+  · rw [hd5, hd6, lor_add _ _ 8 (by omega) ⟨_, by rw [Nat.shiftLeft_eq]; ring⟩, and3fff,
+      Nat.shiftLeft_eq]
+    norm_num; omega
+
+private def gblock (n : ℕ) (h : Rq n) (b : ℕ) : ByteArray :=
+  let i := 4 * b
+  let h0 := (h[i]!).val
+  let h1 := (h[i+1]!).val
+  let h2 := (h[i+2]!).val
+  let h3 := (h[i+3]!).val
+  ByteArray.mk #[ (h0 >>> 6).toUInt8, ((h0 <<< 2) ||| (h1 >>> 12)).toUInt8, (h1 >>> 4).toUInt8,
+     ((h1 <<< 4) ||| (h2 >>> 10)).toUInt8, (h2 >>> 2).toUInt8,
+     ((h2 <<< 6) ||| (h3 >>> 8)).toUInt8, h3.toUInt8 ]
+
+private def encStep (n : ℕ) (h : Rq n) (out : ByteArray) (b : ℕ) : ByteArray :=
+  let i := 4 * b
+  let h0 := (h[i]!).val
+  let h1 := (h[i+1]!).val
+  let h2 := (h[i+2]!).val
+  let h3 := (h[i+3]!).val
+  ((((((out.push ((h0 >>> 6).toUInt8)).push (((h0 <<< 2) ||| (h1 >>> 12)).toUInt8)).push
+    ((h1 >>> 4).toUInt8)).push (((h1 <<< 4) ||| (h2 >>> 10)).toUInt8)).push
+    ((h2 >>> 2).toUInt8)).push (((h2 <<< 6) ||| (h3 >>> 8)).toUInt8)).push (h3.toUInt8)
+
+private theorem gblock_size (n : ℕ) (h : Rq n) (b : ℕ) : (gblock n h b).size = 7 := rfl
+private theorem gblock_data_size (n : ℕ) (h : Rq n) (b : ℕ) : (gblock n h b).data.size = 7 := rfl
+
+private theorem encStep_eq_append (n : ℕ) (h : Rq n) (out : ByteArray) (b : ℕ) :
+    encStep n h out b = out ++ gblock n h b := by
+  apply ByteArray.ext
+  simp only [encStep, gblock, ByteArray.data_push, ByteArray.data_append]
+  rfl
+
+private theorem encStep_size (n : ℕ) (h : Rq n) (out : ByteArray) (b : ℕ) :
+    (encStep n h out b).size = out.size + 7 := by
+  rw [encStep_eq_append, ByteArray.size_append, gblock_size]
+
+private def E (n : ℕ) (h : Rq n) (m : ℕ) : ByteArray :=
+  List.foldl (encStep n h) ByteArray.empty (List.range' 0 m)
+
+private theorem E_succ (n : ℕ) (h : Rq n) (m : ℕ) :
+    E n h (m+1) = encStep n h (E n h m) m := by
+  simp only [E, List.range'_concat, List.foldl_concat]
+  norm_num
+
+private theorem E_size (n : ℕ) (h : Rq n) (m : ℕ) : (E n h m).size = 7 * m := by
+  induction m with
+  | zero => rfl
+  | succ k ih => rw [E_succ, encStep_size, ih]; ring
+
+private theorem E_getElem (n : ℕ) (h : Rq n) (m : ℕ) :
+    ∀ b, b < m → ∀ t, t < 7 → (E n h m).data[7 * b + t]! = (gblock n h b).data[t]! := by
+  induction m with
+  | zero => intro b hb; omega
+  | succ k ih =>
+    intro b hb t ht
+    rw [E_succ, encStep_eq_append, ByteArray.data_append]
+    rcases Nat.lt_or_ge b k with hbk | hbk
+    · -- b < k : append_left into E k
+      have hlt : 7 * b + t < (E n h k).data.size := by
+        rw [← ByteArray.size, E_size]; omega
+      rw [getElem!_pos _ (7*b+t) (by rw [Array.size_append]; omega),
+          Array.getElem_append_left hlt, ← getElem!_pos _ (7*b+t) hlt]
+      exact ih b hbk t ht
+    · -- b = k
+      have hbeq : b = k := by omega
+      subst hbeq
+      have hsz : (E n h b).data.size = 7 * b := by rw [← ByteArray.size, E_size]
+      have hidx : 7 * b + t = (E n h b).data.size + t := by rw [hsz]
+      rw [hidx,
+          getElem!_pos _ ((E n h b).data.size + t)
+            (by rw [Array.size_append, gblock_data_size]; omega),
+          getElem!_pos (gblock n h b).data t (by rw [gblock_data_size]; exact ht),
+          Array.getElem_append_right (by omega)]
+      congr 1
+      omega
+
+private theorem pkEncode_eq_E (n : ℕ) (h : Rq n) (hn : n % 4 = 0) :
+    pkEncode n h = E n h (n / 4) := by
+  unfold pkEncode E
+  have hb : (n % 4 != 0) = false := by simp [hn]
+  simp only [Id.run, Std.Legacy.Range.forIn_eq_forIn_range', Std.Legacy.Range.size, Nat.sub_zero,
+    Nat.div_one, Nat.add_sub_cancel, hb, Bool.false_eq_true, if_false]
+  simp only [List.forIn_pure_yield_eq_foldl, bind_pure]
+  rfl
+
+-- explicit bytes of gblock
+private theorem gblock_byte (n : ℕ) (h : Rq n) (b : ℕ) :
+    let i := 4 * b
+    let c0 := (h[i]!).val; let c1 := (h[i+1]!).val
+    let c2 := (h[i+2]!).val; let c3 := (h[i+3]!).val
+    (gblock n h b).data[0]! = (c0 >>> 6).toUInt8 ∧
+    (gblock n h b).data[1]! = ((c0 <<< 2) ||| (c1 >>> 12)).toUInt8 ∧
+    (gblock n h b).data[2]! = (c1 >>> 4).toUInt8 ∧
+    (gblock n h b).data[3]! = ((c1 <<< 4) ||| (c2 >>> 10)).toUInt8 ∧
+    (gblock n h b).data[4]! = (c2 >>> 2).toUInt8 ∧
+    (gblock n h b).data[5]! = ((c2 <<< 6) ||| (c3 >>> 8)).toUInt8 ∧
+    (gblock n h b).data[6]! = c3.toUInt8 := by
+  refine ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+private theorem pkEncode_size (n : ℕ) (h : Rq n) (hn4 : n % 4 = 0) :
+    (pkEncode n h).size = 7 * (n / 4) := by
+  rw [pkEncode_eq_E n h hn4, E_size]
 
 /-! ## Full signature encoding/decoding -/
 
@@ -212,5 +402,392 @@ def sigDecode (d : ByteArray) (logn : ℕ) : Option (Bytes 40 × List UInt8) := 
       have hone : ({ data := #[48 + UInt8.ofNat logn] } : ByteArray).size = 1 := rfl
       have hempty : ({ data := #[] } : ByteArray).size = 0 := rfl
       simp [sigDecode, sigEncode, hsalt, hone, hempty]
+
+/-- The accumulator loop underlying `ByteArray.toList` reverses its accumulator onto the
+remaining bytes, so the full traversal recovers the underlying array as a list. -/
+private theorem toList_loop_eq (a : ByteArray) :
+    ∀ i (acc : List UInt8), ByteArray.toList.loop a i acc
+      = acc.reverse ++ (a.data.toList.drop i) := by
+  intro i acc
+  fun_induction ByteArray.toList.loop a i acc with
+  | case1 i acc h ih =>
+      rw [ih]
+      have hi : i < a.data.toList.length := by rw [Array.length_toList]; exact h
+      rw [List.drop_eq_getElem_cons hi]
+      simp only [List.reverse_cons, List.append_assoc, List.singleton_append]
+      congr 2
+      cases a with
+      | mk bs =>
+        change bs[i]! = _
+        rw [getElem!_pos bs i (show i < bs.size from h), Array.getElem_toList]
+  | case2 i acc h =>
+      have : a.data.toList.length ≤ i := by
+        rw [Array.length_toList]; exact Nat.le_of_not_lt h
+      rw [List.drop_eq_nil_of_le this]; simp
+
+/-- `ByteArray.toList` agrees with the list of the underlying data array. -/
+private theorem byteArray_toList_eq (a : ByteArray) : a.toList = a.data.toList := by
+  rw [ByteArray.toList, toList_loop_eq]; simp
+
+/-- `ByteArray` `getElem!` agrees with the underlying data array's `getElem!`. -/
+private theorem byteArray_getElem!_data (a : ByteArray) (i : ℕ) : a[i]! = a.data[i]! := by
+  by_cases hi : i < a.size
+  · rw [getElem!_pos a i hi, getElem!_pos a.data i (by rwa [← ByteArray.size])]
+    rfl
+  · rw [getElem!_neg a i hi, getElem!_neg a.data i (by rwa [← ByteArray.size])]
+
+/-- Round-trip: decoding an encoded signature recovers the original salt and compressed bytes.
+A nonempty compressed payload guarantees the encoded length passes the `42`-byte minimum check,
+so the header, salt, and payload segments all decode back to their inputs. -/
+theorem sigDecode_sigEncode (salt : Bytes 40) (compSig : List UInt8) (logn : ℕ)
+    (hne : compSig ≠ []) :
+    sigDecode (sigEncode salt compSig logn) logn = some (salt, compSig) := by
+  have hlen : 1 ≤ compSig.length := by
+    rw [Nat.one_le_iff_ne_zero, ne_eq, List.length_eq_zero_iff]; exact hne
+  set hdr : UInt8 := (0x30 + logn).toUInt8 with hhdr
+  have hb1 : (ByteArray.mk #[hdr]).size = 1 := rfl
+  have hss : (ByteArray.mk salt.toArray).size = 40 := by change salt.toArray.size = 40; simp
+  have hcs : (ByteArray.mk compSig.toArray).size = compSig.length := by
+    change compSig.toArray.size = compSig.length; simp
+  have hesize : (sigEncode salt compSig logn).size = 41 + compSig.length := by
+    change (ByteArray.mk #[hdr] ++ ByteArray.mk salt.toArray ++ ByteArray.mk compSig.toArray).size
+        = 41 + compSig.length
+    rw [ByteArray.size_append, ByteArray.size_append, hb1, hss, hcs]
+  have hguard : ¬ (sigEncode salt compSig logn).size < 42 := by rw [hesize]; omega
+  have hdata : (sigEncode salt compSig logn).data = #[hdr] ++ salt.toArray ++ compSig.toArray := by
+    simp only [sigEncode, ByteArray.data_append, hhdr]
+  have hhead : (sigEncode salt compSig logn)[0]! = hdr := by
+    rw [byteArray_getElem!_data, hdata, getElem!_pos _ 0 (by simp),
+      Array.getElem_append_left (by simp), Array.getElem_append_left (by simp)]
+    rfl
+  have hsalt : (Vector.ofFn fun (i : Fin 40) => (sigEncode salt compSig logn)[i.val + 1]!)
+      = salt := by
+    apply Vector.ext
+    intro i hi
+    rw [Vector.getElem_ofFn, byteArray_getElem!_data, hdata,
+      getElem!_pos _ (i + 1) (by simp; omega), Array.getElem_append_left (by simp; omega),
+      Array.getElem_append_right (by simp)]
+    simp [Vector.getElem_toArray]
+  have hcomp : ((sigEncode salt compSig logn).extract 41
+      (sigEncode salt compSig logn).size).toList = compSig := by
+    rw [hesize]
+    change ((ByteArray.mk #[hdr] ++ ByteArray.mk salt.toArray
+        ++ ByteArray.mk compSig.toArray).extract 41 (41 + compSig.length)).toList = compSig
+    rw [ByteArray.extract_append_eq_right
+      (a := ByteArray.mk #[hdr] ++ ByteArray.mk salt.toArray) (b := ByteArray.mk compSig.toArray)
+      (by rw [ByteArray.size_append, hb1, hss]) (by rw [ByteArray.size_append, hb1, hss, hcs])]
+    rw [byteArray_toList_eq]
+  unfold sigDecode
+  simp only [Id.run, hguard, hhead, hhdr, if_false, bne_self_eq_false, Bool.false_eq_true,
+    hsalt, hcomp]
+  rfl
+
+/-! ### Public key decode round-trip -/
+
+/-- The seven bytes of `pkEncode n h` at group `b` are exactly the bytes of `gblock n h b`. -/
+private theorem pkEncode_group_byte (n : ℕ) (h : Rq n) (hn4 : n % 4 = 0)
+    (b : ℕ) (hb : b < n / 4) (t : ℕ) (ht : t < 7) :
+    (pkEncode n h)[7 * b + t]! = (gblock n h b).data[t]! := by
+  rw [byteArray_getElem!_data, pkEncode_eq_E n h hn4, E_getElem n h (n / 4) b hb t ht]
+
+/-- Each decoded coefficient of `pkEncode n h` at group `b` recovers `h[4b+s].val`, which is
+`< modulus`; hence the decoder's reject branch is never taken. -/
+private theorem pkEncode_group_decode (n : ℕ) (h : Rq n) (hn4 : n % 4 = 0)
+    (b : ℕ) (hb : b < n / 4) :
+    let g := pkEncode n h
+    let d0 := g[7 * b]!.toNat
+    let d1 := g[7 * b + 1]!.toNat
+    let d2 := g[7 * b + 2]!.toNat
+    let d3 := g[7 * b + 3]!.toNat
+    let d4 := g[7 * b + 4]!.toNat
+    let d5 := g[7 * b + 5]!.toNat
+    let d6 := g[7 * b + 6]!.toNat
+    ((d0 <<< 6) ||| (d1 >>> 2)) = (h[4 * b]!).val ∧
+    (((d1 <<< 12) ||| (d2 <<< 4) ||| (d3 >>> 4)) &&& 0x3FFF) = (h[4 * b + 1]!).val ∧
+    (((d3 <<< 10) ||| (d4 <<< 2) ||| (d5 >>> 6)) &&& 0x3FFF) = (h[4 * b + 2]!).val ∧
+    (((d5 <<< 8) ||| d6) &&& 0x3FFF) = (h[4 * b + 3]!).val := by
+  intro g d0 d1 d2 d3 d4 d5 d6
+  obtain ⟨e0, e1, e2, e3, e4, e5, e6⟩ := gblock_byte n h b
+  have hb0 : d0 = ((h[4 * b]!).val >>> 6).toUInt8.toNat := by
+    change g[7 * b]!.toNat = _
+    rw [show 7 * b = 7 * b + 0 from rfl, pkEncode_group_byte n h hn4 b hb 0 (by omega), e0]
+  have hb1 : d1 = (((h[4 * b]!).val <<< 2) ||| ((h[4 * b + 1]!).val >>> 12)).toUInt8.toNat := by
+    change g[7 * b + 1]!.toNat = _
+    rw [pkEncode_group_byte n h hn4 b hb 1 (by omega), e1]
+  have hb2 : d2 = ((h[4 * b + 1]!).val >>> 4).toUInt8.toNat := by
+    change g[7 * b + 2]!.toNat = _
+    rw [pkEncode_group_byte n h hn4 b hb 2 (by omega), e2]
+  have hb3 : d3 = (((h[4 * b + 1]!).val <<< 4) ||| ((h[4 * b + 2]!).val >>> 10)).toUInt8.toNat := by
+    change g[7 * b + 3]!.toNat = _
+    rw [pkEncode_group_byte n h hn4 b hb 3 (by omega), e3]
+  have hb4 : d4 = ((h[4 * b + 2]!).val >>> 2).toUInt8.toNat := by
+    change g[7 * b + 4]!.toNat = _
+    rw [pkEncode_group_byte n h hn4 b hb 4 (by omega), e4]
+  have hb5 : d5 = (((h[4 * b + 2]!).val <<< 6) ||| ((h[4 * b + 3]!).val >>> 8)).toUInt8.toNat := by
+    change g[7 * b + 5]!.toNat = _
+    rw [pkEncode_group_byte n h hn4 b hb 5 (by omega), e5]
+  have hb6 : d6 = (h[4 * b + 3]!).val.toUInt8.toNat := by
+    change g[7 * b + 6]!.toNat = _
+    rw [pkEncode_group_byte n h hn4 b hb 6 (by omega), e6]
+  rw [hb0, hb1, hb2, hb3, hb4, hb5, hb6]
+  exact group_roundtrip _ _ _ _ (ZMod.val_lt _) (ZMod.val_lt _) (ZMod.val_lt _) (ZMod.val_lt _)
+
+/-- Stripping the one-byte public-key header recovers the packed coefficient encoding. -/
+theorem publicKeyBytes_extract (logn : Nat) {n : ℕ} (h : Rq n) :
+    (publicKeyBytes logn h).extract 1 (publicKeyBytes logn h).size = pkEncode n h := by
+  set hdr : UInt8 := publicKeyHeader logn with hhdr
+  have hb1 : (ByteArray.mk #[hdr]).size = 1 := rfl
+  have hsz : (publicKeyBytes logn h).size = 1 + (pkEncode n h).size := by
+    change (ByteArray.mk #[hdr] ++ pkEncode n h).size = 1 + (pkEncode n h).size
+    rw [ByteArray.size_append, hb1]
+  rw [hsz]
+  change (ByteArray.mk #[hdr] ++ pkEncode n h).extract 1 (1 + (pkEncode n h).size) = pkEncode n h
+  rw [ByteArray.extract_append_eq_right (a := ByteArray.mk #[hdr]) (b := pkEncode n h)
+      (by rw [hb1]) (by rw [hb1])]
+
+/-- The decoded value written at sub-index `s ∈ {0,1,2,3}` of group `b`, as a `Coeff`. -/
+private def decVal (g : ByteArray) (b s : ℕ) : Coeff :=
+  let d0 := g[7 * b]!.toNat
+  let d1 := g[7 * b + 1]!.toNat
+  let d2 := g[7 * b + 2]!.toNat
+  let d3 := g[7 * b + 3]!.toNat
+  let d4 := g[7 * b + 4]!.toNat
+  let d5 := g[7 * b + 5]!.toNat
+  let d6 := g[7 * b + 6]!.toNat
+  match s with
+  | 0 => (((d0 <<< 6) ||| (d1 >>> 2) : ℕ) : Coeff)
+  | 1 => ((((d1 <<< 12) ||| (d2 <<< 4) ||| (d3 >>> 4)) &&& 0x3FFF : ℕ) : Coeff)
+  | 2 => ((((d3 <<< 10) ||| (d4 <<< 2) ||| (d5 >>> 6)) &&& 0x3FFF : ℕ) : Coeff)
+  | _ => ((((d5 <<< 8) ||| d6) &&& 0x3FFF : ℕ) : Coeff)
+
+/-- `getD` of `Array.set!` at the same in-bounds index returns the written value. -/
+private theorem getD_set!_self' (out : Array Coeff) (k : ℕ) (v : Coeff) (h : k < out.size) :
+    (out.set! k v).getD k 0 = v := by
+  simp only [Array.set!, Array.getD_eq_getD_getElem?, Array.getElem?_setIfInBounds]; simp [h]
+
+/-- `getD` of `Array.set!` at a different index is unaffected. -/
+private theorem getD_set!_ne' (out : Array Coeff) (k k' : ℕ) (v : Coeff) (h : k ≠ k') :
+    (out.set! k v).getD k' 0 = out.getD k' 0 := by
+  simp only [Array.set!, Array.getD_eq_getD_getElem?, Array.getElem?_setIfInBounds]; simp [h]
+
+/-- The decoder loop body (in `Id`) over a single group index. -/
+private def decBody (n : ℕ) (g : ByteArray) :
+    ℕ → Option (Option (Rq n)) × Array Coeff →
+      Id (ForInStep (Option (Option (Rq n)) × Array Coeff)) :=
+  fun b r =>
+    let d0 := g[7 * b]!.toNat
+    let d1 := g[7 * b + 1]!.toNat
+    let d2 := g[7 * b + 2]!.toNat
+    let d3 := g[7 * b + 3]!.toNat
+    let d4 := g[7 * b + 4]!.toNat
+    let d5 := g[7 * b + 5]!.toNat
+    let d6 := g[7 * b + 6]!.toNat
+    let h0 := (d0 <<< 6) ||| (d1 >>> 2)
+    let h1 := ((d1 <<< 12) ||| (d2 <<< 4) ||| (d3 >>> 4)) &&& 0x3FFF
+    let h2 := ((d3 <<< 10) ||| (d4 <<< 2) ||| (d5 >>> 6)) &&& 0x3FFF
+    let h3 := ((d5 <<< 8) ||| d6) &&& 0x3FFF
+    if h0 ≥ modulus || h1 ≥ modulus || h2 ≥ modulus || h3 ≥ modulus then
+      pure (ForInStep.done (some none, r.2))
+    else
+      pure (ForInStep.yield (none,
+        (((r.2.set! (4 * b) (h0 : Coeff)).set! (4 * b + 1) (h1 : Coeff)).set!
+          (4 * b + 2) (h2 : Coeff)).set! (4 * b + 3) (h3 : Coeff)))
+
+/-- The reject predicate for group `b`: at least one of the four decoded coefficients is out of
+range. The loop's `done` branch fires exactly when this holds. -/
+private def decReject (g : ByteArray) (b : ℕ) : Prop :=
+  (g[7 * b]!.toNat <<< 6 ||| g[7 * b + 1]!.toNat >>> 2 ≥ modulus) ∨
+  (((g[7 * b + 1]!.toNat <<< 12 ||| g[7 * b + 2]!.toNat <<< 4 |||
+     g[7 * b + 3]!.toNat >>> 4) &&& 0x3FFF) ≥ modulus) ∨
+  (((g[7 * b + 3]!.toNat <<< 10 ||| g[7 * b + 4]!.toNat <<< 2 |||
+     g[7 * b + 5]!.toNat >>> 6) &&& 0x3FFF) ≥ modulus) ∨
+  (((g[7 * b + 5]!.toNat <<< 8 ||| g[7 * b + 6]!.toNat) &&& 0x3FFF) ≥ modulus)
+
+/-- The decoder loop invariant: when every visited group decodes in-range, the loop never takes
+the reject branch, the status component stays `none`, the result keeps size `n`, every cell of a
+visited group holds its decoded value, and cells outside the visited range are preserved. The
+statement is generalized over a starting group offset `s` so the standard `range'` cons recursion
+applies. -/
+private theorem decode_loop_invariant (n : ℕ) (g : ByteArray) :
+    ∀ (m s : ℕ) (R0 : Array Coeff), R0.size = n → 4 * (s + m) ≤ n →
+      (∀ b, s ≤ b → b < s + m → ¬ decReject g b) →
+      ∃ R : Array Coeff,
+        forIn (m := Id) (List.range' s m)
+            ((none, R0) : Option (Option (Rq n)) × Array Coeff) (decBody n g)
+          = ((none, R) : Option (Option (Rq n)) × Array Coeff) ∧
+        R.size = n ∧
+        (∀ b k', s ≤ b → b < s + m → k' < 4 → R.getD (4 * b + k') 0 = decVal g b k') ∧
+        (∀ k, k < 4 * s ∨ 4 * (s + m) ≤ k → R.getD k 0 = R0.getD k 0) := by
+  intro m
+  induction m with
+  | zero =>
+    intro s R0 hsz0 _ _
+    refine ⟨R0, rfl, hsz0, ?_, ?_⟩
+    · intro b k' hb hb2; omega
+    · intro k _; rfl
+  | succ m ih =>
+    intro s R0 hsz0 hbound hrej
+    have hrejs : ¬ decReject g s := hrej s (le_refl s) (by omega)
+    -- process group s first
+    rw [show List.range' s (m + 1) = s :: List.range' (s + 1) m from by
+        rw [List.range'_succ]]
+    rw [List.forIn_cons]
+    -- the body at group s yields (no reject), with updated array R1
+    set R1 := (((R0.set! (4 * s) (decVal g s 0)).set! (4 * s + 1) (decVal g s 1)).set!
+      (4 * s + 2) (decVal g s 2)).set! (4 * s + 3) (decVal g s 3) with hR1
+    have hcondfalse :
+        ((g[7 * s]!.toNat <<< 6 ||| g[7 * s + 1]!.toNat >>> 2 ≥ modulus ||
+          (g[7 * s + 1]!.toNat <<< 12 ||| g[7 * s + 2]!.toNat <<< 4 |||
+            g[7 * s + 3]!.toNat >>> 4) &&& 0x3FFF ≥ modulus ||
+          (g[7 * s + 3]!.toNat <<< 10 ||| g[7 * s + 4]!.toNat <<< 2 |||
+            g[7 * s + 5]!.toNat >>> 6) &&& 0x3FFF ≥ modulus ||
+          (g[7 * s + 5]!.toNat <<< 8 ||| g[7 * s + 6]!.toNat) &&& 0x3FFF ≥ modulus)) = false := by
+      have h4 := hrejs
+      simp only [decReject, not_or, not_le] at h4
+      obtain ⟨e0, e1, e2, e3⟩ := h4
+      simp only [Bool.or_eq_false_iff, decide_eq_false_iff_not, ge_iff_le, not_le]
+      exact ⟨⟨⟨e0, e1⟩, e2⟩, e3⟩
+    have hstep : (decBody n g s (none, R0) : Id _)
+        = ForInStep.yield (none, R1) := by
+      change (if (g[7 * s]!.toNat <<< 6 ||| g[7 * s + 1]!.toNat >>> 2 ≥ modulus ||
+          (g[7 * s + 1]!.toNat <<< 12 ||| g[7 * s + 2]!.toNat <<< 4 |||
+            g[7 * s + 3]!.toNat >>> 4) &&& 0x3FFF ≥ modulus ||
+          (g[7 * s + 3]!.toNat <<< 10 ||| g[7 * s + 4]!.toNat <<< 2 |||
+            g[7 * s + 5]!.toNat >>> 6) &&& 0x3FFF ≥ modulus ||
+          (g[7 * s + 5]!.toNat <<< 8 ||| g[7 * s + 6]!.toNat) &&& 0x3FFF ≥ modulus) then
+          (pure (ForInStep.done ((some none, R0) : Option (Option (Rq n)) × Array Coeff))
+            : Id _)
+        else pure (ForInStep.yield ((none, R1) : Option (Option (Rq n)) × Array Coeff)))
+          = ForInStep.yield ((none, R1) : Option (Option (Rq n)) × Array Coeff)
+      rw [if_neg (by rw [hcondfalse]; exact Bool.false_ne_true)]
+      rfl
+    rw [hstep]
+    have hR1sz : R1.size = n := by rw [hR1]; simp [hsz0]
+    have hrej' : ∀ b, s + 1 ≤ b → b < (s + 1) + m → ¬ decReject g b := by
+      intro b hb hb2; exact hrej b (by omega) (by omega)
+    obtain ⟨R, hforIn, hRsz, hRval, hRkeep⟩ := ih (s + 1) R1 hR1sz (by omega) hrej'
+    refine ⟨R, hforIn, hRsz, ?_, ?_⟩
+    · intro b k' hb hb2 hk'
+      rcases Nat.lt_or_ge s b with hsb | hsb
+      · exact hRval b k' (by omega) (by omega) hk'
+      · -- b = s
+        have hbeq : b = s := by omega
+        subst hbeq
+        rw [hRkeep (4 * b + k') (by left; omega)]
+        rw [hR1]
+        have hbn : 4 * b + 3 < n := by omega
+        interval_cases k'
+        · simp only [Nat.add_zero]
+          rw [getD_set!_ne' _ _ _ _ (by omega), getD_set!_ne' _ _ _ _ (by omega),
+              getD_set!_ne' _ _ _ _ (by omega), getD_set!_self' _ _ _ (by rw [hsz0]; omega)]
+        · rw [getD_set!_ne' _ _ _ _ (by omega), getD_set!_ne' _ _ _ _ (by omega),
+              getD_set!_self' _ _ _ (by rw [Array.size_set!, hsz0]; omega)]
+        · rw [getD_set!_ne' _ _ _ _ (by omega),
+              getD_set!_self' _ _ _ (by rw [Array.size_set!, Array.size_set!, hsz0]; omega)]
+        · rw [getD_set!_self' _ _ _
+              (by rw [Array.size_set!, Array.size_set!, Array.size_set!, hsz0]; omega)]
+    · intro k hk
+      rw [hRkeep k (by omega)]
+      rw [hR1]
+      rw [getD_set!_ne' _ _ _ _ (by omega), getD_set!_ne' _ _ _ _ (by omega),
+          getD_set!_ne' _ _ _ _ (by omega), getD_set!_ne' _ _ _ _ (by omega)]
+
+/-- On `pkEncode n h` input, no decoder group is ever rejected. -/
+private theorem pkEncode_not_reject (n : ℕ) (h : Rq n) (hn4 : n % 4 = 0)
+    (b : ℕ) (hb : b < n / 4) : ¬ decReject (pkEncode n h) b := by
+  obtain ⟨v0, v1, v2, v3⟩ := pkEncode_group_decode n h hn4 b hb
+  simp only [decReject, not_or, not_le]
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [v0]; exact ZMod.val_lt _
+  · rw [v1]; exact ZMod.val_lt _
+  · rw [v2]; exact ZMod.val_lt _
+  · rw [v3]; exact ZMod.val_lt _
+
+/-- On `pkEncode n h` input, the decoded value at group `b`, sub-index `s`, is the original
+coefficient `h[4b+s]`. -/
+private theorem decVal_pkEncode (n : ℕ) (h : Rq n) (hn4 : n % 4 = 0)
+    (b : ℕ) (hb : b < n / 4) (s : ℕ) (hs : s < 4) :
+    decVal (pkEncode n h) b s = h[4 * b + s]! := by
+  obtain ⟨v0, v1, v2, v3⟩ := pkEncode_group_decode n h hn4 b hb
+  have hcoeff : ∀ (k : ℕ) (hk : k < n), ((h[k]!).val : Coeff) = h[k]! := by
+    intro k hk
+    rw [ZMod.natCast_val, ZMod.cast_id]
+  have hbn : 4 * b + 3 < n := by omega
+  interval_cases s
+  · change (((pkEncode n h)[7 * b]!.toNat <<< 6 ||| (pkEncode n h)[7 * b + 1]!.toNat >>> 2 : ℕ)
+        : Coeff) = h[4 * b + 0]!
+    rw [v0, hcoeff (4 * b) (by omega), Nat.add_zero]
+  · change ((((pkEncode n h)[7 * b + 1]!.toNat <<< 12 ||| (pkEncode n h)[7 * b + 2]!.toNat <<< 4 |||
+        (pkEncode n h)[7 * b + 3]!.toNat >>> 4) &&& 0x3FFF : ℕ) : Coeff) = _
+    rw [v1, hcoeff (4 * b + 1) (by omega)]
+  · change ((((pkEncode n h)[7 * b + 3]!.toNat <<< 10 ||| (pkEncode n h)[7 * b + 4]!.toNat <<< 2 |||
+        (pkEncode n h)[7 * b + 5]!.toNat >>> 6) &&& 0x3FFF : ℕ) : Coeff) = _
+    rw [v2, hcoeff (4 * b + 2) (by omega)]
+  · change ((((pkEncode n h)[7 * b + 5]!.toNat <<< 8 ||| (pkEncode n h)[7 * b + 6]!.toNat) &&&
+        0x3FFF : ℕ) : Coeff) = _
+    rw [v3, hcoeff (4 * b + 3) (by omega)]
+
+/-- Round-trip: decoding an encoded Falcon public key recovers the original polynomial.
+Requires `4 ∣ n` (true for every Falcon degree); for `n % 4 ≠ 0` the encoder pads to a
+non-canonical length and the decoder rejects. -/
+theorem pkDecode_pkEncode (n : ℕ) (h : Rq n) (hn4 : 4 ∣ n) :
+    pkDecode n (pkEncode n h) = some h := by
+  have hmod : n % 4 = 0 := by omega
+  -- the encoder output has exactly the canonical length, so the size guard is not taken
+  have hsize : (pkEncode n h).size = 7 * n / 4 := by
+    rw [pkEncode_size n h hmod]; omega
+  have hguard : ¬ (pkEncode n h).size < 7 * n / 4 := by rw [hsize]; omega
+  -- obtain the loop result via the invariant
+  obtain ⟨R, hforIn, hRsz, hRval, hRkeep⟩ :=
+    decode_loop_invariant n (pkEncode n h) (n / 4) 0 (Array.replicate n 0)
+      (by simp) (by omega) (fun b _ hb => pkEncode_not_reject n h hmod b (by omega))
+  -- unfold pkDecode and reduce to the post-loop assembly
+  unfold pkDecode
+  have hb : (n % 4 != 0) = false := by simp [hmod]
+  simp only [Id.run, hb, Bool.false_eq_true, if_false, hguard,
+    Std.Legacy.Range.forIn_eq_forIn_range', Std.Legacy.Range.size, Nat.sub_zero, Nat.div_one,
+    Nat.add_sub_cancel]
+  -- the forIn body is definitionally `decBody`, so rewrite using the invariant result
+  have hforIn' : (forIn (m := Id) (List.range' 0 (n / 4))
+        ((none, Array.replicate n 0) : Option (Option (Rq n)) × Array Coeff)
+        (fun b r =>
+          let d0 := (pkEncode n h)[7 * b]!.toNat
+          let d1 := (pkEncode n h)[7 * b + 1]!.toNat
+          let d2 := (pkEncode n h)[7 * b + 2]!.toNat
+          let d3 := (pkEncode n h)[7 * b + 3]!.toNat
+          let d4 := (pkEncode n h)[7 * b + 4]!.toNat
+          let d5 := (pkEncode n h)[7 * b + 5]!.toNat
+          let d6 := (pkEncode n h)[7 * b + 6]!.toNat
+          let h0 := (d0 <<< 6) ||| (d1 >>> 2)
+          let h1 := ((d1 <<< 12) ||| (d2 <<< 4) ||| (d3 >>> 4)) &&& 0x3FFF
+          let h2 := ((d3 <<< 10) ||| (d4 <<< 2) ||| (d5 >>> 6)) &&& 0x3FFF
+          let h3 := ((d5 <<< 8) ||| d6) &&& 0x3FFF
+          if h0 ≥ modulus || h1 ≥ modulus || h2 ≥ modulus || h3 ≥ modulus then
+            pure (ForInStep.done (some none, r.2))
+          else
+            pure (ForInStep.yield (none,
+              (((r.2.set! (4 * b) (h0 : Coeff)).set! (4 * b + 1) (h1 : Coeff)).set!
+                (4 * b + 2) (h2 : Coeff)).set! (4 * b + 3) (h3 : Coeff)))))
+      = ((none, R) : Option (Option (Rq n)) × Array Coeff) := hforIn
+  erw [hforIn']
+  -- the status is `none`, so the assembly returns `some (Vector.ofFn (R.getD · 0))`
+  change some (Vector.ofFn fun x : Fin n => R.getD x.val 0) = some h
+  -- every cell of `R` recovers the original coefficient
+  have hRcoeff : ∀ j, j < n → R.getD j 0 = h[j]! := by
+    intro j hj
+    have hj4 : j = 4 * (j / 4) + j % 4 := by omega
+    have hbk : j / 4 < n / 4 := by omega
+    have hsk : j % 4 < 4 := by omega
+    calc R.getD j 0
+        = R.getD (4 * (j / 4) + j % 4) 0 := by rw [← hj4]
+      _ = decVal (pkEncode n h) (j / 4) (j % 4) :=
+          hRval (j / 4) (j % 4) (by omega) (by omega) hsk
+      _ = h[4 * (j / 4) + j % 4]! := decVal_pkEncode n h hmod (j / 4) hbk (j % 4) hsk
+      _ = h[j]! := by rw [← hj4]
+  congr 1
+  apply Vector.ext
+  intro k hk
+  rw [Vector.getElem_ofFn, hRcoeff k hk, getElem!_pos h k hk]
+  rfl
 
 end Falcon.Concrete


### PR DESCRIPTION
The codec/kernel slice of #471, extracted per its review: the standalone executable Falcon verifier is proved to agree with the abstract verifier with no side conditions beyond the degree. Based on current `main`; independent of #466/#478/#514.

## What is proved

`Falcon.Concrete.FPRBridge.concrete_verify_eq_verify` (already on `main`) relates `concreteVerify` to `Falcon.verify` under four hypotheses: the signature codec round-trips, the public-key codec round-trips, and the two fast arithmetic kernels agree with their specification-level counterparts. This PR discharges all four.

**Codec round-trips** (`LatticeCrypto/Falcon/Concrete/Encoding.lean`):

- `sigDecode_sigEncode`: decoding an encoded signature with a nonempty payload recovers the salt and the compressed bytes (the empty payload is rejected by the 42-byte guard, `sigDecode_sigEncode_nil` from #501).
- `publicKeyBytes_extract`: stripping the one-byte header from `publicKeyBytes` gives `pkEncode`.
- `pkDecode_pkEncode`: for `4 ∣ n`, decoding the packed 14-bit encoding recovers the polynomial. The proof reconstructs the encoder as a fold of seven-byte groups, certifies the per-group bit-packing identity, and runs the decoder loop against an invariant that the in-range check never fires on `ZMod.val` inputs.

`pkEncode` and `pkDecode` are restated as `for b in [0:n/4]` loops with `i := 4 * b` (and `j := 7 * b`) in place of the `while` loops with mutable counters. Same bytes for every `4 ∣ n` (the encoder panics and the decoder returns `none` otherwise, as before); the change only makes the loop a `List.range'` fold that the proofs can induct on.

**Kernel correctness** (`Extern/Falcon/Instance.lean`):

- `negacyclicMulU32_eq_negacyclicMul`: the `UInt32` negacyclic multiplier equals `negacyclicMul` at every degree. Each output cell is shown to stay in `[0, q)` and to accumulate the `ZMod` sum of `±fᵢ·gⱼ` over the anti-diagonal, which is `negacyclicConvCoeff`.
- `pairL2NormSqU32_eq_pairL2NormSq`: the `Int64`/`UInt64` squared norm equals `pairL2NormSq` under `2 · n · (q/2)² < 2⁶⁴`, the no-overflow bound for the accumulator. The centering branch is shown to compute `centeredRepr`, and every prefix sum is bounded so `UInt64` addition commutes with `toNat`.

**The bridge, discharged** (`Extern/Falcon/VerifyBridge.lean`, new): `concrete_verify_eq_verify_of_dvd` takes only `4 ∣ n` and the overflow bound; `concrete_verify_eq_verify_of_logn` takes `2 ≤ logn ≤ 10` and derives both. `FPRBridge.lean` itself is untouched, so this does not conflict with #514.

## Not in this slice

The `SamplerQuality`/`HasUniformSamplerLoss` bundle, the duplicated GPV framework files, the `verify_sign_correct` argument (blocked on the `s₁` redefinition), the collision-to-SIS algebra (in #466's `SISBridge.lean`), and the keygen/NTRU material stay out, per the split. Nothing here is a faithfulness claim against a c-fn-dsa revision: both sides of every equation are this repository's own definitions.

## Checks

All new declarations depend only on `propext`, `Classical.choice`, `Quot.sound` (the one `decide +kernel` is kernel evaluation, not `native_decide`). Every touched file passes `-Dweak.linter.mathlibStandardSet=true` with no warnings; PMF boundary, Extern isolation, and Interop isolation checks pass; full build of all libraries and `LatticeCryptoTest` clean; `lake exe axiomsweep --check` passes.
