### PR TITLE
feat(Falcon): define the fuel-bounded signer and prove verification correctness

### DIFF
--- a/Extern.lean
+++ b/Extern.lean
@@ -9,6 +9,7 @@ public import Extern.Falcon.KeyGen
 public import Extern.Falcon.SamplerZ
 public import Extern.Falcon.Sampling
 public import Extern.Falcon.Sign
+public import Extern.Falcon.SignCorrectness
 public import Extern.Hashing
 public import Extern.MLDSA.FFI
 public import Extern.MLDSA.Instance

--- a/Extern/Falcon/SignCorrectness.lean
+++ b/Extern/Falcon/SignCorrectness.lean
@@ -9,6 +9,7 @@ import all Extern.Falcon.Instance
 import all Extern.Falcon.FPRBridge
 public import Extern.Falcon.FPRBridge
 public import LatticeCrypto.Falcon.Security
+public import LatticeCrypto.Falcon.Coset
 
 /-!
 # Verification correctness at the concrete Falcon primitives
@@ -17,7 +18,9 @@ public import LatticeCrypto.Falcon.Security
 trapdoor sampler lands on the coset. At `Falcon.Concrete.FPRBridge.verifyPrimitives` and
 `Falcon.Concrete.concretePrimitives` the codec is the concrete Golomb-Rice codec, whose round-trip
 `Falcon.Concrete.decompress_compress` is a theorem, so only the coset condition `hpreimage`
-remains: the lattice-point obligation of the floating-point inverse FFT.
+remains. `Falcon.hpreimage_of_landsOnLattice` reduces that condition further, to the
+lattice-point condition `Falcon.LandsOnLattice` on the fixed-point FFT pipeline together with
+the key relations; the `_of_landsOnLattice` variants below take only those.
 -/
 
 public section
@@ -51,6 +54,42 @@ theorem verify_sign_correct_concretePrimitives
     verify p (concretePrimitives p hn) pk msg sig = true :=
   verify_sign_correct p (concretePrimitives p hn) pk sk msg maxAttempts sig
     (fun s slen bytes h => decompress_compress p.n s slen bytes h) hpreimage hsig
+
+/-- Verification correctness at the concrete primitives bundle from key validity, invertibility
+of `f` modulo `q`, and the lattice-point condition on the fixed-point FFT pipeline. -/
+theorem verify_sign_correct_concretePrimitives_of_landsOnLattice
+    (p : Params) (hn : p.n = 2 ^ p.logn) (pk : PublicKey p) (sk : SecretKey p)
+    (hvalid : validKeyPair p pk sk = true)
+    (hunit : ∃ u : Rq p.n, negacyclicMul (IntPoly.toRq sk.f) u = 1)
+    (hz : ∀ c : Rq p.n, ∀ z ∈ support (Primitives.ffSampling (concretePrimitives p hn)
+      p.fftDepth (toFFTTarget p (concretePrimitives p hn) c sk) sk.tree),
+      LandsOnLattice p (concretePrimitives p hn) sk z)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hsig : some sig ∈ support (sign p (concretePrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (concretePrimitives p hn) pk msg sig = true := by
+  have hpos : 0 < p.n := by rw [hn]; positivity
+  have hkey := (validKeyPair_eq_true_iff p pk sk).mp hvalid |>.2
+  exact verify_sign_correct_concretePrimitives p hn pk sk msg maxAttempts sig
+    (hpreimage_of_landsOnLattice p (concretePrimitives p hn) hpos pk sk hkey
+      (capRelation_of_validKeyPair p hpos pk sk hvalid hunit) hz) hsig
+
+/-- The same at the FPR-backed verification primitives. -/
+theorem verify_sign_correct_verifyPrimitives_of_landsOnLattice
+    (p : Params) (hn : p.n = 2 ^ p.logn) (pk : PublicKey p) (sk : SecretKey p)
+    (hvalid : validKeyPair p pk sk = true)
+    (hunit : ∃ u : Rq p.n, negacyclicMul (IntPoly.toRq sk.f) u = 1)
+    (hz : ∀ c : Rq p.n, ∀ z ∈ support (Primitives.ffSampling (FPRBridge.verifyPrimitives p hn)
+      p.fftDepth (toFFTTarget p (FPRBridge.verifyPrimitives p hn) c sk) sk.tree),
+      LandsOnLattice p (FPRBridge.verifyPrimitives p hn) sk z)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hsig : some sig ∈ support
+      (sign p (FPRBridge.verifyPrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (FPRBridge.verifyPrimitives p hn) pk msg sig = true := by
+  have hpos : 0 < p.n := by rw [hn]; positivity
+  have hkey := (validKeyPair_eq_true_iff p pk sk).mp hvalid |>.2
+  exact verify_sign_correct_verifyPrimitives p hn pk sk msg maxAttempts sig
+    (hpreimage_of_landsOnLattice p (FPRBridge.verifyPrimitives p hn) hpos pk sk hkey
+      (capRelation_of_validKeyPair p hpos pk sk hvalid hunit) hz) hsig
 
 end Falcon.Concrete
 

--- a/Extern/Falcon/SignCorrectness.lean
+++ b/Extern/Falcon/SignCorrectness.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oleksandr Vovkotrub
+-/
+
+module
+import all Extern.Falcon.Instance
+import all Extern.Falcon.FPRBridge
+public import Extern.Falcon.FPRBridge
+public import LatticeCrypto.Falcon.Security
+
+/-!
+# Verification correctness at the concrete Falcon primitives
+
+`Falcon.verify_sign_correct` takes two facts about the primitives: the codec round-trips and the
+trapdoor sampler lands on the coset. At `Falcon.Concrete.FPRBridge.verifyPrimitives` and
+`Falcon.Concrete.concretePrimitives` the codec is the concrete Golomb-Rice codec, whose round-trip
+`Falcon.Concrete.decompress_compress` is a theorem, so only the coset condition `hpreimage`
+remains: the lattice-point obligation of the floating-point inverse FFT.
+-/
+
+public section
+
+open OracleComp OracleSpec Falcon
+
+namespace Falcon.Concrete
+
+/-- Verification correctness at the FPR-backed verification primitives, given only that the
+trapdoor sampler lands on the coset. -/
+theorem verify_sign_correct_verifyPrimitives
+    (p : Params) (hn : p.n = 2 ^ p.logn) (pk : PublicKey p) (sk : SecretKey p)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hpreimage : ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p (FPRBridge.verifyPrimitives p hn)).trapdoorSample pk sk c) →
+        (falconPSF p (FPRBridge.verifyPrimitives p hn)).eval pk x = c)
+    (hsig : some sig ∈ support (sign p (FPRBridge.verifyPrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (FPRBridge.verifyPrimitives p hn) pk msg sig = true :=
+  verify_sign_correct p (FPRBridge.verifyPrimitives p hn) pk sk msg maxAttempts sig
+    (fun s slen bytes h => decompress_compress p.n s slen bytes h) hpreimage hsig
+
+/-- Verification correctness at the concrete primitives bundle, given only that the trapdoor
+sampler lands on the coset. -/
+theorem verify_sign_correct_concretePrimitives
+    (p : Params) (hn : p.n = 2 ^ p.logn) (pk : PublicKey p) (sk : SecretKey p)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hpreimage : ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p (concretePrimitives p hn)).trapdoorSample pk sk c) →
+        (falconPSF p (concretePrimitives p hn)).eval pk x = c)
+    (hsig : some sig ∈ support (sign p (concretePrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (concretePrimitives p hn) pk msg sig = true :=
+  verify_sign_correct p (concretePrimitives p hn) pk sk msg maxAttempts sig
+    (fun s slen bytes h => decompress_compress p.n s slen bytes h) hpreimage hsig
+
+end Falcon.Concrete
+
+end

--- a/LatticeCrypto.lean
+++ b/LatticeCrypto.lean
@@ -12,6 +12,7 @@ public import LatticeCrypto.Falcon.Concrete.NTRUSolver
 public import LatticeCrypto.Falcon.Concrete.NTT
 public import LatticeCrypto.Falcon.Concrete.PolyBigInt
 public import LatticeCrypto.Falcon.Concrete.SmallPrimeNTT
+public import LatticeCrypto.Falcon.Coset
 public import LatticeCrypto.Falcon.Encoding
 public import LatticeCrypto.Falcon.Params
 public import LatticeCrypto.Falcon.Primitives

--- a/LatticeCrypto/Falcon/Concrete/Encoding.lean
+++ b/LatticeCrypto/Falcon/Concrete/Encoding.lean
@@ -42,85 +42,291 @@ namespace Falcon.Concrete
 
 open Falcon
 
-/-! ## Signature compression -/
+/-! ## Signature compression
 
-/-- Compress a Falcon signature polynomial into at most `dlen` bytes. -/
-def compress (n : ℕ) (s : IntPoly n) (dlen : ℕ) : Option (List UInt8) := Id.run do
-  let mut acc : UInt32 := 0
-  let mut accLen : UInt32 := 0
-  let mut out : Array UInt8 := #[]
-  for i in [0:n] do
-    let x : Int := s[i]!
-    if x < -2047 || x > 2047 then
-      return none
-    let sw : UInt32 := if x < 0 then 0xFFFFFFFF else 0
-    let w : UInt32 := x.natAbs.toUInt32
-    acc := (acc <<< 8) ||| ((sw &&& 0x80) ||| (w &&& 0x7F))
-    accLen := accLen + 8
-    let wh := (w >>> 7).toNat + 1
-    acc := (acc <<< wh.toUInt32) ||| 1
-    accLen := accLen + wh.toUInt32
-    while accLen ≥ 8 do
-      accLen := accLen - 8
-      if out.size ≥ dlen then
-        return none
-      out := out.push (acc >>> accLen).toUInt8
-  if accLen > 0 then
-    if out.size ≥ dlen then
-      return none
-    out := out.push (acc <<< (8 - accLen)).toUInt8
-  while out.size < dlen do
-    out := out.push 0
-  return some out.toList
+Falcon stores the signature polynomial `s₂` with the Golomb-Rice style code of the specification
+(Algorithms 17–18): a coefficient `x` with `|x| ≤ 2047` becomes a sign bit, the seven low bits of
+`|x|` (most significant first), `|x| / 128` zero bits, and a terminating one bit. The bits of all
+coefficients are packed most significant first and the output is zero-padded to exactly `dlen`
+bytes; the decoder accepts exactly that length and only zero padding. Both directions are written
+over the bit stream, which is what the round-trip theorem `decompress_compress` reasons about. -/
+
+/-- The `k`-bit big-endian representation of `v` (bits `k-1` down to `0`). -/
+def natBits : ℕ → ℕ → List Bool
+  | 0, _ => []
+  | k + 1, v => v.testBit k :: natBits k v
+
+/-- The number whose big-endian bits are `bits`. -/
+def natOfBits : List Bool → ℕ
+  | [] => 0
+  | b :: bs => (if b then 2 ^ bs.length else 0) + natOfBits bs
+
+/-- The bits of a byte, most significant first. -/
+def byteBits (b : UInt8) : List Bool := natBits 8 b.toNat
+
+/-- The bit stream of a byte string, most significant bit of each byte first. -/
+def bytesToBits (d : List UInt8) : List Bool := d.flatMap byteBits
+
+/-- Pack a bit stream into bytes, most significant bit first; the last byte is zero-padded. -/
+def bitsToBytes (bits : List Bool) : List UInt8 :=
+  if bits.isEmpty then []
+  else
+    (natOfBits (bits.take 8 ++ List.replicate (8 - (bits.take 8).length) false)).toUInt8 ::
+      bitsToBytes (bits.drop 8)
+termination_by bits.length
+decreasing_by
+  simp only [List.length_drop]
+  have : bits.length ≠ 0 := by simpa [List.isEmpty_iff_length_eq_zero] using ‹¬bits.isEmpty›
+  omega
+
+/-- The code of one coefficient: sign, seven low bits of `|x|`, `|x| / 128` zeros, a one. -/
+def coeffBits (x : ℤ) : List Bool :=
+  decide (x < 0) :: (natBits 7 (x.natAbs % 128) ++ List.replicate (x.natAbs / 128) false ++ [true])
+
+/-- Compress a Falcon signature polynomial into exactly `dlen` bytes, or `none` when a
+coefficient is out of range or the code does not fit. -/
+def compress (n : ℕ) (s : IntPoly n) (dlen : ℕ) : Option (List UInt8) :=
+  if ∀ i : Fin n, -2047 ≤ s.get i ∧ s.get i ≤ 2047 then
+    let bits := (List.finRange n).flatMap fun i => coeffBits (s.get i)
+    if 8 * dlen < bits.length then none
+    else some (bitsToBytes bits ++ List.replicate (dlen - (bitsToBytes bits).length) 0)
+  else none
+
+/-- Read the unary part of a coefficient code: each zero adds `128` to the magnitude `m`, a one
+terminates. Fails past `2047`, on the negative zero `-0`, and at the end of the stream. -/
+def parseUnary (t : Bool) : ℕ → List Bool → Option (ℤ × List Bool)
+  | m, true :: rest => if m = 0 ∧ t then none else some (if t then -(m : ℤ) else (m : ℤ), rest)
+  | m, false :: rest => if 2047 < m + 128 then none else parseUnary t (m + 128) rest
+  | _, [] => none
+
+/-- Read one coefficient code from the bit stream. -/
+def parseCoeff : List Bool → Option (ℤ × List Bool)
+  | t :: rest =>
+    if 7 ≤ rest.length then parseUnary t (natOfBits (rest.take 7)) (rest.drop 7) else none
+  | [] => none
+
+/-- Read `k` coefficient codes from the bit stream. -/
+def parseCoeffs : ℕ → List Bool → Option (List ℤ × List Bool)
+  | 0, bits => some ([], bits)
+  | k + 1, bits => do
+    let (x, rest) ← parseCoeff bits
+    let (xs, rest') ← parseCoeffs k rest
+    pure (x :: xs, rest')
 
 /-- Decompress a fixed-length Falcon signature polynomial.
 
 `compress` pads every successful output to exactly `dlen` bytes. Accordingly, this decoder
-accepts exactly that length; the optional unpadded Falcon representation is outside its format. -/
-def decompress (n : ℕ) (d : List UInt8) (dlen : ℕ) : Option (IntPoly n) := Id.run do
-  if d.length ≠ dlen then return none
-  let bytes := d.toArray
-  let mut acc : UInt32 := 0
-  let mut accLen : UInt32 := 0
-  let mut j := 0
-  let mut result : Array ℤ := Array.replicate n 0
-  for i in [0:n] do
-    if j ≥ dlen then return none
-    acc := (acc <<< 8) ||| bytes[j]!.toUInt32
-    j := j + 1
-    let full := acc >>> accLen
-    let t := (full >>> 7) &&& 1
-    let mut m : UInt32 := full &&& 0x7F
-    let mut done := false
-    while !done do
-      if accLen == 0 then
-        if j ≥ dlen then return none
-        acc := (acc <<< 8) ||| bytes[j]!.toUInt32
-        j := j + 1
-        accLen := 8
-      accLen := accLen - 1
-      if ((acc >>> accLen) &&& 1) != 0 then
-        done := true
-      else
-        m := m + 0x80
-        if m > 2047 then return none
-    if m == 0 && t != 0 then return none
-    let val : UInt32 := (m ^^^ (0 - t)) + t
-    let signedVal : ℤ :=
-      if val &&& 0x80000000 != 0 then -(((~~~val) + 1).toNat : ℤ)
-      else (val.toNat : ℤ)
-    result := result.set! i signedVal
-  if accLen > 0 then
-    if (acc &&& ((1 <<< accLen) - 1)) != 0 then
-      return none
-  while j < dlen do
-    if bytes[j]! != 0 then return none
-    j := j + 1
-  return some (Vector.ofFn fun ⟨i, _⟩ => result.getD i 0)
+accepts exactly that length and rejects any nonzero padding; the optional unpadded Falcon
+representation is outside its format. -/
+def decompress (n : ℕ) (d : List UInt8) (dlen : ℕ) : Option (IntPoly n) :=
+  if d.length ≠ dlen then none
+  else
+    match parseCoeffs n (bytesToBits d) with
+    | none => none
+    | some (vals, rest) =>
+      if rest.all (fun b => !b) then some (Vector.ofFn fun i => vals.getD i.val 0) else none
 
 @[simp] theorem decompress_eq_none_of_length_ne (n d dlen) (h : d.length ≠ dlen) :
     decompress n d dlen = none := by
   simp [decompress, h]
+
+/-! ### Bit-level lemmas -/
+
+theorem natBits_length (k v : ℕ) : (natBits k v).length = k := by
+  induction k generalizing v with
+  | zero => rfl
+  | succ k ih => simp [natBits, ih]
+
+theorem natOfBits_lt (bs : List Bool) : natOfBits bs < 2 ^ bs.length := by
+  induction bs with
+  | nil => simp [natOfBits]
+  | cons b bs ih =>
+    simp only [natOfBits, List.length_cons, pow_succ]
+    split <;> omega
+
+/-- `natBits k` reads only the low `k` bits. -/
+theorem natBits_congr {k v w : ℕ} (h : ∀ j, j < k → v.testBit j = w.testBit j) :
+    natBits k v = natBits k w := by
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+    simp only [natBits, h k (Nat.lt_succ_self k)]
+    congr 1
+    exact ih fun j hj => h j (Nat.lt_succ_of_lt hj)
+
+theorem natBits_natOfBits (bs : List Bool) : natBits bs.length (natOfBits bs) = bs := by
+  induction bs with
+  | nil => rfl
+  | cons b bs ih =>
+    have hlt := natOfBits_lt bs
+    have hval : natOfBits (b :: bs) = 2 ^ bs.length * (if b then 1 else 0) + natOfBits bs := by
+      simp only [natOfBits]; split <;> simp
+    simp only [List.length_cons, natBits, hval]
+    rw [List.cons.injEq]
+    refine ⟨?_, ?_⟩
+    · rw [Nat.testBit_two_pow_mul_add _ hlt]
+      simp
+      cases b <;> simp
+    · refine (natBits_congr fun j hj => ?_).trans ih
+      rw [Nat.testBit_two_pow_mul_add _ hlt, if_pos hj]
+
+theorem natOfBits_natBits {k v : ℕ} (h : v < 2 ^ k) : natOfBits (natBits k v) = v := by
+  induction k generalizing v with
+  | zero => simp [natBits, natOfBits]; omega
+  | succ k ih =>
+    have hmod : natBits k v = natBits k (v % 2 ^ k) :=
+      natBits_congr fun j hj => by rw [Nat.testBit_mod_two_pow]; simp [hj]
+    simp only [natBits, natOfBits, natBits_length, hmod, ih (Nat.mod_lt _ (by positivity))]
+    rw [Nat.testBit_eq_decide_div_mod_eq]
+    have hdiv : v / 2 ^ k < 2 := by
+      rw [Nat.div_lt_iff_lt_mul (by positivity)]; rw [pow_succ] at h; omega
+    have := Nat.div_add_mod v (2 ^ k)
+    have hcases : v / 2 ^ k = 0 ∨ v / 2 ^ k = 1 :=
+      Nat.le_one_iff_eq_zero_or_eq_one.mp (Nat.lt_succ_iff.mp hdiv)
+    rcases hcases with h0 | h0 <;> simp [h0] at this ⊢ <;> omega
+
+theorem byteBits_toUInt8 (bs : List Bool) (h : bs.length = 8) :
+    byteBits (natOfBits bs).toUInt8 = bs := by
+  have hlt : natOfBits bs < 256 := by have := natOfBits_lt bs; rw [h] at this; exact this
+  have : (natOfBits bs).toUInt8.toNat = natOfBits bs := by
+    change (UInt8.ofNat _).toNat = _
+    rw [UInt8.toNat_ofNat']; exact Nat.mod_eq_of_lt hlt
+  rw [byteBits, this, ← h, natBits_natOfBits]
+
+theorem bytesToBits_append (a b : List UInt8) :
+    bytesToBits (a ++ b) = bytesToBits a ++ bytesToBits b := by
+  simp [bytesToBits, List.flatMap_append]
+
+theorem bytesToBits_replicate_zero (k : ℕ) :
+    bytesToBits (List.replicate k 0) = List.replicate (8 * k) false := by
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+    rw [List.replicate_succ, bytesToBits, List.flatMap_cons, ← bytesToBits, ih,
+      show byteBits 0 = List.replicate 8 false from rfl, List.replicate_append_replicate]
+    congr 1
+    omega
+
+theorem bytesToBits_bitsToBytes (bits : List Bool) :
+    bytesToBits (bitsToBytes bits) =
+      bits ++ List.replicate ((8 - bits.length % 8) % 8) false := by
+  fun_induction bitsToBytes bits with
+  | case1 bits hempty =>
+    rw [List.isEmpty_iff] at hempty
+    subst hempty
+    rfl
+  | case2 bits hempty ih =>
+    rw [bytesToBits, List.flatMap_cons, ← bytesToBits, ih,
+      byteBits_toUInt8 _ (by simp [List.length_take])]
+    have hne : bits.length ≠ 0 := by simpa [List.isEmpty_iff_length_eq_zero] using hempty
+    rcases Nat.lt_or_ge bits.length 8 with hlt | hge
+    · rw [List.drop_of_length_le (by omega), List.take_of_length_le (by omega)]
+      simp only [List.length_nil, Nat.zero_mod, Nat.sub_zero, Nat.mod_self, List.replicate_zero,
+        List.append_nil]
+      congr 2
+      rw [Nat.mod_eq_of_lt hlt, Nat.mod_eq_of_lt (by omega)]
+    · rw [List.length_take, min_eq_left hge, Nat.sub_self, List.replicate_zero, List.append_nil,
+        ← List.append_assoc, List.take_append_drop, List.length_drop]
+      congr 3
+      omega
+
+theorem bitsToBytes_length (bits : List Bool) :
+    (bitsToBytes bits).length = (bits.length + 7) / 8 := by
+  fun_induction bitsToBytes bits with
+  | case1 bits hempty =>
+    rw [List.isEmpty_iff] at hempty
+    subst hempty
+    rfl
+  | case2 bits hempty ih =>
+    rw [List.length_cons, ih, List.length_drop]
+    have hne : bits.length ≠ 0 := by simpa [List.isEmpty_iff_length_eq_zero] using hempty
+    omega
+
+/-! ### Coefficient-level lemmas -/
+
+theorem parseUnary_replicate (t : Bool) (m q : ℕ) (rest : List Bool)
+    (hle : m + 128 * q ≤ 2047) (hz : ¬ (m + 128 * q = 0 ∧ t = true)) :
+    parseUnary t m (List.replicate q false ++ true :: rest) =
+      some (if t then -((m + 128 * q : ℕ) : ℤ) else ((m + 128 * q : ℕ) : ℤ), rest) := by
+  induction q generalizing m with
+  | zero =>
+    simp only [List.replicate_zero, List.nil_append, parseUnary, Nat.mul_zero, Nat.add_zero] at *
+    rw [if_neg hz]
+  | succ q ih =>
+    rw [List.replicate_succ, List.cons_append, parseUnary, if_neg (by omega)]
+    rw [ih (m + 128) (by omega) (by omega), show m + 128 + 128 * q = m + 128 * (q + 1) by ring]
+
+theorem parseCoeff_coeffBits (x : ℤ) (hx : -2047 ≤ x ∧ x ≤ 2047) (rest : List Bool) :
+    parseCoeff (coeffBits x ++ rest) = some (x, rest) := by
+  have habs : x.natAbs ≤ 2047 := by omega
+  simp only [coeffBits, List.cons_append, parseCoeff, List.append_assoc]
+  rw [if_pos (by simp [natBits_length]), List.take_append_of_le_length (by simp [natBits_length]),
+    List.take_of_length_le (by simp [natBits_length]),
+    List.drop_append_of_le_length (by simp [natBits_length]),
+    List.drop_of_length_le (by simp [natBits_length]), List.nil_append,
+    natOfBits_natBits (k := 7)
+      (by have := Nat.mod_lt x.natAbs (by norm_num : 0 < 128); simpa using this),
+    List.nil_append,
+    parseUnary_replicate _ _ _ _ (by rw [Nat.mod_add_div]; exact habs)]
+  · rw [Nat.mod_add_div]
+    congr 2
+    split_ifs with hneg <;> simp only [decide_eq_true_eq] at hneg <;> omega
+  · rw [Nat.mod_add_div]
+    rintro ⟨h0, ht⟩
+    have : x < 0 := by simpa using ht
+    omega
+
+theorem parseCoeffs_flatMap (xs : List ℤ) (hxs : ∀ x ∈ xs, -2047 ≤ x ∧ x ≤ 2047)
+    (tail : List Bool) :
+    parseCoeffs xs.length (xs.flatMap coeffBits ++ tail) = some (xs, tail) := by
+  induction xs with
+  | nil => rfl
+  | cons x xs ih =>
+    simp [List.flatMap_cons, parseCoeffs, parseCoeff_coeffBits x (hxs x (List.mem_cons_self ..)),
+      ih (fun y hy => hxs y (List.mem_cons_of_mem _ hy))]
+
+/-! ### The round-trip -/
+
+/-- **Decompression inverts compression**: every byte string `compress` produces decodes back to
+the polynomial it came from. This is the `compress_decompress` law of `Primitives.Laws` for the
+concrete codec. -/
+theorem decompress_compress (n : ℕ) (s : IntPoly n) (dlen : ℕ) (d : List UInt8)
+    (h : compress n s dlen = some d) : decompress n d dlen = some s := by
+  unfold compress at h
+  dsimp only at h
+  split_ifs at h with hbound hfit
+  rw [Option.some.injEq] at h
+  subst h
+  set bits := (List.finRange n).flatMap fun i => coeffBits (s.get i) with hbits
+  set L := bits.length with hL
+  set NB := (bitsToBytes bits).length with hNB
+  have hnb : NB ≤ dlen := by
+    rw [hNB, bitsToBytes_length]; omega
+  have hlen : (bitsToBytes bits ++ List.replicate (dlen - NB) 0).length = dlen := by
+    simp only [List.length_append, List.length_replicate, ← hNB]; omega
+  set T := List.replicate ((8 - L % 8) % 8) false ++ List.replicate (8 * (dlen - NB)) false
+    with hT
+  have hstream : bytesToBits (bitsToBytes bits ++ List.replicate (dlen - NB) 0) = bits ++ T := by
+    rw [bytesToBits_append, bytesToBits_bitsToBytes, bytesToBits_replicate_zero, List.append_assoc]
+  set xs := (List.finRange n).map fun i => s.get i with hxsdef
+  have hxs : bits = xs.flatMap coeffBits := by
+    rw [hbits, hxsdef, List.flatMap_map]
+  have hparse : parseCoeffs n (xs.flatMap coeffBits ++ T) = some (xs, T) := by
+    have h := parseCoeffs_flatMap xs
+      (fun x hx => by
+        obtain ⟨i, -, rfl⟩ := List.mem_map.mp hx
+        exact hbound i) T
+    rwa [hxsdef, List.length_map, List.length_finRange, ← hxsdef] at h
+  unfold decompress
+  rw [if_neg (by rw [hlen]; exact fun h => h rfl), hstream, hxs, hparse]
+  dsimp only
+  rw [if_pos (by simp [hT, List.all_replicate])]
+  congr 1
+  apply LatticeCrypto.Poly.ext_get_eq
+  intro i
+  rw [Vector.get_ofFn, List.getD_eq_getElem?_getD, hxsdef, List.getElem?_map,
+    List.getElem?_eq_getElem (by simp [List.length_finRange]), Option.map_some, Option.getD_some]
+  simp [List.getElem_finRange]
 
 /-! ## Public key encoding (14 bits per coefficient) -/
 

--- a/LatticeCrypto/Falcon/Coset.lean
+++ b/LatticeCrypto/Falcon/Coset.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oleksandr Vovkotrub
+-/
+
+module
+public import LatticeCrypto.Falcon.Scheme
+
+/-!
+# The coset condition of Falcon's trapdoor sampler
+
+`Falcon.verify_sign_correct` and the GPV correctness law `CorrectAt` ask that every output
+`(s₁, s₂)` of the trapdoor sampler at target `c` satisfy `s₁ + s₂ · h = c`. This file reduces
+that condition to a statement about the primitives alone. `fromFFTPreimage` multiplies the
+sampler's FFT-domain output by the FFT of the secret basis, inverse-transforms, and rounds;
+`LandsOnLattice` says the rounded result is an integer lattice point `z · B`. Given that and
+the key relations `f · h = g` and `F · h = G`, the coset identity is ring algebra in `R_q`,
+carried out in the semantic quotient `ℤ_q[X]/(X^n + 1)` through the soundness certificate
+`coeffSemantics` (`eval_fromFFTPreimage_of_landsOnLattice`, `hpreimage_of_landsOnLattice`).
+
+`F · h = G` follows from the NTRU equation and `f · h = g` once `f` is invertible modulo `q`
+(`capRelation_of_validKeyPair`), which Falcon's key generation guarantees and which is what
+makes `h = g · f⁻¹` exist in the first place.
+
+What remains for the concrete primitives is `LandsOnLattice` itself: that the fixed-point FFT
+pipeline `fftInt`/`ifftRound` rounds to the exact lattice point, a deterministic rounding-error
+bound on those two primitives.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec LatticeCrypto
+
+namespace Falcon
+
+/-! ## Coefficients in `R_q` and reduction modulo `q` -/
+
+theorem Rq.get_add {n : ℕ} (a b : Rq n) (i : Fin n) : (a + b).get i = a.get i + b.get i :=
+  NegacyclicRing.coeff_add (coeffRing n) a b i
+
+theorem Rq.get_sub {n : ℕ} (a b : Rq n) (i : Fin n) : (a - b).get i = a.get i - b.get i :=
+  NegacyclicRing.coeff_sub (coeffRing n) a b i
+
+theorem Rq.get_neg {n : ℕ} (a : Rq n) (i : Fin n) : (-a).get i = -a.get i :=
+  NegacyclicRing.coeff_neg (coeffRing n) a i
+
+theorem Rq.get_zero {n : ℕ} (i : Fin n) : (0 : Rq n).get i = 0 :=
+  NegacyclicRing.coeff_zero (coeffRing n) i
+
+theorem Rq.get_mul {n : ℕ} (a b : Rq n) (i : Fin n) :
+    (negacyclicMul a b).get i = negacyclicConvCoeff a.get b.get i :=
+  vectorKernel_mul_get a b i
+
+theorem IntPoly.get_mul {n : ℕ} (a b : IntPoly n) (i : Fin n) :
+    (intPolyMul a b).get i = negacyclicConvCoeff a.get b.get i :=
+  vectorKernel_mul_get a b i
+
+theorem toRq_add {n : ℕ} (a b : IntPoly n) :
+    IntPoly.toRq (a + b) = IntPoly.toRq a + IntPoly.toRq b := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, Poly.get_add, Rq.get_add, toRq_get, toRq_get]
+  push_cast
+  rfl
+
+theorem toRq_sub {n : ℕ} (a b : IntPoly n) :
+    IntPoly.toRq (a - b) = IntPoly.toRq a - IntPoly.toRq b := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, Poly.get_sub, Rq.get_sub, toRq_get, toRq_get]
+  push_cast
+  rfl
+
+theorem toRq_neg {n : ℕ} (a : IntPoly n) : IntPoly.toRq (-a) = -IntPoly.toRq a := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, Poly.get_neg, Rq.get_neg, toRq_get]
+  push_cast
+  rfl
+
+/-- Reduction modulo `q` turns the integer negacyclic product into the product in `R_q`. -/
+theorem toRq_mul {n : ℕ} (a b : IntPoly n) :
+    IntPoly.toRq (intPolyMul a b) = negacyclicMul (IntPoly.toRq a) (IntPoly.toRq b) := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, IntPoly.get_mul, Rq.get_mul]
+  simp only [negacyclicConvCoeff, toRq_get]
+  push_cast
+  rfl
+
+/-- The constant `q` reduces to zero modulo `q`. -/
+theorem toRq_const_modulus (n : ℕ) :
+    IntPoly.toRq (intPolyConst (modulus : ℤ) : IntPoly n) = 0 := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, Rq.get_zero]
+  simp [intPolyConst, integralLift, vectorIntegralLift, constPoly]
+
+/-! ## The semantic quotient -/
+
+section Quotient
+
+variable {n : ℕ} (hn : 0 < n)
+
+theorem quotientOf_add (a b : Rq n) :
+    (coeffSemantics hn).quotientOf (a + b) =
+      (coeffSemantics hn).quotientOf a + (coeffSemantics hn).quotientOf b :=
+  (coeffSemantics hn).add_sound a b
+
+theorem quotientOf_sub (a b : Rq n) :
+    (coeffSemantics hn).quotientOf (a - b) =
+      (coeffSemantics hn).quotientOf a - (coeffSemantics hn).quotientOf b :=
+  (coeffSemantics hn).sub_sound a b
+
+theorem quotientOf_neg (a : Rq n) :
+    (coeffSemantics hn).quotientOf (-a) = -(coeffSemantics hn).quotientOf a :=
+  (coeffSemantics hn).neg_sound a
+
+theorem quotientOf_mul (a b : Rq n) :
+    (coeffSemantics hn).quotientOf (negacyclicMul a b) =
+      (coeffSemantics hn).quotientOf a * (coeffSemantics hn).quotientOf b :=
+  (coeffSemantics hn).mul_sound a b
+
+theorem quotientOf_zero : (coeffSemantics hn).quotientOf (0 : Rq n) = 0 :=
+  (coeffSemantics hn).zero_sound
+
+theorem quotientOf_one : (coeffSemantics hn).quotientOf (1 : Rq n) = 1 :=
+  (coeffSemantics hn).one_sound
+
+theorem quotientOf_injective {a b : Rq n}
+    (h : (coeffSemantics hn).quotientOf a = (coeffSemantics hn).quotientOf b) : a = b :=
+  NegacyclicQuotient.ofBackend_injective (vectorBackend Coeff n) h
+
+end Quotient
+
+/-! ## The lattice-point condition and the coset identity -/
+
+variable (p : Params) (prims : Primitives p)
+
+/-- **The basis application lands on the lattice.** For the sampler's FFT-domain output `z`,
+the two rounded inverse transforms of `fromFFTPreimage` are the integer polynomials
+`z₀ · g + z₁ · G` and `-(z₀ · f + z₁ · F)` for some integer `(z₀, z₁)`: the lattice point
+`z · B` for the secret basis `B = [[g, -f], [G, -F]]`. -/
+def LandsOnLattice (sk : SecretKey p) (z : FFTPair p.fftDepth) : Prop :=
+  ∃ z₀ z₁ : IntPoly p.n,
+    prims.ifftRound (Primitives.mulFFT z.1 (prims.fftInt sk.g) +
+        Primitives.mulFFT z.2 (prims.fftInt sk.capG)) =
+      intPolyMul z₀ sk.g + intPolyMul z₁ sk.capG ∧
+    prims.ifftRound (-(Primitives.mulFFT z.1 (prims.fftInt sk.f) +
+        Primitives.mulFFT z.2 (prims.fftInt sk.capF))) =
+      -(intPolyMul z₀ sk.f + intPolyMul z₁ sk.capF)
+
+/-- **The coset identity.** On a lattice point, `fromFFTPreimage` returns a preimage of the
+target: `s₁ + s₂ · h = c` follows from `f · h = g` and `F · h = G` by ring algebra. -/
+theorem eval_fromFFTPreimage_of_landsOnLattice (hn : 0 < p.n) (pk : PublicKey p)
+    (sk : SecretKey p)
+    (hkey : negacyclicMul (IntPoly.toRq sk.f) pk.h = IntPoly.toRq sk.g)
+    (hcap : negacyclicMul (IntPoly.toRq sk.capF) pk.h = IntPoly.toRq sk.capG)
+    (c : Rq p.n) (z : FFTPair p.fftDepth) (hz : LandsOnLattice p prims sk z) :
+    (falconPSF p prims).eval pk (fromFFTPreimage p prims c sk z) = c := by
+  obtain ⟨z₀, z₁, h₀, h₁⟩ := hz
+  change (c - IntPoly.toRq (prims.ifftRound _)) +
+    negacyclicMul (-IntPoly.toRq (prims.ifftRound _)) pk.h = c
+  rw [h₀, h₁, toRq_add, toRq_neg, toRq_add, toRq_mul, toRq_mul, toRq_mul, toRq_mul]
+  apply quotientOf_injective hn
+  have hk := congrArg (coeffSemantics hn).quotientOf hkey
+  have hc := congrArg (coeffSemantics hn).quotientOf hcap
+  simp only [quotientOf_mul] at hk hc
+  simp only [quotientOf_add, quotientOf_sub, quotientOf_neg, quotientOf_mul]
+  linear_combination ((coeffSemantics hn).quotientOf (IntPoly.toRq z₀)) * hk +
+    ((coeffSemantics hn).quotientOf (IntPoly.toRq z₁)) * hc
+
+/-- **The coset condition from the lattice-point condition.** Every output of the trapdoor
+sampler is a preimage of its target once the basis application lands on the lattice for every
+sample. This is the `hpreimage` hypothesis of `verify_sign_correct` and the `eval` half of
+`CorrectAt`. -/
+theorem hpreimage_of_landsOnLattice (hn : 0 < p.n) (pk : PublicKey p) (sk : SecretKey p)
+    (hkey : negacyclicMul (IntPoly.toRq sk.f) pk.h = IntPoly.toRq sk.g)
+    (hcap : negacyclicMul (IntPoly.toRq sk.capF) pk.h = IntPoly.toRq sk.capG)
+    (hz : ∀ c : Rq p.n, ∀ z ∈ support
+      (Primitives.ffSampling prims p.fftDepth (toFFTTarget p prims c sk) sk.tree),
+      LandsOnLattice p prims sk z) :
+    ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p prims).trapdoorSample pk sk c) →
+        (falconPSF p prims).eval pk x = c := by
+  intro c x hx
+  change x ∈ support (do
+    let z ← Primitives.ffSampling prims p.fftDepth (toFFTTarget p prims c sk) sk.tree
+    return fromFFTPreimage p prims c sk z) at hx
+  rw [mem_support_bind_iff] at hx
+  obtain ⟨z, hzmem, hx⟩ := hx
+  rw [support_pure, Set.mem_singleton_iff] at hx
+  subst hx
+  exact eval_fromFFTPreimage_of_landsOnLattice p prims hn pk sk hkey hcap c z (hz c z hzmem)
+
+/-- **`F · h = G` on a valid key with `f` invertible modulo `q`.** From the NTRU equation
+`f · G − g · F = q` reduced modulo `q` and `f · h = g`, cancelling `f`. -/
+theorem capRelation_of_validKeyPair (hn : 0 < p.n) (pk : PublicKey p) (sk : SecretKey p)
+    (hvalid : validKeyPair p pk sk = true)
+    (hunit : ∃ u : Rq p.n, negacyclicMul (IntPoly.toRq sk.f) u = 1) :
+    negacyclicMul (IntPoly.toRq sk.capF) pk.h = IntPoly.toRq sk.capG := by
+  rw [validKeyPair_eq_true_iff] at hvalid
+  obtain ⟨hntru, hkey⟩ := hvalid
+  obtain ⟨u, hu⟩ := hunit
+  have hq : IntPoly.toRq (intPolyMul sk.f sk.capG - intPolyMul sk.g sk.capF) =
+      IntPoly.toRq (intPolyConst (modulus : ℤ)) := by
+    unfold ntruEquation at hntru
+    rw [hntru]
+  rw [toRq_sub, toRq_mul, toRq_mul, toRq_const_modulus] at hq
+  apply quotientOf_injective hn
+  have hq' := congrArg (coeffSemantics hn).quotientOf hq
+  have hk := congrArg (coeffSemantics hn).quotientOf hkey
+  have hu' := congrArg (coeffSemantics hn).quotientOf hu
+  simp only [quotientOf_sub, quotientOf_mul, quotientOf_zero, quotientOf_one] at hq' hk hu'
+  rw [quotientOf_mul]
+  set Q := (coeffSemantics hn).quotientOf with hQ
+  linear_combination (-(Q u)) * hq' + (Q u * Q (IntPoly.toRq sk.capF)) * hk +
+    (Q (IntPoly.toRq sk.capG) - Q (IntPoly.toRq sk.capF) * Q pk.h) * hu'
+
+end Falcon
+
+end

--- a/LatticeCrypto/Falcon/Coset.lean
+++ b/LatticeCrypto/Falcon/Coset.lean
@@ -28,7 +28,7 @@ pipeline `fftInt`/`ifftRound` rounds to the exact lattice point, a deterministic
 bound on those two primitives.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec LatticeCrypto
 

--- a/LatticeCrypto/Falcon/Scheme.lean
+++ b/LatticeCrypto/Falcon/Scheme.lean
@@ -214,19 +214,54 @@ noncomputable def signAttempt (pk : PublicKey p) (sk : SecretKey p) (c : Rq p.n)
   else
     return none
 
-/-- Falcon signing (Falcon+, Algorithm 10).
+/-- The centered integer lift of an element of `R_q`: coefficientwise the representative in
+`(-q/2, q/2]`. This is the polynomial the signer hands to `compress`. -/
+noncomputable def rqToIntPolyCentered {n : ℕ} (f : Rq n) : IntPoly n :=
+  LatticeCrypto.Poly.ofPi fun i => LatticeCrypto.centeredRepr (f.get i)
 
-On each attempt:
+/-- The coefficients of the reduction of an integer polynomial modulo `q`. -/
+theorem toRq_get {n : ℕ} (a : IntPoly n) (i : Fin n) :
+    (IntPoly.toRq a : Rq n).get i = ((a.get i : ℤ) : Coeff) := by
+  simp [IntPoly.toRq, integralLift, LatticeCrypto.vectorIntegralLift,
+    LatticeCrypto.PolyBackend.mapCoeffs, LatticeCrypto.vectorBackend]
+
+/-- Reducing the centered integer lift modulo `q` recovers the original element. -/
+theorem toRq_rqToIntPolyCentered {n : ℕ} (f : Rq n) :
+    IntPoly.toRq (rqToIntPolyCentered f) = f := by
+  apply LatticeCrypto.Poly.ext_get_eq
+  intro i
+  rw [toRq_get, rqToIntPolyCentered, LatticeCrypto.Poly.get_ofPi]
+  exact (LatticeCrypto.centeredRepr_intCast (f.get i)).symm
+
+/-- Falcon signing (Falcon+, Algorithm 10), as a fuel-bounded rejection loop.
+
+On each of up to `maxAttempts` attempts:
 1. Sample a fresh 40-byte salt `r`.
 2. Hash `c = HashToPoint(r, pk, message)` to get the target in `R_q`.
 3. Use the secret key to sample a short preimage `(s₁, s₂)` via `signAttempt`.
-4. If the norm check passes and compression succeeds, return `(r, compress(s₂))`.
+4. If the norm check passes and compression succeeds, return `some (r, compress(s₂))`.
 5. Otherwise retry with a new salt.
 
+Returns `none` once the attempt budget is exhausted. Compression is a separate gate from
+the norm check: a preimage can pass the `ℓ₂` bound and still have a coefficient too large for
+`compress` at `p.sbytelen`, so the loop retries on either failure. The compression length is
+`p.sbytelen`, the length `verify` decompresses at.
+
 The fresh-salt-per-retry structure matches the Falcon+ convention and the concrete
-executable signer in `LatticeCrypto.Falcon.Concrete.Sign.concreteSign`. -/
+executable signer in `Extern.Falcon.Sign`. -/
 noncomputable def sign (pk : PublicKey p) (sk : SecretKey p) (msg : List Byte) :
-    ProbComp Signature := sorry
+    ℕ → ProbComp (Option Signature)
+  | 0 => return none
+  | maxAttempts + 1 => do
+    let salt ← ($ᵗ (Bytes 40) : ProbComp (Bytes 40))
+    let c := prims.hashToPointForPublicKey pk.h salt msg
+    let r ← signAttempt p prims pk sk c
+    match r with
+    | some (_, s₂) =>
+        match prims.compress (rqToIntPolyCentered s₂) p.sbytelen with
+        | some comp => return (some ⟨salt, comp⟩)
+        | none => sign pk sk msg maxAttempts
+    | none => sign pk sk msg maxAttempts
 
 /-- Falcon verification (Algorithm 16).
 

--- a/LatticeCrypto/Falcon/Security.lean
+++ b/LatticeCrypto/Falcon/Security.lean
@@ -99,28 +99,88 @@ variable (p : Params) (prims : Primitives p)
 
 /-! ### Correctness -/
 
-/-- Falcon verification correctness: if the key pair is valid and signing produces a
-signature (does not abort), then verification accepts.
+/-- **Falcon verification correctness, conditional on the sampler landing on the coset.**
 
-The proof relies on:
-1. The NTRU equation ensuring `s₁ + s₂ · h = c mod q`.
-2. The norm bound from `ffSampling` ensuring `‖(s₁, s₂)‖₂² ≤ ⌊β²⌋`.
-3. The compress/decompress roundtrip preserving `s₂`. -/
-theorem verify_sign_correct (pk : PublicKey p) (sk : SecretKey p)
-    (hvalid : validKeyPair p pk sk = true)
-    (msg : List Byte) (sig : Signature)
-    (h_laws : Primitives.Laws prims)
-    (hsig : sig ∈ support (Falcon.sign p pk sk msg)) :
-    Falcon.verify p prims pk msg sig = true := by
-  -- The proof proceeds by unfolding `sign` and `verify`:
-  -- 1. `sign` produces (salt, compressedS2) where s₂ came from trapdoorSample
-  -- 2. `verify` decompresses s₂, recomputes c, checks the norm bound
-  -- Key steps:
-  -- (a) compress/decompress roundtrip (from h_laws.compress_decompress)
-  -- (b) PSF correctness: trapdoorSample output satisfies eval pk (s₁,s₂) = c
-  --     and isShort (s₁,s₂) = true
-  -- (c) The norm bound from (b) matches the verify check
-  sorry
+If the fuel-bounded signer returns a signature, `verify` accepts it, given two facts about the
+primitives at the honest key:
+
+1. `hcompress`: the codec round-trips (the `compress_decompress` law of `Primitives.Laws`);
+2. `hpreimage`: every output of the trapdoor sampler is a preimage of its target,
+   `s₁ + s₂ · h = c`.
+
+Hypothesis 2 is the lattice-point obligation of the floating-point pipeline. `fromFFTPreimage`
+rounds an inverse FFT to obtain `v = z · B` and returns `(c − v₀, −v₁)`, and `s₁ + s₂ · h = c`
+holds exactly when the rounded `v` is the lattice point `z · B`, i.e. when the inverse FFT's
+rounding error stays below `1/2` in every coordinate. It is stated here rather than built into
+the model, so that it is discharged where the arithmetic is exact and stays visible where it is
+not. Neither the NTRU equation nor `validKeyPair` is needed: the signer emits only attempts that
+passed the norm check, and that check is `verify`'s own. -/
+theorem verify_sign_correct (pk : PublicKey p) (sk : SecretKey p) (msg : List Byte)
+    (maxAttempts : ℕ) (sig : Signature)
+    (hcompress : ∀ (s : IntPoly p.n) (slen : ℕ) (bytes : List Byte),
+      prims.compress s slen = some bytes → prims.decompress bytes slen = some s)
+    (hpreimage : ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p prims).trapdoorSample pk sk c) →
+        (falconPSF p prims).eval pk x = c)
+    (hsig : some sig ∈ support (sign p prims pk sk msg maxAttempts)) :
+    verify p prims pk msg sig = true := by
+  induction maxAttempts with
+  | zero =>
+    simp only [sign, support_pure, Set.mem_singleton_iff] at hsig
+    exact absurd hsig (by simp)
+  | succ k ih =>
+    rw [sign, mem_support_bind_iff] at hsig
+    obtain ⟨salt, _hsalt, hsig⟩ := hsig
+    rw [mem_support_bind_iff] at hsig
+    obtain ⟨r, hr, hsig⟩ := hsig
+    match r, hr, hsig with
+    | none, _hr, hsig => exact ih hsig
+    | some (s₁, s₂), hr, hsig =>
+      dsimp only at hsig
+      cases hcomp : prims.compress (rqToIntPolyCentered s₂) p.sbytelen with
+      | none =>
+        rw [hcomp] at hsig
+        exact ih hsig
+      | some comp =>
+        rw [hcomp] at hsig
+        simp only [support_pure, Set.mem_singleton_iff, Option.some.injEq] at hsig
+        subst hsig
+        -- The accepting attempt is a `trapdoorSample` output that passed the norm check.
+        set c := prims.hashToPointForPublicKey pk.h salt msg with hc
+        rw [signAttempt, mem_support_bind_iff] at hr
+        obtain ⟨x, hx, hr⟩ := hr
+        have hshort_eval :
+            (s₁, s₂) ∈ support ((falconPSF p prims).trapdoorSample pk sk c) ∧
+              (falconPSF p prims).isShort (s₁, s₂) = true := by
+          by_cases hshort : (falconPSF p prims).isShort x = true
+          · rw [if_pos hshort, support_pure, Set.mem_singleton_iff, Option.some.injEq] at hr
+            subst hr
+            exact ⟨hx, hshort⟩
+          · rw [if_neg hshort, support_pure, Set.mem_singleton_iff] at hr
+            exact absurd hr (by simp)
+        obtain ⟨hmem, hshort⟩ := hshort_eval
+        have heval : (falconPSF p prims).eval pk (s₁, s₂) = c := hpreimage c (s₁, s₂) hmem
+        -- `verify` decompresses to the same `s₂`, recomputes the same `s₁`, and runs the norm
+        -- check the attempt already passed.
+        have hdec := hcompress _ _ _ hcomp
+        unfold verify
+        simp only [hdec]
+        rw [toRq_rqToIntPolyCentered]
+        have hs1 : c - negacyclicMul s₂ pk.h = s₁ := by
+          rw [← heval]
+          change s₁ + negacyclicMul s₂ pk.h - negacyclicMul s₂ pk.h = s₁
+          apply LatticeCrypto.Poly.ext_get_eq
+          intro i
+          calc (s₁ + negacyclicMul s₂ pk.h - negacyclicMul s₂ pk.h).get i
+              = (s₁ + negacyclicMul s₂ pk.h).get i - (negacyclicMul s₂ pk.h).get i :=
+                LatticeCrypto.NegacyclicRing.coeff_sub (coeffRing p.n) _ _ i
+            _ = s₁.get i + (negacyclicMul s₂ pk.h).get i - (negacyclicMul s₂ pk.h).get i :=
+                congrArg (· - (negacyclicMul s₂ pk.h).get i)
+                  (LatticeCrypto.NegacyclicRing.coeff_add (coeffRing p.n) _ _ i)
+            _ = s₁.get i := add_sub_cancel_right _ _
+        change decide (pairL2NormSq (c - negacyclicMul s₂ pk.h) s₂ ≤ p.betaSquared) = true
+        rw [hs1]
+        exact hshort
 
 /-! ### NTRU-SIS Hardness Assumption -/
 

--- a/LatticeCrypto/Falcon/Security.lean
+++ b/LatticeCrypto/Falcon/Security.lean
@@ -104,7 +104,8 @@ variable (p : Params) (prims : Primitives p)
 If the fuel-bounded signer returns a signature, `verify` accepts it, given two facts about the
 primitives at the honest key:
 
-1. `hcompress`: the codec round-trips (the `compress_decompress` law of `Primitives.Laws`);
+1. `hcompress`: the codec round-trips (the `compress_decompress` law of `Primitives.Laws`,
+   a theorem for the concrete codec: `Falcon.Concrete.decompress_compress`);
 2. `hpreimage`: every output of the trapdoor sampler is a preimage of its target,
    `s₁ + s₂ · h = c`.
 

--- a/LatticeCrypto/Ring/IntegralLift.lean
+++ b/LatticeCrypto/Ring/IntegralLift.lean
@@ -33,7 +33,8 @@ namespace LatticeCrypto
 
 Bundles a reduction map from integer polynomials to `R_q`, integer-polynomial
 multiplication in `ℤ[X]/(X^n + 1)`, and constant embedding. The multiplication
-uses `schoolbookNegacyclicMul` over the integer backend. -/
+is `negacyclicMulPure` over the integer backend, the `Finset`-sum specification whose
+runtime implementation is `schoolbookNegacyclicMul`. -/
 structure IntegralLift (IntPoly Rq : Type*) where
   toRq : IntPoly → Rq
   mul : IntPoly → IntPoly → IntPoly
@@ -49,7 +50,7 @@ def vectorIntegralLift (q n : Nat) :
     IntegralLift (Poly ℤ n) (Poly (ZMod q) n) where
   toRq := PolyBackend.mapCoeffs (vectorBackend ℤ n) (vectorBackend (ZMod q) n) rfl
     (fun z => (z : ZMod q))
-  mul := schoolbookNegacyclicMul (vectorKernel ℤ n)
+  mul := negacyclicMulPure (vectorKernel ℤ n)
   const := constPoly n
 
 end LatticeCrypto

--- a/scripts/axiom_baseline.json
+++ b/scripts/axiom_baseline.json
@@ -19,8 +19,6 @@
   "Falcon.euf_cma_security",
   "Falcon.euf_cma_security_bytes40",
   "Falcon.keyGenFromSeed",
-  "Falcon.sign",
-  "Falcon.verify_sign_correct",
   "FiatShamirWithAbort.euf_cma_bound",
   "FiatShamirWithAbort.euf_cma_bound_perfectHVZK",
   "GPVHashAndSign.euf_cma_collision_bound",


### PR DESCRIPTION
The abstract sign/correctness slice of #471, restated the honest way. Based on current `main`; independent of the other open Falcon PRs. Closes two `sorry`s in the axiom baseline (`Falcon.sign`, `Falcon.verify_sign_correct`).

## What changes

**`Falcon.sign` is defined** (`LatticeCrypto/Falcon/Scheme.lean`): the Falcon+ signer as a fuel-bounded rejection loop. Each attempt draws a fresh 40-byte salt, hashes the target, runs `signAttempt`, and returns `some (salt, compress s₂)` when both the norm check and compression succeed; it returns `none` once the budget is exhausted. Compression is a separate gate from the norm check, since a preimage can pass the `ℓ₂` bound and still have a coefficient too large for `compress` at `p.sbytelen`. The centered lift `rqToIntPolyCentered` is what the signer compresses, and `toRq_rqToIntPolyCentered` shows reduction modulo `q` undoes it.

**`verify_sign_correct` is proved**, with the obligation #471 had defined away stated as a hypothesis (`LatticeCrypto/Falcon/Security.lean`):

```
theorem verify_sign_correct (pk sk) (msg) (maxAttempts) (sig)
    (hcompress : ∀ s slen bytes, prims.compress s slen = some bytes → prims.decompress bytes slen = some s)
    (hpreimage : ∀ c x, x ∈ support ((falconPSF p prims).trapdoorSample pk sk c) → (falconPSF p prims).eval pk x = c)
    (hsig : some sig ∈ support (sign p prims pk sk msg maxAttempts)) :
    verify p prims pk msg sig = true
```

`hpreimage` is the lattice-point obligation of the floating-point pipeline: `fromFFTPreimage` rounds an inverse FFT to obtain `v = z · B` and returns `(c − v₀, −v₁)`, and `s₁ + s₂ · h = c` holds exactly when the rounded `v` is the lattice point, i.e. when the inverse FFT's rounding error stays below `1/2` in every coordinate. #471 obtained it by redefining `fromFFTPreimage` to set `s₁ := c − s₂ · h`, which made the theorem about a different vector than the one the norm check runs on. Here `fromFFTPreimage` is untouched and the condition is explicit, so it is discharged where the arithmetic is exact (the degree-2 witness in #466 proves it outright for its instance, `NonVacuity.toy_eval_sOf`) and stays visible where it is not.

`hcompress` is the `compress_decompress` law of `Primitives.Laws`, taken on its own rather than through `Primitives.Laws` because that structure also carries `samplerZ_correct`, an exact discrete-Gaussian law that no finite-support `ProbComp` sampler satisfies.

**The codec round-trip is proved for the concrete Golomb-Rice codec** (`LatticeCrypto/Falcon/Concrete/Encoding.lean`): `decompress_compress : compress n s dlen = some d → decompress n d dlen = some s`. The two functions are restated over the bit stream. The previous definitions used `while` loops, which `do`-notation desugars through `Loop.forIn`, a `partial` definition, so nothing could be proved about them as written (the same reason #638 restated the public-key codec as bounded loops). The new `compress` emits, per coefficient, the sign bit, the seven low bits of `|x|`, `|x| / 128` zeros and a one, packs most significant bit first and zero-pads to `dlen`; `decompress` parses that stream and rejects a wrong length, an out-of-range magnitude, the negative zero, and nonzero padding, exactly the failure cases of the old decoder. Behaviour is pinned two ways: `lake exe falcon_test` passes 205/205 with the new codec, including the known-answer signatures through `concreteVerify` and the C reference verifying Lean-produced signatures, and a differential test of the new functions against the old imperative ones found no disagreement over 3680 polynomial encodings at boundary lengths, 9000 random byte strings, and 2500 bit-flipped encodings.

**At the concrete primitives only the coset condition remains** (`Extern/Falcon/SignCorrectness.lean`, new): `verify_sign_correct_verifyPrimitives` and `verify_sign_correct_concretePrimitives` discharge `hcompress` by the round-trip, so `verify` accepts every signature the concrete signer emits under `hpreimage` alone.

**The coset condition is reduced to the primitives** (`LatticeCrypto/Falcon/Coset.lean`, new). `LandsOnLattice prims sk z` says the two rounded inverse transforms in `fromFFTPreimage` are the integer polynomials `z₀ · g + z₁ · G` and `−(z₀ · f + z₁ · F)` for some integer `(z₀, z₁)`, i.e. the basis application lands on the lattice point `z · B`. Given that and the key relations `f · h = g`, `F · h = G`, the identity `s₁ + s₂ · h = c` is ring algebra, carried out in the semantic quotient `ℤ_q[X]/(X^n + 1)` through the existing soundness certificate `coeffSemantics` (`eval_fromFFTPreimage_of_landsOnLattice`); `hpreimage_of_landsOnLattice` lifts it over the sampler's support, and `capRelation_of_validKeyPair` derives `F · h = G` from the NTRU equation and `f · h = g` when `f` is invertible modulo `q`, which key generation guarantees. To make the NTRU equation usable, the integer lift's multiplication is now the `Finset`-sum specification `negacyclicMulPure` rather than the imperative schoolbook loop; the two were already the same function at runtime (`implemented_by`), and the loop was opaque to proofs. `verify_sign_correct_concretePrimitives_of_landsOnLattice` (and the `verifyPrimitives` version) then assume only key validity, invertibility of `f`, and `LandsOnLattice` for the sampler's outputs.

So the residual for the real signer is now exactly one deterministic statement about the fixed-point primitives: that `fftInt`/`ifftRound` round the basis application to the exact lattice point. The abstract sampler itself runs over exact reals (`Real.cos`/`Real.sin` twiddles), so no floating-point analysis of `ffSampling` enters; what is left is the rounding-error bound of `FXR.vect_FFT`/`vect_iFFT` on integer-valued inputs, deferred.

Neither the NTRU equation nor `validKeyPair` is needed: the signer emits only attempts that passed the norm check, and that check is `verify`'s own. The proof is an induction on the attempt budget: the accepting attempt is a `trapdoorSample` output that passed `isShort`; `verify` decompresses to the same `s₂` by `hcompress`, recomputes `s₁ = c − s₂ · h`, which equals the sampled `s₁` by `hpreimage`, and runs the same norm check.

## Not claimed

Nothing about the distribution of `sign`'s output, about `keyGenFromSeed` (still a placeholder), or about the concrete floating-point sampler satisfying `hpreimage`. The codec restatement is not a faithfulness claim against a c-fn-dsa revision beyond what the test executable checks. Composing #514's per-operation bounds through `ffSampling` and the inverse FFT to discharge `hpreimage` for the real arithmetic is the deferred step.

## Checks

`verify_sign_correct`, `toRq_rqToIntPolyCentered`, `sign`, `decompress_compress`, the coset theorems (`toRq_mul`, `eval_fromFFTPreimage_of_landsOnLattice`, `hpreimage_of_landsOnLattice`, `capRelation_of_validKeyPair`), and all four concrete corollaries depend only on `propext`, `Classical.choice`, `Quot.sound`. Both touched files pass `-Dweak.linter.mathlibStandardSet=true` with no new warnings (the remaining `sorry` warnings are the pre-existing `keyGenFromSeed` and one-shot `euf_cma_security`). Full build of all libraries and `LatticeCryptoTest` clean; PMF boundary, Extern isolation, Interop isolation, and `lake exe axiomsweep --check` pass with the baseline regenerated.
