### PR TITLE
test(VCVioTest): make the tactic gates machine-checked and fail CI on test warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,19 @@ jobs:
       # not elaborate anything. Kept out of the timed build commands on purpose: the
       # timing report compares exactly the seven non-test libraries.
       - name: Build the canary library
-        run: lake build VCVioTest
+        shell: bash  # explicit bash gives pipefail; the default `bash -e {0}` does not
+        run: lake build VCVioTest 2>&1 | tee "$BUILD_TIMING_LOG_DIR/test_build.log"
+      # The canary library is the tactic gate: a warning there (an unused tactic, a
+      # redundant `grind` parameter, a deprecated name) is a gate entry going stale, so
+      # it fails the job like a proof-library warning does. Dependency logs are replayed
+      # into this output too, hence the `VCVioTest` path prefixes: the five `sorry`
+      # warnings under `VCVio/CryptoFoundations/**` are the proof-library gate's business.
+      - name: Check canary warning budget
+        run: |
+          python3 ./scripts/check-warning-log.py "$BUILD_TIMING_LOG_DIR/test_build.log" \
+            --path-prefix VCVioTest/ \
+            --path-prefix VCVioTest.lean \
+            --label 'VCVioTest warnings'
       # `LatticeCryptoTest.lean` deliberately omits the native `Main` executables,
       # which remain covered by the nightly FFI workflow. Building this library
       # elaborates every Lean-only lattice helper, vector, and regression canary.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,8 +295,8 @@ jobs:
       # The canary library is the tactic gate: a warning there (an unused tactic, a
       # redundant `grind` parameter, a deprecated name) is a gate entry going stale, so
       # it fails the job like a proof-library warning does. Dependency logs are replayed
-      # into this output too, hence the `VCVioTest` path prefixes: the five `sorry`
-      # warnings under `VCVio/CryptoFoundations/**` are the proof-library gate's business.
+      # into this output too, hence the `VCVioTest` path prefixes: existing `sorry`
+      # warnings in dependencies are the proof-library gate's business.
       - name: Check canary warning budget
         run: |
           python3 ./scripts/check-warning-log.py "$BUILD_TIMING_LOG_DIR/test_build.log" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,30 @@ ASCII banners are visually loud, do not appear in the generated documentation, a
 - Respect the module layering documented in [`AGENTS.md`](AGENTS.md).
 - Use `/-! ## Title -/` doc-headers, not ASCII banners, for inline section breaks (see *Documentation Expectations* above).
 
+## Tactic Gate Files
+
+`VCVioTest/ProbabilityTactics.lean`, `VCVioTest/MonadProbability.lean`, `VCVioTest/GrindFailFast.lean`
+and their siblings are the *tactic gates*: they state what the basic tactics must do on the whole
+(see *Normal forms and the tactic contract* in [`docs/agents/probability.md`](docs/agents/probability.md)).
+Four rules keep them honest:
+
+1. **One terminal call.** A positive entry is `by <one tactic>` (or a term): `simp`, `grind`,
+   `gcongr`, `finiteness`, `simp [S]`, `simp only [S]`.
+2. **Known gaps are machine-checked and self-expiring.** Where the expected tactic does not close
+   a goal, the entry is a *gap pair*: `fail_if_success (tac; done)` on its own line, then the
+   working closer, with a dated `gap(tac, YYYY-MM-DD): reason` comment. The guard errors the moment
+   the set improves, so the PR that closes a gap must also retire its guard. One guard covers a
+   family of same-shaped entries when the family is named in the section note.
+3. **No multi-call scripts.** A `;`/multi-line script is allowed only as the closer of a gap pair.
+   A one-call entry that stops closing is fixed in the simp/grind set or filed as a dated gap pair;
+   it is never fixed by adding a second call.
+4. **Normalizers pin their normal form.** Where a set is a normalizer rather than a closer
+   (`simp only [monad_norm]`, `handler_step`), the entry is `simp only [S]` followed by
+   `guard_target =ₛ <expected form>` and then a closer.
+
+Warnings in `VCVioTest` fail CI (the *Check canary warning budget* step), so a stale entry cannot
+linger as a warning.
+
 ## Licensing
 
 This project is licensed under Apache 2.0. By contributing, you agree that your contributions are licensed under the same terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,8 @@ Four rules keep them honest:
    working closer, with a dated `gap(tac, YYYY-MM-DD): reason` comment. The guard errors the moment
    the set improves, so the PR that closes a gap must also retire its guard. One guard covers a
    family of same-shaped entries when the family is named in the section note.
+   Use bare `fail_if_success simp` for an explicit no-progress check; `done` is unreachable
+   when `simp` itself fails without progress. Bare `fail_if_success grind` already tests closure.
 3. **No multi-call scripts.** A `;`/multi-line script is allowed only as the closer of a gap pair.
    A one-call entry that stops closing is fixed in the simp/grind set or filed as a dated gap pair;
    it is never fixed by adding a second call.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,31 +125,8 @@ ASCII banners are visually loud, do not appear in the generated documentation, a
 - Respect the module layering documented in [`AGENTS.md`](AGENTS.md).
 - Use `/-! ## Title -/` doc-headers, not ASCII banners, for inline section breaks (see *Documentation Expectations* above).
 
-## Tactic Gate Files
-
-`VCVioTest/ProbabilityTactics.lean`, `VCVioTest/MonadProbability.lean`, `VCVioTest/GrindFailFast.lean`
-and their siblings are the *tactic gates*: they state what the basic tactics must do on the whole
-(see *Normal forms and the tactic contract* in [`docs/agents/probability.md`](docs/agents/probability.md)).
-Four rules keep them honest:
-
-1. **One terminal call.** A positive entry is `by <one tactic>` (or a term): `simp`, `grind`,
-   `gcongr`, `finiteness`, `simp [S]`, `simp only [S]`.
-2. **Known gaps are machine-checked and self-expiring.** Where the expected tactic does not close
-   a goal, the entry is a *gap pair*: `fail_if_success (tac; done)` on its own line, then the
-   working closer, with a dated `gap(tac, YYYY-MM-DD): reason` comment. The guard errors the moment
-   the set improves, so the PR that closes a gap must also retire its guard. One guard covers a
-   family of same-shaped entries when the family is named in the section note.
-   Use bare `fail_if_success simp` for an explicit no-progress check; `done` is unreachable
-   when `simp` itself fails without progress. Bare `fail_if_success grind` already tests closure.
-3. **No multi-call scripts.** A `;`/multi-line script is allowed only as the closer of a gap pair.
-   A one-call entry that stops closing is fixed in the simp/grind set or filed as a dated gap pair;
-   it is never fixed by adding a second call.
-4. **Normalizers pin their normal form.** Where a set is a normalizer rather than a closer
-   (`simp only [monad_norm]`, `handler_step`), the entry is `simp only [S]` followed by
-   `guard_target =ₛ <expected form>` and then a closer.
-
-Warnings in `VCVioTest` fail CI (the *Check canary warning budget* step), so a stale entry cannot
-linger as a warning.
+For probability tactic tests, follow the
+[tactic-test conventions](docs/agents/probability.md#normal-forms-and-the-tactic-contract).
 
 ## Licensing
 

--- a/VCVio/EvalDist/Monad/Seq.lean
+++ b/VCVio/EvalDist/Monad/Seq.lean
@@ -52,7 +52,7 @@ section spmf
 
 variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
 
-@[simp]
+@[simp, grind norm]
 lemma evalSPMF_seq (mf : m (α → β)) (mx : m α) :
     𝒮[mf <*> mx] = 𝒮[mf] <*> 𝒮[mx] := by simp [monad_norm]
 
@@ -111,7 +111,7 @@ variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
   [MonadLiftT m SetM] [EvalDistCompatible m]
 
 omit [MonadLiftT m SetM] [EvalDistCompatible m] in
-@[simp]
+@[simp, grind norm]
 lemma evalSPMF_seqLeft (mx : m α) (my : m β) :
     𝒮[mx <* my] = 𝒮[mx] <* 𝒮[my] := by
   simp [seqLeft_eq]
@@ -164,7 +164,7 @@ variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
   [MonadLiftT m SetM] [EvalDistCompatible m]
 
 omit [MonadLiftT m SetM] [EvalDistCompatible m] in
-@[simp]
+@[simp, grind norm]
 lemma evalSPMF_seqRight (mx : m α) (my : m β) :
     𝒮[mx *> my] = 𝒮[mx] *> 𝒮[my] := by
   simp [seqRight_eq]

--- a/VCVioTest/MonadProbability.lean
+++ b/VCVioTest/MonadProbability.lean
@@ -22,8 +22,9 @@ factor**: over a failing monad, `Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= 
 only when `Pr[⊥] = 0` (as in `ProbComp`).
 
 As in the concrete battery: where a fact closes by both `simp` and `grind`, both are kept (the
-mirror); otherwise a single terminal tactic + a `target(...)` note. Operations with no probability
-API yet are recorded as `target` gaps at the end.
+mirror); otherwise a gap pair (`fail_if_success (tac; done)` guard, dated reason, then the working
+closer; see `CONTRIBUTING.md`, *Tactic Gate Files*). Operations with no probability API yet are
+recorded as prose gaps at the end.
 -/
 
 @[expose] public section
@@ -72,9 +73,12 @@ example (mx : m α) (my : α → m β) :
 example (mx : m α) (my : α → m β) : 𝒮[mx >>= my] = 𝒮[mx] >>= fun x => 𝒮[my x] := by simp
 example (mx : m α) (my : α → m β) : 𝒮[mx >>= my] = 𝒮[mx] >>= fun x => 𝒮[my x] := by grind
 
--- target(simp): the `tsum` bind expansions are `@[grind =]` only.
+-- by design: the `tsum` bind expansions are `@[grind =]` only (`gotchas.md` §10); the guard is
+-- the machine-checked form of that decision.
 example (mx : m α) (my : α → m β) (y : β) :
-    Pr[= y | mx >>= my] = ∑' x : α, Pr[= x | mx] * Pr[= y | my x] := by grind
+    Pr[= y | mx >>= my] = ∑' x : α, Pr[= x | mx] * Pr[= y | my x] := by
+  fail_if_success simp  -- gap(simp, 2026-09-03): deliberate, bind expansion is not default simp
+  grind
 example (mx : m α) (my : α → m β) :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + ∑' x : α, Pr[= x | mx] * Pr[⊥ | my x] := by grind
 
@@ -110,9 +114,11 @@ example (f : α → β) (mx : m α) : support (f <$> mx) = f '' support mx := by
 example (f : α → β) (mx : m α) : 𝒮[f <$> mx] = f <$> 𝒮[mx] := by simp
 example (f : α → β) (mx : m α) : 𝒮[f <$> mx] = f <$> 𝒮[mx] := by grind
 
--- target(simp): `probOutput_map` is `@[grind =]` only (`simp` keeps its injective/equiv map forms).
+-- by design: `probOutput_map` is `@[grind =]` only (`simp` keeps its injective/equiv map forms).
 example (f : α → β) (mx : m α) (y : β) :
-    Pr[= y | f <$> mx] = Pr[ fun x => f x = y | mx] := by grind
+    Pr[= y | f <$> mx] = Pr[ fun x => f x = y | mx] := by
+  fail_if_success simp  -- gap(simp, 2026-09-03): deliberate, `probOutput_map` is not simp
+  grind
 
 /-! ## `seqLeft` (`<*`) / `seqRight` (`*>`) — the headline failure factors
 
@@ -128,20 +134,30 @@ example (mx my : m α) (y : α) : Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[=
 example (mx my : m α) (p : α → Prop) :
     Pr[ p | mx <* my] = (1 - Pr[⊥ | my]) * Pr[ p | mx] := by simp
 example (mx my : m α) (p : α → Prop) :
+    Pr[ p | mx <* my] = (1 - Pr[⊥ | my]) * Pr[ p | mx] := by grind
+example (mx my : m α) (p : α → Prop) :
     Pr[ p | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[ p | my] := by simp
+example (mx my : m α) (p : α → Prop) :
+    Pr[ p | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[ p | my] := by grind
 
 example (mx my : m α) :
     Pr[⊥ | mx <* my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by simp
 example (mx my : m α) :
+    Pr[⊥ | mx <* my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by grind
+example (mx my : m α) :
     Pr[⊥ | mx *> my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by simp
+example (mx my : m α) :
+    Pr[⊥ | mx *> my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by grind
 
 example (mx my : m α) : 𝒮[mx *> my] = 𝒮[mx] *> 𝒮[my] := by simp
+example (mx my : m α) : 𝒮[mx *> my] = 𝒮[mx] *> 𝒮[my] := by grind
 example (mx my : m α) : 𝒮[mx <* my] = 𝒮[mx] <* 𝒮[my] := by simp
+example (mx my : m α) : 𝒮[mx <* my] = 𝒮[mx] <* 𝒮[my] := by grind
 
 /-! ## `seq` (`<*>`)
 
-Failure is inclusion–exclusion; the `Prod.mk` product factors (`simp`-only — `grind` cannot
-factor an applicative product). -/
+Failure is inclusion–exclusion; the `Prod.mk` product factors under both tactics (`simp` by the
+`@[simp high]` rule, `grind` by the same lemma as a `@[grind norm]` rule). -/
 
 example (mf : m (α → β)) (mx : m α) :
     Pr[⊥ | mf <*> mx] = Pr[⊥ | mf] + Pr[⊥ | mx] - Pr[⊥ | mf] * Pr[⊥ | mx] := by simp
@@ -149,6 +165,7 @@ example (mf : m (α → β)) (mx : m α) :
     Pr[⊥ | mf <*> mx] = Pr[⊥ | mf] + Pr[⊥ | mx] - Pr[⊥ | mf] * Pr[⊥ | mx] := by grind
 
 example (mf : m (α → β)) (mx : m α) : 𝒮[mf <*> mx] = 𝒮[mf] <*> 𝒮[mx] := by simp
+example (mf : m (α → β)) (mx : m α) : 𝒮[mf <*> mx] = 𝒮[mf] <*> 𝒮[mx] := by grind
 
 -- the applicative product factors under both: `simp` by the `@[simp high]` rule, `grind` by the
 -- same lemma as a `@[grind norm]` rule (the `Seq.seq` thunk is unindexable for E-matching, but
@@ -169,7 +186,9 @@ failing ones it does not — that contrast is the point. -/
 /-! ## `Id` -/
 example (x : Bool) : Pr[= x | (pure x : Id Bool)] = 1 := by simp
 example (x : Bool) : Pr[= x | (pure x : Id Bool)] = 1 := by grind
-example (mx my : Id Bool) (y : Bool) : Pr[= y | mx *> my] = Pr[= y | my] := by simp
+example (mx my : Id Bool) (y : Bool) : Pr[= y | mx *> my] = Pr[= y | my] := by
+  fail_if_success grind  -- gap(grind, 2026-09-03): the factor `1 - 0` is `ℝ≥0∞` arithmetic
+  simp
 
 /-! ## `OptionT ProbComp` (the failing case used in cryptography) -/
 example (x : Bool) : Pr[= x | (pure x : OptionT ProbComp Bool)] = 1 := by simp
@@ -180,6 +199,8 @@ example : Pr[⊥ | (failure : OptionT ProbComp Bool)] = 1 := by grind
 -- the failure factor is visible here (the discarded draw can fail):
 example (mx my : OptionT ProbComp Bool) (y : Bool) :
     Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by simp
+example (mx my : OptionT ProbComp Bool) (y : Bool) :
+    Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by grind
 
 /-! ## `ExceptT` over `ProbComp` (a failing carrier — failure factor visible) -/
 example (x : Bool) : Pr[= x | (pure x : ExceptT String ProbComp Bool)] = 1 := by simp
@@ -191,23 +212,30 @@ example (x : Bool) : Pr[= x | (pure x : SPMF Bool)] = 1 := by grind
 
 /-! ## `orElse` (`<|>`) and `guard` over `OptionT ProbComp`
 
-The freshly-added API (`probFailure_orElse` / `probOutput_orElse` / `support_guard`). -/
+The `orElse`/`guard` API (`probFailure_orElse` / `probOutput_orElse` / `support_guard`).
+gap(grind): none of these lemmas is a `grind` rule yet; the first entry of each family carries the
+guard. -/
 
 example (oa oa' : OptionT ProbComp Bool) :
-    Pr[⊥ | oa <|> oa'] = Pr[⊥ | oa] * Pr[⊥ | oa'] := by simp
+    Pr[⊥ | oa <|> oa'] = Pr[⊥ | oa] * Pr[⊥ | oa'] := by
+  fail_if_success grind  -- gap(grind, 2026-09-03): `orElse` family
+  simp
 
 example (oa oa' : OptionT ProbComp Bool) (x : Bool) :
     Pr[= x | oa <|> oa'] = Pr[= x | oa] + Pr[⊥ | oa] * Pr[= x | oa'] := by simp
 
 example (p : Prop) [Decidable p] :
-    support (guard p : OptionT ProbComp Unit) = if p then {()} else ∅ := by simp
+    support (guard p : OptionT ProbComp Unit) = if p then {()} else ∅ := by
+  fail_if_success grind  -- gap(grind, 2026-09-03): `guard` family
+  simp
 
 example (p : Prop) [Decidable p] :
     Pr[⊥ | (guard p : OptionT ProbComp Unit)] = if p then 0 else 1 := by simp
 
-/-! # Remaining API gaps (`target`)
+/-! # Remaining API gaps
 
-These common monad operations have no probability lemmas yet; each is a future API addition:
+These common monad operations have no probability lemmas yet (re-verified 2026-09-03); each is a
+future API addition:
 
 * `support_orElse` — `support (oa <|> oa') = support oa ∪ {x | Pr[⊥ | oa] ≠ 0 ∧ x ∈ support oa'}`;
   follows from `probOutput_orElse` via the support↔probability bridge.

--- a/VCVioTest/MonadProbability.lean
+++ b/VCVioTest/MonadProbability.lean
@@ -23,8 +23,8 @@ only when `Pr[⊥] = 0` (as in `ProbComp`).
 
 As in the concrete battery: where a fact closes by both `simp` and `grind`, both are kept (the
 mirror); otherwise a gap pair (`fail_if_success (tac; done)` guard, dated reason, then the working
-closer; see `CONTRIBUTING.md`, *Tactic Gate Files*). Operations with no probability API yet are
-recorded as prose gaps at the end.
+closer; see *Normal forms and the tactic contract* in `docs/agents/probability.md`). Operations
+with no probability API yet are recorded as prose gaps at the end.
 -/
 
 @[expose] public section

--- a/VCVioTest/ProbabilityTactics.lean
+++ b/VCVioTest/ProbabilityTactics.lean
@@ -16,15 +16,18 @@ distributions**, each discharged by a single *terminal* tactic — `simp` or `gr
 **gates `simp` and `grind` as stable terminal tactics** over this surface, so a regression in
 either surfaces here in isolation rather than deep inside a downstream proof.
 
-Conventions:
+Conventions (the full rules are in `CONTRIBUTING.md`, *Tactic Gate Files*):
 * **Mirrors.** Where a fact is closed by *both* `simp` and `grind`, both are kept, so each tactic
   stays exercised on that shape. This is the bulk of the file.
-* **Single tactic + target.** Where only one tactic closes a goal, that tactic is used and the gap
-  is recorded with a `target(grind)` / `target(simp)` note — a concrete goal for future tactic work.
+* **Gap pairs.** Where only one tactic closes a goal, the entry is a *gap pair*: a
+  `fail_if_success (tac; done)` guard on its own line, then the working closer, with a dated
+  `gap(tac, date): reason` comment. The guard errors the moment the set improves, so the PR that
+  closes a gap retires the guard. One guard covers a family of same-shaped entries when the
+  family is named in the section note.
+* **One terminal call.** A `;`/multi-line script appears only as the closer of a gap pair.
 * **Only stable tactics.** No example hangs or explodes. `grind` reasons well about symbolic /
   atomic / membership / equiprobability / `pure`+`bind`-normalised goals; computing a concrete value
-  or factoring a structured computation (`<*>`, a non-trivial `<$>`/`if`) is `simp`'s job, so those
-  are `simp`-terminal with a `target(grind)` note.
+  or factoring a structured computation (`<*>`, a non-trivial `<$>`/`if`) is `simp`'s job.
 
 `grind` normalises monadic structure (`bind_pure`, `pure_bind`, `bind_assoc`, `map_pure` are
 `@[grind =]`), so `bind`-`pure`-shaped goals close by `grind`; `Set.Nonempty` bridges
@@ -55,10 +58,13 @@ example (x : Bool) : Pr[= x | (pure x : ProbComp Bool)] ≠ 0 := by grind
 /-! ## Uniform draws
 Every outcome of a uniform draw over an `n`-element type has probability `1 / n`.
 
-target(grind): computing a concrete value needs `Fintype.card`/`ℝ≥0∞` arithmetic `grind` does not do
-(it fails fast); `simp` evaluates it. Symbolic facts (`≠ 0`, equiprobability) close by both. -/
+gap(grind): computing a concrete value needs `Fintype.card`/`ℝ≥0∞` arithmetic `grind` does not do
+(it fails fast); `simp` evaluates it. The first entry carries the guard for the family. Symbolic
+facts (`≠ 0`, equiprobability) close by both. -/
 
-example : Pr[= true | $ᵗ Bool] = 2⁻¹ := by simp
+example : Pr[= true | $ᵗ Bool] = 2⁻¹ := by
+  fail_if_success grind  -- gap(grind, 2026-09-03): concrete values, covers this section
+  simp
 example : Pr[= (0 : Fin 6) | $ᵗ (Fin 6)] = 6⁻¹ := by simp
 
 example : Pr[= true | $ᵗ Bool] ≠ 0 := by simp
@@ -73,14 +79,16 @@ example : Pr[= true | $ᵗ Bool] = Pr[= false | $ᵗ Bool] := by grind
 example : Pr[= (3 : ZMod 5) | $ᵗ (ZMod 5)] = 5⁻¹ := by simp
 example : Pr[= (0 : BitVec 4) | $ᵗ (BitVec 4)] = 16⁻¹ := by simp
 
+example : Pr[= (0 : Fin 3) | $ᵗ (Fin 3)] ≠ 0 := by simp
 example : Pr[= (0 : Fin 3) | $ᵗ (Fin 3)] ≠ 0 := by grind
 
+example (x : Bool ⊕ Bool) : Pr[= x | $ᵗ (Bool ⊕ Bool)] ≠ 0 := by simp
 example (x : Bool ⊕ Bool) : Pr[= x | $ᵗ (Bool ⊕ Bool)] ≠ 0 := by grind
 
 /-! ## Bounds
 An outcome probability lies in `[0, 1]` and is never `⊤`.
 
-target(grind): `0 ≤ _` in `ℝ≥0∞` is just `zero_le`, but `grind` routes through the support machinery
+gap(grind): `0 ≤ _` in `ℝ≥0∞` is just `zero_le`, but `grind` routes through the support machinery
 and fails; `simp` closes it. -/
 
 example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] ≤ 1 := by simp
@@ -89,7 +97,9 @@ example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] ≤ 1 := by grind
 example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] ≠ ⊤ := by simp
 example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] ≠ ⊤ := by grind
 
-example (mx : ProbComp Bool) (x : Bool) : 0 ≤ Pr[= x | mx] := by simp
+example (mx : ProbComp Bool) (x : Bool) : 0 ≤ Pr[= x | mx] := by
+  fail_if_success grind  -- gap(grind, 2026-09-03): `zero_le` behind the support machinery
+  simp
 
 /-! ## `bind`/`pure`-normalised computations
 `grind` normalises monadic structure, so a redundant `bind`/`pure` collapses and the outcome
@@ -113,12 +123,15 @@ The applicative (`<$> … <*>`) spelling factors under `grind` via the `@[grind 
 `probOutput_seq_map_prod_mk_eq_mul` (the `Seq.seq` thunk is unindexable for E-matching, but
 `grind`'s normalization phase handles it).
 
-target(grind): the `bind`-spelled product — the second draw sits under `bind`'s continuation, which
-neither E-matching nor the seq-keyed norm rule reaches; `simp` factors it. -/
+gap(grind): the `bind`-spelled product — the second draw sits under `bind`'s continuation, which
+neither E-matching nor the seq-keyed norm rule reaches; `simp` factors it. The first entry carries
+the guard. -/
 
 example (a b : Bool) :
     Pr[= (a, b) | do let x ← $ᵗ Bool; let y ← $ᵗ Bool; pure (x, y)]
-      = Pr[= a | $ᵗ Bool] * Pr[= b | $ᵗ Bool] := by simp
+      = Pr[= a | $ᵗ Bool] * Pr[= b | $ᵗ Bool] := by
+  fail_if_success grind  -- gap(grind, 2026-09-03): bind-spelled product, covers this section
+  simp
 
 example :
     Pr[= ((5 : Fin 6), (5 : Fin 6)) | do let x ← $ᵗ (Fin 6); let y ← $ᵗ (Fin 6); pure (x, y)]
@@ -146,7 +159,10 @@ example (mx : ProbComp Bool) (p : Bool → Prop) : Pr[p | mx] ≠ ⊤ := by grin
 example (mx : ProbComp Bool) : Pr[fun _ => False | mx] = 0 := by simp
 example (mx : ProbComp Bool) : Pr[fun _ => False | mx] = 0 := by grind
 example : Pr[fun b => b = true | $ᵗ Bool] = 2⁻¹ := by simp
-example : Pr[fun n => n < 3 | $ᵗ (Fin 6)] = 3 / 6 := by simp; rfl
+example : Pr[fun n => n < 3 | $ᵗ (Fin 6)] = 3 / 6 := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): the filter card is not evaluated
+  fail_if_success grind  -- gap(grind, 2026-09-03): counting
+  simp; rfl
 
 /-! ## Monotonicity and complement
 An event implies a wider event; the complement subtracts from one. -/
@@ -154,20 +170,28 @@ An event implies a wider event; the complement subtracts from one. -/
 example (mx : ProbComp Bool) (p q : Bool → Prop) (h : ∀ x, p x → q x) :
     Pr[p | mx] ≤ Pr[q | mx] := probEvent_mono'' h
 
-example : Pr[fun b => b ≠ true | $ᵗ Bool] = 2⁻¹ := by simp
+example : Pr[fun b => b ≠ true | $ᵗ Bool] = 2⁻¹ := by simp  -- concrete value, see §uniform draws
 
 /-! ## Counting (favourable / total)
-target(grind): the finite count needs `rfl` after the `probEvent_uniformSample` rewrite; ideally
-`grind` evaluates the count itself. -/
+gap: the favourable count over a concrete finite type is left as `↑{…}.card / n`; `rfl`/`congr`
+evaluates it afterwards, `simp +decide` does not, and `grind` fails. -/
 
-example : Pr[fun n => n = 0 ∨ n = 1 | $ᵗ (Fin 6)] = 2 / 6 := by simp; rfl
-example : Pr[fun p => p.1 = true ∨ p.2 = true | $ᵗ (Bool × Bool)] = 3 / 4 := by simp; congr 1
+example : Pr[fun n => n = 0 ∨ n = 1 | $ᵗ (Fin 6)] = 2 / 6 := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): the filter card is not evaluated
+  fail_if_success grind  -- gap(grind, 2026-09-03): counting
+  simp; rfl
+example : Pr[fun p => p.1 = true ∨ p.2 = true | $ᵗ (Bool × Bool)] = 3 / 4 := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): the filter card is not evaluated
+  fail_if_success grind  -- gap(grind, 2026-09-03): counting
+  simp; congr 1
 
 /-! ## Map pushforward
 The event-probability of a map is the pulled-back event. -/
 
 example (mx : ProbComp Bool) (q : Fin 6 → Prop) (f : Bool → Fin 6) :
     Pr[q | f <$> mx] = Pr[q ∘ f | mx] := by simp
+example (mx : ProbComp Bool) (q : Fin 6 → Prop) (f : Bool → Fin 6) :
+    Pr[q | f <$> mx] = Pr[q ∘ f | mx] := by grind
 
 /-! # 3. Failure probability — `Pr[⊥ | _]` -/
 
@@ -199,10 +223,16 @@ example : Pr[⊥ | (failure : OptionT ProbComp Bool)] = 1 := by simp
 example : Pr[⊥ | (failure : OptionT ProbComp Bool)] = 1 := by grind
 
 example : Pr[⊥ | ($ ([true, false] : List Bool) : OptionT ProbComp Bool)] = 0 := by simp
+example : Pr[⊥ | ($ ([true, false] : List Bool) : OptionT ProbComp Bool)] = 0 := by grind
 
-example (mx : OptionT ProbComp Bool) (h : (support mx).Nonempty) : Pr[⊥ | mx] ≠ 1 := by grind
-example (mx : ProbComp Bool) (h : (support mx).Nonempty) : Pr[⊥ | mx] ≠ 1 := by grind
+example (mx : OptionT ProbComp Bool) (h : (support mx).Nonempty) : Pr[⊥ | mx] ≠ 1 := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): stops at `¬support mx = ∅`
+  grind
+example (mx : ProbComp Bool) : Pr[⊥ | mx] ≠ 1 := by
+  fail_if_success grind  -- gap(grind, 2026-09-03): `≠ 1` from `Pr[⊥] = 0` needs `0 ≠ 1` in `ℝ≥0∞`
+  simp
 
+example (α : Type) [SampleableType α] : Pr[⊥ | $ᵗ α] ≠ 1 := by simp
 example (α : Type) [SampleableType α] : Pr[⊥ | $ᵗ α] ≠ 1 := by grind
 
 /-! # 4. Support and finite support -/
@@ -243,16 +273,23 @@ example (x : Bool) : x ∈ finSupport ($ᵗ Bool) := by grind
 example (x : Bool) : x ∈ support (pure x : ProbComp Bool) := by simp
 example (x : Bool) : x ∈ support (pure x : ProbComp Bool) := by grind
 
+example (α : Type) [SampleableType α] (x : α) : x ∈ support ($ᵗ α) := by simp
 example (α : Type) [SampleableType α] (x : α) : x ∈ support ($ᵗ α) := by grind
 
+example (α : Type) [SampleableType α] : (support ($ᵗ α)).Nonempty := by simp
 example (α : Type) [SampleableType α] : (support ($ᵗ α)).Nonempty := by grind
 
 /-! ## The support ↔ probability bridge
 A value has zero probability exactly when it is outside the support.
 
-target(simp): `simp` rewrites the `= 0` side but cannot close the `Iff`; `grind` discharges it. -/
+gap(simp): `simp` rewrites the `= 0` side to `x ∉ finSupport mx` and stops. Tagging
+`mem_finSupport_iff_mem_support` `@[simp]` is not the fix: library proofs use `a ∈ finSupport oa`
+as a *decidable* condition inside `dite` (`ProgramLogic/Relational/Quantitative.lean`), which the
+`support` form loses. -/
 
-example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] = 0 ↔ x ∉ support mx := by grind
+example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] = 0 ↔ x ∉ support mx := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): stops at the `finSupport` form
+  grind
 
 example (mx : ProbComp Bool) (x : Bool) : 0 < Pr[= x | mx] ↔ x ∈ support mx := by simp
 example (mx : ProbComp Bool) (x : Bool) : 0 < Pr[= x | mx] ↔ x ∈ support mx := by grind
@@ -264,15 +301,20 @@ An *event* has (non)zero probability exactly when some / no reachable output sat
 would saturate. -/
 
 example (mx : ProbComp Bool) (p : Bool → Prop) :
-    Pr[ p | mx] ≠ 0 ↔ {x ∈ support mx | p x}.Nonempty := by grind
+    Pr[ p | mx] ≠ 0 ↔ {x ∈ support mx | p x}.Nonempty := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): `Set.Nonempty` companion, `grind`-shaped
+  grind
 example (mx : ProbComp Bool) (p : Bool → Prop) :
     Pr[ p | mx] = 0 ↔ ¬ {x ∈ support mx | p x}.Nonempty := by grind
 
 /-! ## Structured supports
-target(grind): a non-trivial `<$>`/`do` support equality needs `simp`'s computation normalisation
-(and a set extensionality); `grind` would expand it instead. -/
+gap: a non-trivial `<$>`/`do` support equality needs `simp`'s computation normalisation and a set
+extensionality; `grind` would expand it instead, and `simp` stops at the image of the set
+literal. -/
 
 example : support (do let b ← $ᵗ Bool; pure (!b)) = Set.univ := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): the image of a finite set literal
+  fail_if_success grind  -- gap(grind, 2026-09-03): structured support
   ext b; cases b <;> simp
 
 /-! # 5. Evaluation distribution — `𝒮[_]` -/
@@ -290,10 +332,12 @@ example (mx : ProbComp Bool) : 𝒮[mx >>= pure] = 𝒮[mx] := by grind
 Adding a uniform key makes the ciphertext distribution independent of the message (`ZMod 2` — a
 one-bit XOR pad).
 
-target(grind): this needs the translation-invariance lemma to fire before `evalSPMF_uniformSample`
-unfolds the uniform draw, so it is `simp only`-terminal. -/
+gap: this needs the translation-invariance lemma to fire before `evalSPMF_uniformSample` unfolds
+the uniform draw, so it is `simp only`-terminal. -/
 
 example (msg : ZMod 2) : 𝒮[(msg + ·) <$> ($ᵗ (ZMod 2))] = 𝒮[$ᵗ (ZMod 2)] := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): the uniform draw unfolds first
+  fail_if_success grind  -- gap(grind, 2026-09-03): translation invariance is not a grind rule
   simp only [evalSPMF_add_left_uniform]
 
 /-! # 6. The shape of `do`
@@ -339,7 +383,9 @@ example : Pr[⊥ | nestedDraw] = 0 := by grind [nestedDraw]
 example : Pr[⊥ | branchToFin] = 0 := by grind [branchToFin]
 example : Pr[⊥ | fiveCoins] = 0 := by grind [fiveCoins]
 
-example : Pr[= false | coinThenNeg] = Pr[= true | $ᵗ Bool] := by simp [coinThenNeg]
+example : Pr[= false | coinThenNeg] = Pr[= true | $ᵗ Bool] := by
+  fail_if_success grind [coinThenNeg]  -- gap(grind, 2026-09-03): a `let :=` step under `do`
+  simp [coinThenNeg]
 
 /-- Abort unless the coin comes up `true`: fails with probability one half. -/
 def abortOnFalse : OptionT ProbComp Bool := do
@@ -347,6 +393,7 @@ def abortOnFalse : OptionT ProbComp Bool := do
   if b then pure true else failure
 
 example : Pr[⊥ | abortOnFalse] = 2⁻¹ := by
+  fail_if_success (simp [abortOnFalse]; done)  -- gap(simp, 2026-09-03): bind expansion, not simp
   simp [abortOnFalse, probFailure_bind_eq_add_tsum]
 
 /-! # 7. Cryptography prerequisites
@@ -355,19 +402,24 @@ probability, and outcome probabilities summing to one. -/
 
 example (guess : Fin 6) : Pr[= guess | $ᵗ (Fin 6)] = 6⁻¹ := by simp
 
-example : Pr[fun p => p.1 = p.2 | $ᵗ (Fin 6 × Fin 6)] = 6 / 36 := by simp; rfl
+example : Pr[fun p => p.1 = p.2 | $ᵗ (Fin 6 × Fin 6)] = 6 / 36 := by
+  fail_if_success (simp; done)  -- gap(simp, 2026-09-03): the filter card is not evaluated
+  fail_if_success grind  -- gap(grind, 2026-09-03): counting
+  simp; rfl
 
 example : ∑ k : Fin 6, Pr[= k | $ᵗ (Fin 6)] = 1 := sum_probOutput_eq_one (by simp)
 
 /-! # 8. Abstract carriers
 The same facts over an arbitrary `SampleableType` carrier. `grind` handles the symbolic ones
-(equiprobability, never-fails, nonempty support); `grind` cannot factor the applicative product, so
-the product equiprobability is `simp; grind` (`simp` factors, `grind` finishes). -/
+(equiprobability, never-fails, nonempty support) and, through the `@[grind norm]` factorization
+rule, the applicative product. -/
 
 section abstract
 variable (α β : Type) [SampleableType α] [SampleableType β]
 
-example (x y : α) : Pr[= x | $ᵗ α] = Pr[= y | $ᵗ α] := by grind
+example (x y : α) : Pr[= x | $ᵗ α] = Pr[= y | $ᵗ α] := by
+  fail_if_success simp  -- gap(simp, 2026-09-03): no progress on abstract equiprobability
+  grind
 
 example : support ($ᵗ α) = Set.univ := by simp
 example : support ($ᵗ α) = Set.univ := by grind

--- a/VCVioTest/ProbabilityTactics.lean
+++ b/VCVioTest/ProbabilityTactics.lean
@@ -16,7 +16,7 @@ distributions**, each discharged by a single *terminal* tactic — `simp` or `gr
 **gates `simp` and `grind` as stable terminal tactics** over this surface, so a regression in
 either surfaces here in isolation rather than deep inside a downstream proof.
 
-Conventions (the full rules are in `CONTRIBUTING.md`, *Tactic Gate Files*):
+Conventions (see *Normal forms and the tactic contract* in `docs/agents/probability.md`):
 * **Mirrors.** Where a fact is closed by *both* `simp` and `grind`, both are kept, so each tactic
   stays exercised on that shape. This is the bulk of the file.
 * **Gap pairs.** Where only one tactic closes a goal, the entry is a *gap pair*: a

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -324,9 +324,12 @@ the `withBadFlag`/`withBadUpdate`/`flattenStateT` run-shapes, `simulateQ_option_
 `VCVioTest/ProbabilityTactics.lean` is the living benchmark and **gate** for all of this: a broad
 corpus of probability / event / failure / support / distribution facts organised by category, each
 closed by a single *terminal* tactic. Where a fact closes by **both** `simp` and `grind`, both are
-kept (the mirror), so each tactic stays exercised on that shape; where only one closes, the gap is a
-`target(simp)` / `target(grind)` note. A regression in either tactic surfaces there in isolation.
-When adding probability automation, add the corresponding battery rows.
+kept (the mirror), so each tactic stays exercised on that shape; where only one closes, the entry
+is a *gap pair* (`fail_if_success (tac; done)` then the working closer, with a dated
+`gap(tac, …)` reason), so the gap is machine-checked and expires the moment the set improves. A
+regression in either tactic surfaces there in isolation. When adding probability automation, add
+the corresponding battery rows and retire the guards it makes obsolete. The rules are in
+*Normal forms and the tactic contract* below and in `CONTRIBUTING.md`.
 
 `VCVioTest/MonadProbability.lean` is the **generic-`m`** companion: the same gate over an abstract
 monad `m` with the EvalDist instance stack (`[LawfulMonadLiftT m SPMF]`, …) and over the concrete
@@ -345,6 +348,72 @@ disable a rule per call (`grind [-bind_pure]`), ignore the default set entirely
 (`grind only [the, lemmas, you, want]`), or unset a tag for a whole file
 (`attribute [-grind] bind_pure`). `grind?` reports a minimal `grind only [...]` call for a goal it
 closes, which is the easiest way to make a fragile call site independent of the default set.
+
+## Normal forms and the tactic contract
+
+The simp, grind and `gcongr` sets of the probability layer are designed around one *normal-form
+ladder*: one canonical spelling per rung, mass-left throughout, each rung reached from the one
+above it by an existing pathway rather than by a per-rung twin lemma.
+
+| rung | form | reached by |
+|---|---|---|
+| 0 closed | numerals, `(Fintype.card α)⁻¹`, `if … then 1 else 0`, `#{x \| p x} / Fintype.card α` | `simp` (`probOutput_pure/query/uniformSample/guard/ite`, `probOutput_bind_const`, `probOutput_map_equiv`) |
+| 1 finite sum | `∑ x, Pr[= x \| mx] * g x` | `simp` from rung 2 through Mathlib's `@[simp] tsum_fintype`; `Finset.sum_boole`/`sum_ite_eq` finish |
+| 2 tsum | `∑' x, Pr[= x \| mx] * g x`, which is `expectedValue mx g` | `grind` (bind expansion, `probOutput_bind_eq_tsum` is `@[grind =]`); `rw [probOutput_bind_eq_expectedValue]` when a `gcongr` head is wanted |
+| 3 integral | `∫⁻ x, g x ∂𝒟[mx]` | never a terminal form on a discrete carrier: the measure side reduces *into* the façade (singleton and expectation bridges), then rungs 2–0 apply |
+
+Mass-left is canonical: it is the orientation of Mathlib's `PMF.bind_apply`,
+`PMF.toMeasure_bind_apply` and Bochner `integral_fintype`, of `expectedValue`, and of every
+bind lemma in this library. Mathlib's `lintegral_countable'`/`lintegral_fintype` are mass-right;
+they meet this library exactly once, inside the proof of the measure-to-façade bridge, never as a
+normal form.
+
+**What each tactic promises.**
+
+- `simp` is the *structural* normalizer: it reaches a closed form when one exists, applies the
+  monad laws, and collapses `∑'` to `∑` on a `Fintype`. It never expands a bind into a `tsum`
+  (`gotchas.md` §10); `simp [probOutput_bind_eq_tsum]` is the documented one-step to the sum,
+  and on a `Fintype` that call lands on rung 1 with no library lemma involved.
+- `grind` is the *symbolic* closer after bind expansion: equiprobability, membership, directed
+  iffs, `bind`/`pure`-normalised structure. It is not an `ℝ≥0∞`/`Fintype.card` arithmetic engine
+  and must keep failing fast on the `Pr[…] = 0/1 ↔ …` characterization family
+  (`VCVioTest/GrindFailFast.lean`).
+- `gcongr` and `finiteness` are the *bound* closers, with `expectedValue` as the head symbol for
+  rung 2 (a bind is not a `gcongr` head; `probOutput_bind_eq_expectedValue` puts one there).
+  `expectedValue` is a `def` that `simp` does not unfold; `expectedValue_def` is a `rw`/`grind`
+  lemma.
+- The measure side has one public head, `𝒟[…]`. Its Giry laws (`evalDist_pure`, `evalDist_bind`,
+  `evalDist_map`, the const laws) are stated once; the singleton, event and expectation bridges
+  (`𝒟[mx] {x} = Pr[= x | mx]`, `∫⁻ x, g x ∂𝒟[mx] = expectedValue mx g`) are the only crossing
+  into the façade. There is no measure-side family of sum lemmas. (This rung is being completed
+  by the measure-bridge PR; until it lands the bridges are the `SPMF.toMeasure_*` lemmas.)
+
+**What the gates enforce.** The gate files (`VCVioTest/ProbabilityTactics.lean`,
+`MonadProbability.lean`, `GrindFailFast.lean`, `Tactic/*.lean`, `EvalDist/*.lean`) state
+"goal family → one terminal tactic" and are the gate for every change to these sets:
+
+1. *One terminal call.* A positive entry is `by <one tactic>` or a term.
+2. *Known gaps are machine-checked and self-expiring.* A gap is a pair: `fail_if_success
+   (tac; done)` on its own line, then the working closer, with a dated `gap(tac, date): reason`
+   comment. The guard errors as soon as the set improves, so the PR that closes a gap retires
+   the guard in the same diff. One guard covers a family of same-shaped entries when the family
+   is named in the section note. (`fail_if_success` takes a tactic sequence, so the closer must be
+   on its own line; bare `fail_if_success simp` passes only when `simp` makes *no progress*,
+   hence the `(tac; done)` form.)
+3. *No multi-call scripts.* A `;`/multi-line script is allowed only as the closer of a gap pair.
+   A one-call entry that stops closing is fixed in the set or filed as a dated gap pair, never by
+   adding a second call.
+4. *Normalizers pin their normal form* with `guard_target =ₛ …` after `simp only [S]`.
+5. *Negatives for every deliberate exclusion*: whatever these docs say is "deliberately not in
+   the default set" has a `fail_if_success` entry.
+6. *Fail fast stays fail fast*: a saturating `grind` is a deterministic timeout under the default
+   heartbeat limit, which escapes `fail_if_success` and fails the build; gate files never raise
+   the limit.
+
+Warnings in `VCVioTest` fail CI, so a stale entry (an unused tactic, a redundant `grind`
+parameter, a deprecated name) cannot linger. A PR that touches a simp/grind/`gcongr` set says
+which rung its lemmas target, which gate entries it adds and which guards it retires, and which
+library proofs got shorter; a set with no library caller is itself a finding.
 
 ## Common Mistakes
 

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -329,7 +329,7 @@ is a *gap pair* (`fail_if_success (tac; done)` then the working closer, with a d
 `gap(tac, …)` reason), so the gap is machine-checked and expires the moment the set improves. A
 regression in either tactic surfaces there in isolation. When adding probability automation, add
 the corresponding battery rows and retire the guards it makes obsolete. The rules are in
-*Normal forms and the tactic contract* below and in `CONTRIBUTING.md`.
+*Normal forms and the tactic contract* below.
 
 `VCVioTest/MonadProbability.lean` is the **generic-`m`** companion: the same gate over an abstract
 monad `m` with the EvalDist instance stack (`[LawfulMonadLiftT m SPMF]`, …) and over the concrete
@@ -394,7 +394,8 @@ normal form.
 `MonadProbability.lean`, `GrindFailFast.lean`, `Tactic/*.lean`, `EvalDist/*.lean`) state
 "goal family → one terminal tactic" and are the gate for every change to these sets:
 
-1. *One terminal call.* A positive entry is `by <one tactic>` or a term.
+1. *One terminal call.* A positive entry is `by <one tactic>` or a term: `simp`, `grind`,
+   `gcongr`, `finiteness`, `simp [S]`, or `simp only [S]`.
 2. *Known gaps are machine-checked and self-expiring.* A gap is a pair: `fail_if_success
    (tac; done)` on its own line, then the working closer, with a dated `gap(tac, date): reason`
    comment. The guard errors as soon as the set improves, so the PR that closes a gap retires
@@ -407,7 +408,9 @@ normal form.
 3. *No multi-call scripts.* A `;`/multi-line script is allowed only as the closer of a gap pair.
    A one-call entry that stops closing is fixed in the set or filed as a dated gap pair, never by
    adding a second call.
-4. *Normalizers pin their normal form* with `guard_target =ₛ …` after `simp only [S]`.
+4. *Normalizers pin their normal form.* For a normalizer such as `simp only [monad_norm]` or
+   `handler_step`, follow the normalizing call with `guard_target =ₛ <expected form>` and then
+   a closer.
 5. *Negatives for every deliberate exclusion*: whatever these docs say is "deliberately not in
    the default set" has a `fail_if_success` entry.
 6. *Fail fast stays fail fast*: a saturating `grind` is a deterministic timeout under the default

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -359,8 +359,8 @@ above it by an existing pathway rather than by a per-rung twin lemma.
 |---|---|---|
 | 0 closed | numerals, `(Fintype.card α)⁻¹`, `if … then 1 else 0`, `#{x \| p x} / Fintype.card α` | `simp` (`probOutput_pure/query/uniformSample/guard/ite`, `probOutput_bind_const`, `probOutput_map_equiv`) |
 | 1 finite sum | `∑ x, Pr[= x \| mx] * g x` | `simp` from rung 2 through Mathlib's `@[simp] tsum_fintype`; `Finset.sum_boole`/`sum_ite_eq` finish |
-| 2 tsum | `∑' x, Pr[= x \| mx] * g x`, which is `expectedValue mx g` | `grind` (bind expansion, `probOutput_bind_eq_tsum` is `@[grind =]`); `rw [probOutput_bind_eq_expectedValue]` when a `gcongr` head is wanted |
-| 3 integral | `∫⁻ x, g x ∂𝒟[mx]` | never a terminal form on a discrete carrier: the measure side reduces *into* the façade (singleton and expectation bridges), then rungs 2–0 apply |
+| 2 tsum | `∑' x, Pr[= x \| mx] * g x`, which is `expectedValue mx g` | `grind` (bind expansion, `probOutput_bind_eq_tsum` is `@[grind =]`); `rw [probOutput_bind_eq_tsum, ← expectedValue_def]` exposes the expectation head |
+| 3 integral | `∫⁻ x, g x ∂𝒟[mx]` | countable discrete compatibility measures admit the expectation bridge below; measure-native proofs can keep this form for Mathlib's integration API |
 
 Mass-left is canonical: it is the orientation of Mathlib's `PMF.bind_apply`,
 `PMF.toMeasure_bind_apply` and Bochner `integral_fintype`, of `expectedValue`, and of every
@@ -379,14 +379,16 @@ normal form.
   and must keep failing fast on the `Pr[…] = 0/1 ↔ …` characterization family
   (`VCVioTest/GrindFailFast.lean`).
 - `gcongr` and `finiteness` are the *bound* closers, with `expectedValue` as the head symbol for
-  rung 2 (a bind is not a `gcongr` head; `probOutput_bind_eq_expectedValue` puts one there).
-  `expectedValue` is a `def` that `simp` does not unfold; `expectedValue_def` is a `rw`/`grind`
-  lemma.
-- The measure side has one public head, `𝒟[…]`. Its Giry laws (`evalDist_pure`, `evalDist_bind`,
-  `evalDist_map`, the const laws) are stated once; the singleton, event and expectation bridges
-  (`𝒟[mx] {x} = Pr[= x | mx]`, `∫⁻ x, g x ∂𝒟[mx] = expectedValue mx g`) are the only crossing
-  into the façade. There is no measure-side family of sum lemmas. (This rung is being completed
-  by the measure-bridge PR; until it lands the bridges are the `SPMF.toMeasure_*` lemmas.)
+  rung 2. Rewrite a bind with `probOutput_bind_eq_tsum` and fold the sum with
+  `← expectedValue_def` to expose that head. `expectedValue` is a `def` that `simp` does not
+  unfold; its untagged `expectedValue_def` equation can be supplied explicitly to `rw` or `grind`.
+- The measure side uses `𝒟[…]`, with `evalDist_pure` and `evalDist_bind` under
+  `LawfulEvalDistSemantics`; bind also requires a measurable continuation. For `FreeM`,
+  `FreeM.evalDist_apply_singleton` and `FreeM.evalDist_apply_setOf` connect observations to
+  `Pr[...]` under their countability, measurability, and query-specification agreement hypotheses.
+  `OracleComp.EvalDist.expectedValue_eq_lintegral` identifies expectations with integrals against
+  the compatibility measure `OracleComp.EvalDist.toMeasure` on countable discrete result spaces.
+  These are explicit coherence boundaries; measure-native proofs keep their measure denotation.
 
 **What the gates enforce.** The gate files (`VCVioTest/ProbabilityTactics.lean`,
 `MonadProbability.lean`, `GrindFailFast.lean`, `Tactic/*.lean`, `EvalDist/*.lean`) state
@@ -399,7 +401,9 @@ normal form.
    the guard in the same diff. One guard covers a family of same-shaped entries when the family
    is named in the section note. (`fail_if_success` takes a tactic sequence, so the closer must be
    on its own line; bare `fail_if_success simp` passes only when `simp` makes *no progress*,
-   hence the `(tac; done)` form.)
+   hence the `(tac; done)` form for partial-progress gaps. Explicit no-progress checks keep
+   bare `fail_if_success simp` to avoid an unreachable `done`. Bare `fail_if_success grind`
+   already tests closure.)
 3. *No multi-call scripts.* A `;`/multi-line script is allowed only as the closer of a gap pair.
    A one-call entry that stops closing is fixed in the set or filed as a dated gap pair, never by
    adding a second call.


### PR DESCRIPTION
Probability tactic tests now fail when a recorded automation gap closes, and CI rejects warnings in the framework test library.

- Pair known gaps with failure guards and dated reasons; use `(simp; done)` for partial-progress gaps and bare guards for explicit no-progress checks. Add missing `simp`/`grind` mirrors while retaining the deliberate fail-fast exclusions.
- Add `grind norm` to the three `evalSPMF` applicative homomorphism laws, enabling single-call `grind` proofs for `<*>`, `<*`, and `*>`. The equations and existing `simp` behavior are unchanged.
- Capture the canary build log with `pipefail` and enforce the existing warning checker against `VCVioTest` paths, excluding replayed dependency warnings.
- Keep detailed tactic-test conventions in `docs/agents/probability.md`, with a short link from `CONTRIBUTING.md`. Document probability normal forms and the current measure coherence APIs with their required assumptions.

Validation: all seven production libraries plus `VCVioTest` and `LatticeCryptoTest`; no non-sorry source warnings or test warnings; style, documentation, import boundaries, and axiom-baseline checks. Standalone probes verify the documented expectation rewrite, warning-path filtering, and preservation of pipeline failures.
