### PR TITLE
refactor(EvalDist): prove the bind-layer bounds through expectedValue and gcongr

### DIFF
--- a/Examples/CommitmentScheme/Hiding/CountBounds.lean
+++ b/Examples/CommitmentScheme/Hiding/CountBounds.lean
@@ -1044,17 +1044,12 @@ lemma probEvent_countAll_bad_le_wp_countPred
     OracleComp.ProgramLogic.wp
       ((simulateQ hidingImplCountAll (hidingOa A s)).run (∅, fun _ => 0))
       (fun z : Bool × (QueryCache (CMOracle M S C) × (S → ℕ)) => (z.2.2 s - 1 : ℝ≥0∞)) := by
-  rw [OracleComp.ProgramLogic.probEvent_eq_wp_propInd,
-    OracleComp.ProgramLogic.wp_eq_tsum, OracleComp.ProgramLogic.wp_eq_tsum]
-  refine ENNReal.tsum_le_tsum fun z => ?_
-  by_cases hz : z ∈ support ((simulateQ hidingImplCountAll (hidingOa A s)).run (∅, fun _ => 0))
-  · simp only [OracleComp.ProgramLogic.propInd_eq_ite]
-    exact mul_le_mul'
-      le_rfl
-      (bad_indicator_le_count_pred_of_mem_support_run_hidingImplCountAll
-        (M := M) (S := S) (C := C) A s hz)
-  · rw [probOutput_eq_zero_of_not_mem_support hz]
-    simp [OracleComp.ProgramLogic.propInd_eq_ite]
+  rw [OracleComp.ProgramLogic.probEvent_eq_wp_propInd, OracleComp.ProgramLogic.wp_eq_expectedValue,
+    OracleComp.ProgramLogic.wp_eq_expectedValue]
+  gcongr with z hz
+  simp only [OracleComp.ProgramLogic.propInd_eq_ite]
+  exact bad_indicator_le_count_pred_of_mem_support_run_hidingImplCountAll
+    (M := M) (S := S) (C := C) A s hz
 
 /- Fixed-salt expectation bound for the counted excess at the challenge salt. -/
 lemma wp_countPred_le_queryBound_of_run_hidingImplCountAll

--- a/Examples/CommitmentScheme/Hiding/LoggingBounds/Average.lean
+++ b/Examples/CommitmentScheme/Hiding/LoggingBounds/Average.lean
@@ -843,11 +843,7 @@ lemma sum_wp_distinguish_incrementIndicators_le_queryResidual_of_choose_count_su
           OracleComp.ProgramLogic.wp
             ((simulateQ hidingImplCountAll (A.distinguish qchoose.1.2 cm)).run qchoose.2)
             (fun z : Bool × HidingCountState M S C => (z.2.2 s - qchoose.2.2 s : ℝ≥0∞))) := by
-    refine Finset.sum_le_sum ?_
-    intro s hs
-    refine OracleComp.ProgramLogic.wp_mono
-      ((simulateQ hidingImplCountAll (A.distinguish qchoose.1.2 cm)).run qchoose.2) ?_
-    intro z
+    gcongr with s hs z
     by_cases hslt : qchoose.2.2 s < z.2.2 s
     · simp only [OracleComp.ProgramLogic.propInd, if_pos hslt]
       exact_mod_cast (Nat.succ_le_of_lt (Nat.sub_pos_of_lt hslt))

--- a/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
+++ b/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
@@ -315,11 +315,7 @@ lemma sum_wp_distinguish_incrementIndicators_le_queryResidual_of_choose_count_su
             ((simulateQ hidingImplCountAll (A.distinguish qchoose.1.2 cm)).run qch.2)
             (fun z : Bool × HidingCountState M S C =>
               (z.2.2 s - qch.2.2 s : ℝ≥0∞))) := by
-    refine Finset.sum_le_sum ?_
-    intro s hs
-    refine OracleComp.ProgramLogic.wp_mono
-      ((simulateQ hidingImplCountAll (A.distinguish qchoose.1.2 cm)).run qch.2) ?_
-    intro z
+    gcongr with s hs z
     by_cases hslt : qch.2.2 s < z.2.2 s
     · simp [OracleComp.ProgramLogic.propInd, hslt]
       have hsub : 1 ≤ (z.2.2 s - qch.2.2 s : ℕ) := by

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -1050,6 +1050,18 @@ theorem expectedValue_add (mx : m α) (g h : α → ℝ≥0∞) :
   simp only [expectedValue, mul_add]
   exact ENNReal.tsum_add
 
+/-- The expectation of an indicator is the event probability. -/
+theorem expectedValue_ite_one (mx : m α) (p : α → Prop) [DecidablePred p] :
+    expectedValue mx (fun x => if p x then 1 else 0) = Pr[ p | mx] := by
+  rw [expectedValue_def, probEvent_eq_tsum_ite]
+  exact tsum_congr fun x => by split_ifs <;> simp
+
+/-- A constant factor scales the expectation. -/
+theorem expectedValue_mul_const (mx : m α) (g : α → ℝ≥0∞) (c : ℝ≥0∞) :
+    expectedValue mx (fun x => g x * c) = expectedValue mx g * c := by
+  rw [expectedValue_def, expectedValue_def, ← ENNReal.tsum_mul_right]
+  exact tsum_congr fun x => (mul_assoc _ _ _).symm
+
 variable [MonadLiftT m SetM] [EvalDistCompatible m]
 
 /-- `expectedValue_mono` with the hypothesis restricted to `support mx`. After `gcongr with x hx`

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -283,14 +283,11 @@ lemma probEvent_bind_le_probEvent [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (h : ∀ x ∈ support mx, ¬ p x → Pr[ q | my x] = 0) :
     Pr[ q | mx >>= my] ≤ Pr[ p | mx] := by
   classical
-  rw [probEvent_bind_eq_tsum, probEvent_eq_tsum_indicator]
-  refine ENNReal.tsum_le_tsum fun x ↦ ?_
+  rw [probEvent_bind_eq_expectedValue, ← expectedValue_ite_one]
+  gcongr with x hx
   by_cases hp : p x
-  · refine le_trans (mul_le_mul' le_rfl probEvent_le_one) ?_
-    simp [hp]
-  · by_cases hx : x ∈ support mx
-    · simp [h x hx hp]
-    · simp [probOutput_eq_zero_of_not_mem_support hx]
+  · simp only [if_pos hp]; exact probEvent_le_one
+  · simp only [if_neg hp, h x hx hp, le_refl]
 
 /-- If a continuation event is bounded by `ε` exactly on a prefix event and is
 impossible off that event, then only the prefix mass is charged. -/
@@ -301,13 +298,11 @@ lemma probEvent_bind_le_probEvent_mul [MonadLiftT m SPMF] [LawfulMonadLiftT m SP
     (hzero : ∀ x ∈ support mx, ¬ p x → Pr[ q | my x] = 0) :
     Pr[ q | mx >>= my] ≤ Pr[ p | mx] * ε := by
   classical
-  rw [probEvent_bind_eq_tsum, probEvent_eq_tsum_indicator, ← ENNReal.tsum_mul_right]
-  refine ENNReal.tsum_le_tsum fun x ↦ ?_
-  by_cases hx : x ∈ support mx
-  · by_cases hp : p x
-    · exact (mul_le_mul' le_rfl (hle x hx hp)).trans_eq (by simp [hp])
-    · simp [hp, hzero x hx hp]
-  · simp [probOutput_eq_zero_of_not_mem_support hx]
+  rw [probEvent_bind_eq_expectedValue, ← expectedValue_ite_one, ← expectedValue_mul_const]
+  gcongr with x hx
+  by_cases hp : p x
+  · simp only [if_pos hp, one_mul]; exact hle x hx hp
+  · simp only [if_neg hp, zero_mul, hzero x hx hp, le_refl]
 
 /-- Division-form corollary of `probEvent_bind_le_probEvent_mul`. -/
 lemma probEvent_bind_le_probEvent_div [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
@@ -335,24 +330,18 @@ lemma probEvent_bind_le_probEvent_add [MonadLiftT m SPMF] [LawfulMonadLiftT m SP
     (h : ∀ x ∈ support mx, ¬ p x → Pr[ q | my x] ≤ ε) :
     Pr[ q | mx >>= my] ≤ Pr[ p | mx] + ε := by
   classical
-  rw [probEvent_bind_eq_tsum, probEvent_eq_tsum_indicator]
-  calc ∑' x, Pr[= x | mx] * Pr[ q | my x]
-      ≤ ∑' x, ({x | p x}.indicator (Pr[= · | mx]) x
-          + {x | ¬ p x}.indicator (fun x ↦ Pr[= x | mx] * ε) x) := by
-        refine ENNReal.tsum_le_tsum fun x ↦ ?_
+  rw [probEvent_bind_eq_expectedValue]
+  calc expectedValue mx (fun x => Pr[ q | my x])
+      ≤ expectedValue mx (fun x => (if p x then 1 else 0) + ε) := by
+        gcongr with x hx
         by_cases hp : p x
-        · refine le_trans (mul_le_mul' le_rfl probEvent_le_one) ?_
-          simp [hp]
-        · by_cases hx : x ∈ support mx
-          · refine le_trans (mul_le_mul' le_rfl (h x hx hp)) ?_
-            simp [hp]
-          · simp [probOutput_eq_zero_of_not_mem_support hx]
-    _ = (∑' x, {x | p x}.indicator (Pr[= · | mx]) x)
-          + ∑' x, {x | ¬ p x}.indicator (fun x ↦ Pr[= x | mx] * ε) x := ENNReal.tsum_add
-    _ ≤ (∑' x, {x | p x}.indicator (Pr[= · | mx]) x) + ε := by
+        · simp only [if_pos hp]; exact probEvent_le_one.trans le_self_add
+        · simp only [if_neg hp, zero_add]; exact h x hx hp
+    _ = Pr[ p | mx] + expectedValue mx (fun _ => ε) := by
+        rw [expectedValue_add, expectedValue_ite_one]
+    _ ≤ Pr[ p | mx] + ε := by
         gcongr
-        exact (ENNReal.tsum_le_tsum fun x ↦ Set.indicator_le_self _ _ x).trans
-          (tsum_probOutput_mul_le_of_le mx fun _ => le_rfl)
+        exact expectedValue_le_of_le mx fun _ => le_rfl
 
 /-- Convex prefix-event split for a bind. The off-prefix tail bound `ε` is charged
 only on the mass outside `p`, giving `Pr[p] + (1 - Pr[p]) * ε`. -/
@@ -362,35 +351,21 @@ lemma probEvent_bind_le_probEvent_convex [MonadLiftT m SPMF] [LawfulMonadLiftT m
     (h : ∀ x ∈ support mx, ¬ p x → Pr[ q | my x] ≤ ε) :
     Pr[ q | mx >>= my] ≤ Pr[ p | mx] + (1 - Pr[ p | mx]) * ε := by
   classical
-  have hsplit : Pr[ q | mx >>= my] ≤ Pr[ p | mx] + Pr[ fun x ↦ ¬ p x | mx] * ε := by
-    rw [probEvent_bind_eq_tsum, probEvent_eq_tsum_indicator (p := p),
-      probEvent_eq_tsum_indicator (p := fun x ↦ ¬ p x)]
-    calc ∑' x, Pr[= x | mx] * Pr[ q | my x]
-        ≤ ∑' x, ({x | p x}.indicator (Pr[= · | mx]) x
-            + {x | ¬ p x}.indicator (fun x ↦ Pr[= x | mx] * ε) x) := by
-          refine ENNReal.tsum_le_tsum fun x ↦ ?_
-          by_cases hp : p x
-          · refine le_trans (mul_le_mul' le_rfl probEvent_le_one) ?_
-            simp [hp]
-          · by_cases hx : x ∈ support mx
-            · refine le_trans (mul_le_mul' le_rfl (h x hx hp)) ?_
-              simp [hp]
-            · simp [probOutput_eq_zero_of_not_mem_support hx]
-      _ = (∑' x, {x | p x}.indicator (Pr[= · | mx]) x)
-            + ∑' x, {x | ¬ p x}.indicator (fun x ↦ Pr[= x | mx] * ε) x :=
-          ENNReal.tsum_add
-      _ = (∑' x, {x | p x}.indicator (Pr[= · | mx]) x)
-            + (∑' x, {x | ¬ p x}.indicator (Pr[= · | mx]) x) * ε := by
-          rw [← ENNReal.tsum_mul_right]
-          refine congrArg _ (tsum_congr fun x ↦ ?_)
-          by_cases hp : p x <;> simp [Set.indicator, hp]
-  have hle_one : Pr[ p | mx] + Pr[ fun x ↦ ¬ p x | mx] ≤ 1 := by
-    rw [probEvent_eq_tsum_indicator (p := p), probEvent_eq_tsum_indicator (p := fun x ↦ ¬ p x),
-      ← ENNReal.tsum_add]
-    refine le_trans (ENNReal.tsum_le_tsum fun x ↦ ?_) (tsum_probOutput_le_one (mx := mx))
-    by_cases hp : p x <;> simp [Set.indicator, hp]
-  refine le_trans hsplit (add_le_add le_rfl (mul_le_mul' ?_ le_rfl))
-  exact ENNReal.le_sub_of_add_le_left probEvent_ne_top hle_one
+  rw [probEvent_bind_eq_expectedValue]
+  calc expectedValue mx (fun x => Pr[ q | my x])
+      ≤ expectedValue mx (fun x => (if p x then 1 else 0) + (if ¬ p x then 1 else 0) * ε) := by
+        gcongr with x hx
+        by_cases hp : p x
+        · simp only [if_pos hp, if_neg (not_not_intro hp), zero_mul, add_zero]
+          exact probEvent_le_one
+        · simp only [if_neg hp, if_pos hp, zero_add, one_mul]; exact h x hx hp
+    _ = Pr[ p | mx] + Pr[ fun x => ¬ p x | mx] * ε := by
+        rw [expectedValue_add, expectedValue_mul_const, expectedValue_ite_one,
+          expectedValue_ite_one]
+    _ ≤ Pr[ p | mx] + (1 - Pr[ p | mx]) * ε := by
+        gcongr
+        exact ENNReal.le_sub_of_add_le_left probEvent_ne_top
+          ((probEvent_compl mx p).trans_le tsub_le_self)
 
 lemma probOutput_bind_eq_sum_finSupport [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     [MonadLiftT m SetM] [EvalDistCompatible m] [HasEvalFinset m]

--- a/VCVio/EvalDist/Monad/Disagreement.lean
+++ b/VCVio/EvalDist/Monad/Disagreement.lean
@@ -29,7 +29,7 @@ specialisation is `m = ProbComp`.
 
 universe u v
 
-open ENNReal
+open ENNReal OracleComp.EvalDist
 
 variable {α β γ : Type u} {m : Type u → Type v} [Monad m]
   [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
@@ -44,27 +44,20 @@ lemma probEvent_bind_le_add_of_disagree {mx : m α}
     (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + ε₂) :
     Pr[ q | mx >>= my] ≤ Pr[ q | mx >>= oc] + ε₁ + ε₂ := by
   classical
-  have := Classical.decPred q
-  rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
-  calc ∑' x, Pr[= x | mx] * Pr[q | my x]
-      ≤ ∑' x, (Pr[= x | mx] * Pr[q | oc x]
-            + (if D x then Pr[= x | mx] else 0) + Pr[= x | mx] * ε₂) := by
-        refine ENNReal.tsum_le_tsum fun x => ?_
-        by_cases hx : x ∈ support mx
-        · by_cases hDx : D x
-          · simp only [if_pos hDx]
-            exact (mul_le_of_le_one_right' probEvent_le_one).trans
-              (le_add_right (le_add_left le_rfl))
-          · simp only [if_neg hDx, add_zero]
-            exact (mul_le_mul' le_rfl (h x hx hDx)).trans_eq (left_distrib ..)
-        · simp [probOutput_eq_zero_of_not_mem_support hx]
-    _ = (∑' x, Pr[= x | mx] * Pr[q | oc x])
-          + (∑' x, if D x then Pr[= x | mx] else 0) + (∑' x, Pr[= x | mx] * ε₂) := by
-        rw [ENNReal.tsum_add, ENNReal.tsum_add]
-    _ ≤ (∑' x, Pr[= x | mx] * Pr[q | oc x]) + ε₁ + ε₂ := by
+  rw [probEvent_bind_eq_expectedValue, probEvent_bind_eq_expectedValue]
+  calc expectedValue mx (fun x => Pr[ q | my x])
+      ≤ expectedValue mx (fun x => Pr[ q | oc x] + (if D x then 1 else 0) + ε₂) := by
+        gcongr with x hx
+        by_cases hDx : D x
+        · simp only [if_pos hDx]
+          exact probEvent_le_one.trans (le_add_right (le_add_left le_rfl))
+        · simp only [if_neg hDx, add_zero]; exact h x hx hDx
+    _ = expectedValue mx (fun x => Pr[ q | oc x]) + Pr[ D | mx]
+          + expectedValue mx (fun _ => ε₂) := by
+        rw [expectedValue_add, expectedValue_add, expectedValue_ite_one]
+    _ ≤ expectedValue mx (fun x => Pr[ q | oc x]) + ε₁ + ε₂ := by
         gcongr
-        · rw [← probEvent_eq_tsum_ite]; exact hD
-        · exact tsum_probOutput_mul_le_of_le mx fun _ => le_rfl
+        exact expectedValue_le_of_le mx fun _ => le_rfl
 
 /-- **Three-way disagreement-aware additive bind bound (hop A).** A coupled three-world variant of
 `probEvent_bind_le_add_of_disagree`: the three worlds share the sampling computation `mx`, and at
@@ -77,28 +70,22 @@ lemma probEvent_bind_le_add_bad_of_disagree {mx : m α}
     (hbad : ∀ x ∈ support mx, D x → Pr[ r | ob x] = 1)
     (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + ε) :
     Pr[ q | mx >>= my] ≤ Pr[ q | mx >>= oc] + Pr[ r | mx >>= ob] + ε := by
-  classical
-  have := Classical.decPred q
-  have := Classical.decPred r
-  rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
-  calc ∑' x, Pr[= x | mx] * Pr[q | my x]
-      ≤ ∑' x, (Pr[= x | mx] * Pr[q | oc x]
-            + Pr[= x | mx] * Pr[r | ob x] + Pr[= x | mx] * ε) := by
-        refine ENNReal.tsum_le_tsum fun x => ?_
-        by_cases hx : x ∈ support mx
-        · by_cases hDx : D x
-          · exact ((mul_le_mul' le_rfl probEvent_le_one).trans_eq
-              (by rw [hbad x hx hDx])).trans (le_add_right (le_add_left le_rfl))
-          · exact ((mul_le_mul' le_rfl (h x hx hDx)).trans_eq (left_distrib ..)).trans
-              (add_le_add (le_add_right le_rfl) le_rfl)
-        · simp [probOutput_eq_zero_of_not_mem_support hx]
-    _ = (∑' x, Pr[= x | mx] * Pr[q | oc x])
-          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + (∑' x, Pr[= x | mx] * ε) := by
-        rw [ENNReal.tsum_add, ENNReal.tsum_add]
-    _ ≤ (∑' x, Pr[= x | mx] * Pr[q | oc x])
-          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + ε := by
+  rw [probEvent_bind_eq_expectedValue, probEvent_bind_eq_expectedValue,
+    probEvent_bind_eq_expectedValue]
+  calc expectedValue mx (fun x => Pr[ q | my x])
+      ≤ expectedValue mx (fun x => Pr[ q | oc x] + Pr[ r | ob x] + ε) := by
+        gcongr with x hx
+        by_cases hDx : D x
+        · rw [hbad x hx hDx]
+          exact probEvent_le_one.trans (le_add_right (le_add_left le_rfl))
+        · exact (h x hx hDx).trans (add_le_add (le_add_right le_rfl) le_rfl)
+    _ = expectedValue mx (fun x => Pr[ q | oc x]) + expectedValue mx (fun x => Pr[ r | ob x])
+          + expectedValue mx (fun _ => ε) := by
+        rw [expectedValue_add, expectedValue_add]
+    _ ≤ expectedValue mx (fun x => Pr[ q | oc x]) + expectedValue mx (fun x => Pr[ r | ob x])
+          + ε := by
         gcongr
-        exact tsum_probOutput_mul_le_of_le mx fun _ => le_rfl
+        exact expectedValue_le_of_le mx fun _ => le_rfl
 
 /-- **Four-way disagreement-aware additive bind bound (hop A).** A strengthening of
 `probEvent_bind_le_add_bad_of_disagree`: the per-step inductive hypothesis itself carries a
@@ -112,27 +99,22 @@ lemma probEvent_bind_le_add_bad_of_disagree' {mx : m α}
     (hbad : ∀ x ∈ support mx, D x → Pr[ r | ob x] = 1)
     (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + Pr[ r | ob x] + ε) :
     Pr[ q | mx >>= my] ≤ Pr[ q | mx >>= oc] + Pr[ r | mx >>= ob] + ε := by
-  classical
-  have := Classical.decPred q
-  have := Classical.decPred r
-  rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
-  calc ∑' x, Pr[= x | mx] * Pr[q | my x]
-      ≤ ∑' x, (Pr[= x | mx] * Pr[q | oc x]
-            + Pr[= x | mx] * Pr[r | ob x] + Pr[= x | mx] * ε) := by
-        refine ENNReal.tsum_le_tsum fun x => ?_
-        by_cases hx : x ∈ support mx
-        · by_cases hDx : D x
-          · exact ((mul_le_mul' le_rfl probEvent_le_one).trans_eq
-              (by rw [hbad x hx hDx])).trans (le_add_right (le_add_left le_rfl))
-          · exact (mul_le_mul' le_rfl (h x hx hDx)).trans_eq (by rw [left_distrib, left_distrib])
-        · simp [probOutput_eq_zero_of_not_mem_support hx]
-    _ = (∑' x, Pr[= x | mx] * Pr[q | oc x])
-          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + (∑' x, Pr[= x | mx] * ε) := by
-        rw [ENNReal.tsum_add, ENNReal.tsum_add]
-    _ ≤ (∑' x, Pr[= x | mx] * Pr[q | oc x])
-          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + ε := by
+  rw [probEvent_bind_eq_expectedValue, probEvent_bind_eq_expectedValue,
+    probEvent_bind_eq_expectedValue]
+  calc expectedValue mx (fun x => Pr[ q | my x])
+      ≤ expectedValue mx (fun x => Pr[ q | oc x] + Pr[ r | ob x] + ε) := by
+        gcongr with x hx
+        by_cases hDx : D x
+        · rw [hbad x hx hDx]
+          exact probEvent_le_one.trans (le_add_right (le_add_left le_rfl))
+        · exact h x hx hDx
+    _ = expectedValue mx (fun x => Pr[ q | oc x]) + expectedValue mx (fun x => Pr[ r | ob x])
+          + expectedValue mx (fun _ => ε) := by
+        rw [expectedValue_add, expectedValue_add]
+    _ ≤ expectedValue mx (fun x => Pr[ q | oc x]) + expectedValue mx (fun x => Pr[ r | ob x])
+          + ε := by
         gcongr
-        exact tsum_probOutput_mul_le_of_le mx fun _ => le_rfl
+        exact expectedValue_le_of_le mx fun _ => le_rfl
 
 /-- **Four-way disagreement+bad additive bind bound.** A merge of
 `probEvent_bind_le_add_of_disagree` with the three-world `probEvent_bind_le_add_bad_of_disagree`:
@@ -146,29 +128,20 @@ lemma probEvent_bind_le_add_bad_disagree {mx : m α}
     (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + Pr[ r | ob x] + ε₂) :
     Pr[ q | mx >>= my] ≤ Pr[ q | mx >>= oc] + Pr[ r | mx >>= ob] + ε₁ + ε₂ := by
   classical
-  have := Classical.decPred q
-  have := Classical.decPred r
-  rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
-  calc ∑' x, Pr[= x | mx] * Pr[q | my x]
-      ≤ ∑' x, (Pr[= x | mx] * Pr[q | oc x]
-            + Pr[= x | mx] * Pr[r | ob x] + (if D x then Pr[= x | mx] else 0)
-            + Pr[= x | mx] * ε₂) := by
-        refine ENNReal.tsum_le_tsum fun x => ?_
-        by_cases hx : x ∈ support mx
-        · by_cases hDx : D x
-          · simp only [if_pos hDx]
-            exact (mul_le_of_le_one_right' probEvent_le_one).trans
-              (le_add_right (le_add_left le_rfl))
-          · simp only [if_neg hDx, add_zero]
-            exact (mul_le_mul' le_rfl (h x hx hDx)).trans_eq
-              (by rw [left_distrib, left_distrib])
-        · simp [probOutput_eq_zero_of_not_mem_support hx]
-    _ = (∑' x, Pr[= x | mx] * Pr[q | oc x])
-          + (∑' x, Pr[= x | mx] * Pr[r | ob x])
-          + (∑' x, if D x then Pr[= x | mx] else 0) + (∑' x, Pr[= x | mx] * ε₂) := by
-        rw [ENNReal.tsum_add, ENNReal.tsum_add, ENNReal.tsum_add]
-    _ ≤ (∑' x, Pr[= x | mx] * Pr[q | oc x])
-          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + ε₁ + ε₂ := by
+  rw [probEvent_bind_eq_expectedValue, probEvent_bind_eq_expectedValue,
+    probEvent_bind_eq_expectedValue]
+  calc expectedValue mx (fun x => Pr[ q | my x])
+      ≤ expectedValue mx
+          (fun x => Pr[ q | oc x] + Pr[ r | ob x] + (if D x then 1 else 0) + ε₂) := by
+        gcongr with x hx
+        by_cases hDx : D x
+        · simp only [if_pos hDx]
+          exact probEvent_le_one.trans (le_add_right (le_add_left le_rfl))
+        · simp only [if_neg hDx, add_zero]; exact h x hx hDx
+    _ = expectedValue mx (fun x => Pr[ q | oc x]) + expectedValue mx (fun x => Pr[ r | ob x])
+          + Pr[ D | mx] + expectedValue mx (fun _ => ε₂) := by
+        rw [expectedValue_add, expectedValue_add, expectedValue_add, expectedValue_ite_one]
+    _ ≤ expectedValue mx (fun x => Pr[ q | oc x]) + expectedValue mx (fun x => Pr[ r | ob x])
+          + ε₁ + ε₂ := by
         gcongr
-        · rw [← probEvent_eq_tsum_ite]; exact hD
-        · exact tsum_probOutput_mul_le_of_le mx fun _ => le_rfl
+        exact expectedValue_le_of_le mx fun _ => le_rfl

--- a/VCVio/ProgramLogic/Unary/HoareTriple.lean
+++ b/VCVio/ProgramLogic/Unary/HoareTriple.lean
@@ -91,6 +91,17 @@ theorem wp_eq_mAlgOrdered_wp (oa : OracleComp spec α) (post : α → ℝ≥0∞
     wp oa post =
       MAlgOrdered.wp (m := OracleComp spec) (l := ℝ≥0∞) oa post := rfl
 
+/-- `wp` is the expectation of the postcondition under the output distribution. This is the
+bridge to the `expectedValue` laws; it is a `rw` target, not a simp lemma, because `wp` stays the
+head the program-logic tactics match on. -/
+theorem wp_eq_expectedValue (oa : OracleComp spec α) (post : α → ℝ≥0∞) :
+    wp oa post = OracleComp.EvalDist.expectedValue oa post := by
+  rw [wp_eq_mAlgOrdered_wp]
+  change μ (oa >>= fun a => pure (post a)) = _
+  unfold μ
+  rw [OracleComp.EvalDist.expectedValue_bind]
+  simp only [OracleComp.EvalDist.expectedValue_pure]
+
 /-- Bridge between Loom2's inductive `Std.Do'.Triple` and Mathlib's `≤` on
 `ℝ≥0∞`. Loom2 defines `Std.Do'.Triple.iff` against
 `Lean.Order.PartialOrder.rel`; on `ℝ≥0∞` our `Lean.Order.PartialOrder`
@@ -196,11 +207,13 @@ theorem triple_toLE
         (fun s => wp (xs.foldlM f s) post) := by
   rw [List.foldlM_cons, wp_bind]
 
+/-- `wp` is monotone in the postcondition; `gcongr` descends through it. -/
+@[gcongr]
 theorem wp_mono (oa : OracleComp spec α) {post post' : α → ℝ≥0∞}
     (hpost : ∀ x, post x ≤ post' x) :
     wp oa post ≤ wp oa post' := by
-  simp only [wp_eq_mAlgOrdered_wp]
-  exact MAlgOrdered.wp_mono (m := OracleComp spec) (l := ℝ≥0∞) oa hpost
+  rw [wp_eq_expectedValue, wp_eq_expectedValue]
+  exact OracleComp.EvalDist.expectedValue_mono oa hpost
 
 @[game_rule] theorem wp_map (f : α → β) (oa : OracleComp spec α) (post : β → ℝ≥0∞) :
     wp (f <$> oa) post =
@@ -212,31 +225,27 @@ theorem wp_mono (oa : OracleComp spec α) {post post' : α → ℝ≥0∞}
 /-- General unfolding: `wp` as weighted sum over output probabilities. -/
 theorem wp_eq_tsum (oa : OracleComp spec α) (post : α → ℝ≥0∞) :
     wp oa post = ∑' x, Pr[= x | oa] * post x := by
-  rw [wp_eq_mAlgOrdered_wp, MAlgOrdered.wp]
-  change μ (oa >>= fun a => pure (post a)) = _
-  rw [μ_bind_eq_tsum]
-  refine tsum_congr fun x => congrArg (Pr[= x | oa] * ·) ?_
-  have : DecidableEq ℝ≥0∞ := Classical.decEq _
-  simp [μ, probOutput_pure]
+  rw [wp_eq_expectedValue, OracleComp.EvalDist.expectedValue_def]
 
 @[simp] theorem wp_const (oa : OracleComp spec α) (c : ℝ≥0∞) :
     wp oa (fun _ => c) = c := by
-  rw [wp_eq_tsum, ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
+  rw [wp_eq_expectedValue]
+  exact OracleComp.EvalDist.expectedValue_const (probFailure_of_liftM_PMF _) c
 
 @[game_rule] theorem wp_add (oa : OracleComp spec α) (f g : α → ℝ≥0∞) :
     wp oa (fun x => f x + g x) =
       wp oa f + wp oa g := by
-  simp only [wp_eq_tsum, mul_add, ENNReal.tsum_add]
-
-@[game_rule] theorem wp_mul_const (oa : OracleComp spec α) (c : ℝ≥0∞) (f : α → ℝ≥0∞) :
-    wp oa (fun x => c * f x) =
-      c * wp oa f := by
-  simp only [wp_eq_tsum]; simp_rw [mul_left_comm]; exact ENNReal.tsum_mul_left
+  simp only [wp_eq_expectedValue, OracleComp.EvalDist.expectedValue_add]
 
 theorem wp_const_mul (oa : OracleComp spec α) (f : α → ℝ≥0∞) (c : ℝ≥0∞) :
     wp oa (fun x => f x * c) =
       wp oa f * c := by
-  simp_rw [mul_comm _ c]; rw [wp_mul_const, mul_comm]
+  simp only [wp_eq_expectedValue, OracleComp.EvalDist.expectedValue_mul_const]
+
+@[game_rule] theorem wp_mul_const (oa : OracleComp spec α) (c : ℝ≥0∞) (f : α → ℝ≥0∞) :
+    wp oa (fun x => c * f x) =
+      c * wp oa f := by
+  simp_rw [mul_comm c]; exact wp_const_mul oa f c
 
 /-! ## `Triple` lemmas (against `Triple _ _ _`)
 

--- a/VCVio/ProgramLogic/Unary/Loom/Quantitative.lean
+++ b/VCVio/ProgramLogic/Unary/Loom/Quantitative.lean
@@ -10,6 +10,7 @@ public import PolyFun.Control.Monad.Algebra
 public import ToMathlib.Control.OptionT
 public import ToMathlib.Control.StateT
 public import ToMathlib.Control.WriterT
+public import VCVio.EvalDist.Expectation
 public import VCVio.EvalDist.Monad.Basic
 public import VCVio.OracleComp.EvalDist
 public import Loom.WP.Basic
@@ -86,22 +87,20 @@ variable {α β : Type}
 
 /-! ## Expectation algebra and the `MAlgOrdered` instance -/
 
-/-- Expectation-style algebra for oracle computations returning `ℝ≥0∞`. -/
+/-- Expectation-style algebra for oracle computations returning `ℝ≥0∞`: the expectation
+(`OracleComp.EvalDist.expectedValue`) of the identity functional. -/
 noncomputable def μ (oa : OracleComp spec ℝ≥0∞) : ℝ≥0∞ :=
-  ∑' x, Pr[= x | oa] * x
+  OracleComp.EvalDist.expectedValue oa fun x => x
 
 lemma μ_bind_eq_tsum {α : Type}
     (oa : OracleComp spec α) (ob : α → OracleComp spec ℝ≥0∞) :
     μ (oa >>= ob) = ∑' x, Pr[= x | oa] * μ (ob x) := by
-  simp_rw [μ, probOutput_bind_eq_tsum, ← ENNReal.tsum_mul_right, mul_assoc]
-  rw [ENNReal.tsum_comm]
-  simp_rw [ENNReal.tsum_mul_left]
+  unfold μ
+  rw [OracleComp.EvalDist.expectedValue_bind, OracleComp.EvalDist.expectedValue_def]
 
 noncomputable instance instMAlgOrdered : MAlgOrdered (OracleComp spec) ℝ≥0∞ where
   μ := μ (spec := spec)
-  μ_pure x := by
-    have : DecidableEq ℝ≥0∞ := Classical.decEq _
-    simp [μ, probOutput_pure]
+  μ_pure x := by simp [μ]
   μ_bind_mono f g hfg x := by
     simp_rw [μ_bind_eq_tsum]
     gcongr with a

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -25,6 +25,7 @@ public import VCVioTest.OracleComp.SecurityFamily
 public import VCVioTest.PFunctorFacade
 public import VCVioTest.PerfectMerkleTree
 public import VCVioTest.ProbabilityTactics
+public import VCVioTest.ProgramLogic.GCongr
 public import VCVioTest.QueryHom
 public import VCVioTest.RoundByRound.OneRound
 public import VCVioTest.SMDTDSPRFinalValidity

--- a/VCVioTest/ProgramLogic/GCongr.lean
+++ b/VCVioTest/ProgramLogic/GCongr.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import VCVio.ProgramLogic.Unary.HoareTriple
+
+/-!
+# `gcongr` through `wp`
+
+Canaries for the `@[gcongr]` tag on `wp_mono`: `gcongr` descends through `wp` into the
+postcondition, also under a finite sum, and `wp_eq_expectedValue` is the bridge to the
+`expectedValue` laws.
+-/
+
+public section
+
+open ENNReal OracleSpec OracleComp
+open Lean.Order
+open OracleComp.ProgramLogic
+open scoped OracleComp.ProgramLogic
+
+namespace VCVioTest.ProgramLogicGCongr
+
+universe u
+
+variable {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec] {α : Type}
+
+example (oa : OracleComp spec α) (f g : α → ℝ≥0∞) (h : ∀ x, f x ≤ g x) :
+    wp oa f ≤ wp oa g := by
+  gcongr with x
+  exact h x
+
+example (oa : OracleComp spec α) (f g : Fin 3 → α → ℝ≥0∞) (h : ∀ s x, f s x ≤ g s x) :
+    ∑ s, wp oa (f s) ≤ ∑ s, wp oa (g s) := by
+  gcongr with s _ x
+  exact h s x
+
+example (oa : OracleComp spec α) (post : α → ℝ≥0∞) :
+    wp oa post = OracleComp.EvalDist.expectedValue oa post :=
+  wp_eq_expectedValue oa post
+
+end VCVioTest.ProgramLogicGCongr


### PR DESCRIPTION
## Summary

The smell test for the `gcongr`/`expectedValue` idiom of #636 (this PR is stacked on it): the eight long proofs of the bind layer are re-proved through the `expectedValue` head, and every one of them gets shorter.

- **Idiom.** Rewrite the binds with `probEvent_bind_eq_expectedValue`, one `gcongr with x hx` to the per-output goal, one `by_cases` on the exceptional set, then `expectedValue_add` plus the two new laws `expectedValue_ite_one` (`expectedValue mx (fun x => if p x then 1 else 0) = Pr[p | mx]`) and `expectedValue_mul_const` to read off the aggregate. The hand-rolled `Pr[p] + Pr[¬p] ≤ 1` inside the convex bound is `probEvent_compl`.
- **Line deltas** (proof bodies): the four `Monad/Disagreement.lean` hop lemmas 22/22/22/27 → 15/16/16/18; `probEvent_bind_le_probEvent` 9 → 6, `_mul` 8 → 6, `_add` 19 → 13, `_convex` 30 → 16. Three files, +106/−146; statements unchanged.
- **Ladder rung.** Rung 2 (`expectedValue` as the `gcongr` head); no simp/grind set changes, no new gate entries needed (the shape is already exercised in `VCVioTest/Tactic/GCongr.lean`).

## Verification

- `lake build VCVio Examples VCVioTest` clean, zero warnings; `lake exe axiomsweep --check` baseline unchanged; `scripts/check-pmf-boundary.sh` and `lake exe lint-style` clean.

## Spike: what the idiom shortens (2026-09-05)

The last commit folds the program logic's expectation layer onto `expectedValue` (the maintainer's call: fully, not just tags) and uses the resulting `@[gcongr]` tag on `wp_mono`.

| declaration | file | before | after | idiom |
|---|---|---|---|---|
| `μ` | `ProgramLogic/Unary/Loom/Quantitative.lean` | `∑' x, Pr[= x \| oa] * x` | `expectedValue oa fun x => x` | definitionally the same term; `μ_bind_eq_tsum` 3 → 2 proof lines, `μ_pure` one line |
| `wp_eq_tsum`, `wp_const`, `wp_add`, `wp_mul_const`, `wp_const_mul`, `wp_mono` | `ProgramLogic/Unary/HoareTriple.lean` | 5, 1, 1, 1, 1, 2 proof lines | 1, 2, 1, 1, 1, 2 | each is the corresponding `expectedValue` law through the new `wp_eq_expectedValue` (+7, a `rw` target: `wp` stays the head the tactics key on); `wp_mono` is `@[gcongr]` |
| `probEvent_countAll_bad_le_wp_countPred` | `Examples/CommitmentScheme/Hiding/CountBounds.lean` | 21 | 16 | `wp_eq_expectedValue` + `gcongr with z hz` replaces `wp_eq_tsum` + `tsum_le_tsum` + the support split |
| `sum_wp_distinguish_incrementIndicators_le_queryResidual_of_choose_count_support` | `…/LoggingBounds/Average.lean` | 50 | 46 | `gcongr with s hs z` replaces `Finset.sum_le_sum`/`intro`/`wp_mono`/`intro` |
| `…_with_state` | `…/LoggingBounds/QuerySalt.lean` | 58 | 54 | same |

Gate: new `VCVioTest/ProgramLogic/GCongr.lean` (`gcongr` through `wp`, under a finite sum, and the bridge lemma). Statements are unchanged everywhere; the 21 `μ` uses and every `wp_*` caller compile as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVfC71YUdB39wUWfC2MBUH

