### PR TITLE
feat(EvalDist): the measure-side account of failure

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -140,6 +140,7 @@ public import VCVio.EvalDist.Defs.Support
 public import VCVio.EvalDist.Divergence.KLDivergence
 public import VCVio.EvalDist.Expectation
 public import VCVio.EvalDist.ExpectationMeasure
+public import VCVio.EvalDist.FailureMeasure
 public import VCVio.EvalDist.Fintype
 public import VCVio.EvalDist.IndepProduct
 public import VCVio.EvalDist.Inequalities

--- a/VCVio/EvalDist/Defs/AlternativeMonad.lean
+++ b/VCVio/EvalDist/Defs/AlternativeMonad.lean
@@ -31,6 +31,15 @@ protected class HasEvalSet.LawfulFailure (m : Type u → Type v)
     [AlternativeMonad m] [MonadLiftT m SetM] : Prop where
   support_failure' {α : Type u} : support (failure : m α) = ∅
 
+/-- `failure` in `SPMF` itself has empty support, so the generic failure laws below apply to the
+finite backend directly. -/
+instance : HasEvalSet.LawfulFailure SPMF where
+  support_failure' := by
+    intro α
+    ext x
+    change x ∈ (failure : SPMF _).support ↔ x ∈ (∅ : Set _)
+    simp [SPMF.mem_support_iff, SPMF.failure_apply]
+
 open HasEvalSet (LawfulFailure)
 
 @[simp, grind =]

--- a/VCVio/EvalDist/FailureMeasure.lean
+++ b/VCVio/EvalDist/FailureMeasure.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import VCVio.EvalDist.ExpectationMeasure
+public import VCVio.EvalDist.Defs.NeverFails
+public import VCVio.EvalDist.Instances.OptionT
+
+/-!
+# Failure on the measure side
+
+On the measure side a computation's failure is *missing mass*: `𝒟[mx]` is a subprobability
+measure and `Pr[⊥ | mx]` is what it lacks to be a probability measure. This module records that
+account of failure against the façade bridge `DiscreteEvalDistCompatible`:
+
+* `probFailure_eq_one_sub_evalDist_univ`, `evalDist_apply_univ_eq_one_iff`,
+  `isProbabilityMeasure_evalDist_iff` — failure is the missing mass, and a computation denotes a
+  probability measure exactly when it never fails; `NeverFail mx` gives the
+  `IsProbabilityMeasure 𝒟[mx]` instance.
+* `evalDist_failure` — `failure` denotes the zero measure.
+* `evalDist_withFailure_apply_none`/`_some` — the failure-completed denotation
+  `(𝒟[mx]).withFailure : Measure (Option α)` is the probability measure with the failure mass at
+  `none` and the point probabilities at `some x`.
+* `evalDist_bind_apply_univ`, `evalDist_map_apply_univ`, `probFailure_bind_eq_add_expectedValue`
+  — how success mass moves through `bind` and `map`, in `expectedValue` form.
+* `OptionT.evalDist_eq_dropNone` — an `OptionT` computation denotes the `dropNone` of its run:
+  the `none` branch is discarded mass, not an output.
+-/
+
+@[expose] public section
+
+open MeasureTheory OracleComp.EvalDist
+open scoped ENNReal
+
+universe u v
+
+variable {m : Type u → Type v} {α β : Type u}
+
+section compatible
+
+variable [MonadLiftT m SPMF] [EvalDistSemantics m] [DiscreteEvalDistCompatible m]
+  [MeasurableSpace α]
+
+/-- Failure is the mass missing from the denoted measure. -/
+theorem probFailure_eq_one_sub_evalDist_univ (mx : m α) :
+    Pr[⊥ | mx] = 1 - 𝒟[mx] Set.univ := by
+  rw [evalDist_apply_univ, ENNReal.sub_sub_cancel ENNReal.one_ne_top probFailure_le_one]
+
+/-- The denoted measure has total mass one exactly when the computation never fails. -/
+theorem evalDist_apply_univ_eq_one_iff (mx : m α) : 𝒟[mx] Set.univ = 1 ↔ Pr[⊥ | mx] = 0 := by
+  constructor
+  · intro h
+    rw [probFailure_eq_one_sub_evalDist_univ, h, tsub_self]
+  · intro h
+    rw [evalDist_apply_univ, h, tsub_zero]
+
+/-- A computation denotes a probability measure exactly when it never fails. -/
+theorem isProbabilityMeasure_evalDist_iff (mx : m α) :
+    IsProbabilityMeasure 𝒟[mx] ↔ Pr[⊥ | mx] = 0 := by
+  rw [isProbabilityMeasure_iff, evalDist_apply_univ_eq_one_iff]
+
+/-- A computation that never fails denotes a probability measure. -/
+instance [Monad m] (mx : m α) [NeverFail mx] : IsProbabilityMeasure 𝒟[mx] :=
+  (isProbabilityMeasure_evalDist_iff mx).mpr probFailure_eq_zero
+
+/-- `failure` denotes the zero measure. -/
+@[simp]
+theorem evalDist_failure [AlternativeMonad m] [MonadLiftT m SetM] [EvalDistCompatible m]
+    [HasEvalSet.LawfulFailure m] : 𝒟[(failure : m α)] = 0 := by
+  rw [← Measure.measure_univ_eq_zero, evalDist_apply_univ, probFailure_failure, tsub_self]
+
+variable [DiscreteMeasurableSpace α]
+
+/-- The failure-completed denotation puts the failure probability at `none`. -/
+@[simp]
+theorem evalDist_withFailure_apply_none (mx : m α) :
+    (𝒟[mx]).withFailure {none} = Pr[⊥ | mx] := by
+  rw [Measure.withFailure_apply_none, evalDist_apply_univ,
+    ENNReal.sub_sub_cancel ENNReal.one_ne_top probFailure_le_one]
+
+/-- The failure-completed denotation keeps every point probability at `some x`. -/
+@[simp]
+theorem evalDist_withFailure_apply_some (mx : m α) (x : α) :
+    (𝒟[mx]).withFailure {some x} = Pr[= x | mx] := by
+  rw [Measure.withFailure_apply_some, evalDist_apply_singleton]
+
+/-- The failure-completed denotation is a probability measure. -/
+instance (mx : m α) : IsProbabilityMeasure (𝒟[mx]).withFailure :=
+  Measure.withFailure_isProbabilityMeasure _ (evalDist_apply_univ_le_one mx)
+
+end compatible
+
+section lawful
+
+variable [Monad m] [MonadLiftT m SPMF] [EvalDistSemantics m] [DiscreteEvalDistCompatible m]
+  [LawfulEvalDistSemantics m] [MeasurableSpace α] [DiscreteMeasurableSpace α]
+  [MeasurableSpace β]
+
+/-- The success mass of a bind is the expected success mass of the continuation. -/
+theorem evalDist_bind_apply_univ (mx : m α) (f : α → m β) :
+    𝒟[mx >>= f] Set.univ = expectedValue mx fun x => 𝒟[f x] Set.univ := by
+  rw [evalDist_bind_of_discrete, Measure.bind_apply MeasurableSet.univ
+    Measurable.of_discrete.aemeasurable, lintegral_evalDist]
+
+omit [MonadLiftT m SPMF] [DiscreteEvalDistCompatible m] [DiscreteMeasurableSpace α] in
+/-- A measurable map preserves success mass. -/
+theorem evalDist_map_apply_univ [LawfulMonad m] (mx : m α) {f : α → β} (hf : Measurable f) :
+    𝒟[f <$> mx] Set.univ = 𝒟[mx] Set.univ := by
+  rw [evalDist_map mx hf, Measure.map_apply hf MeasurableSet.univ, Set.preimage_univ]
+
+end lawful
+
+/-- `probFailure_bind_eq_add_tsum` with the sum packaged as an `expectedValue`: the failure of
+a bind is the prefix failure plus the expected failure of the continuation. -/
+theorem probFailure_bind_eq_add_expectedValue [Monad m] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF] (mx : m α) (my : α → m β) :
+    Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + expectedValue mx fun x => Pr[⊥ | my x] :=
+  probFailure_bind_eq_add_tsum mx my
+
+namespace OptionT
+
+variable [Monad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [MeasurableSpace α]
+  [DiscreteMeasurableSpace α]
+
+/-- An `OptionT` computation denotes the `dropNone` of its run: the `none` branch is discarded
+mass, not an output. -/
+theorem evalDist_eq_dropNone (mx : OptionT m α) : 𝒟[mx] = (𝒟[mx.run]).dropNone := by
+  change (𝒮[mx]).toMeasure = Measure.dropNone (𝒮[mx.run]).toMeasure
+  rw [OptionT.evalSPMF_eq, OptionT.mapM', Measure.dropNone, SPMF.toMeasure_bind]
+  refine Measure.bind_congr_right (Filter.Eventually.of_forall fun o => ?_)
+  cases o <;> simp
+
+end OptionT

--- a/VCVio/EvalDist/FailureMeasure.lean
+++ b/VCVio/EvalDist/FailureMeasure.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma
 -/
+
 module
 
 public import VCVio.EvalDist.ExpectationMeasure
@@ -30,7 +31,7 @@ account of failure against the façade bridge `DiscreteEvalDistCompatible`:
   the `none` branch is discarded mass, not an output.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory OracleComp.EvalDist
 open scoped ENNReal

--- a/VCVioTest/EvalDist/MeasureBridge.lean
+++ b/VCVioTest/EvalDist/MeasureBridge.lean
@@ -119,7 +119,8 @@ example (mx : ProbComp (Fin 3)) (f : Fin 3 → ProbComp (Fin 2)) : 𝒟[mx >>= f
 A coin and a die drawn independently, closed on the measure side by the same calls as the
 façade: the point mass is the product of the two uniform masses (the closed form `simp` reaches;
 merging `2⁻¹ * 6⁻¹` into `12⁻¹` is `ℝ≥0∞` arithmetic, not a probability rule), an event on one
-coordinate needs the bind expanded under `Pr[…]` and `ENNReal.div_self` for the total factor. -/
+coordinate needs the bind expanded under `Pr[…]` and `ENNReal.div_self` for the total factor, and
+the failure-side facts need nothing beyond the program never failing. -/
 
 /-- A coin and a die, drawn independently. -/
 def coinDie : ProbComp (Bool × Fin 6) := do
@@ -131,6 +132,9 @@ example : 𝒟[coinDie] {(true, 0)} = 2⁻¹ * 6⁻¹ := by simp [coinDie]
 example : 𝒟[coinDie] {z | z.1 = true} = 2⁻¹ := by
   simp [coinDie, probEvent_bind_eq_tsum, ENNReal.div_self]
 example (g : Bool × Fin 6 → ℝ≥0∞) : ∫⁻ z, g z ∂𝒟[coinDie] = expectedValue coinDie g := by simp
+example : 𝒟[coinDie] Set.univ = 1 := by simp
+example : (𝒟[coinDie]).withFailure {none} = 0 := by simp
+example : IsProbabilityMeasure 𝒟[coinDie] := inferInstance
 
 /-! ## Continuous carriers are untouched -/
 

--- a/VCVioTest/EvalDist/MeasureBridge.lean
+++ b/VCVioTest/EvalDist/MeasureBridge.lean
@@ -105,6 +105,15 @@ example (mx : OptionT ProbComp Bool) (g : Bool → ℝ≥0∞) :
 example (mx : OptionT ProbComp Bool) (my : OptionT ProbComp (Fin 3)) :
     𝒟[mx >>= fun _ => my] = 𝒟[mx] Set.univ • 𝒟[my] := by simp
 
+/-! ## Failure is missing mass -/
+
+example : 𝒟[(failure : OptionT ProbComp Bool)] = 0 := by simp
+example (mx : OptionT ProbComp Bool) : (𝒟[mx]).withFailure {none} = Pr[⊥ | mx] := by simp
+example (mx : OptionT ProbComp Bool) (x : Bool) :
+    (𝒟[mx]).withFailure {some x} = Pr[= x | mx] := by simp
+example (mx : ProbComp Bool) : IsProbabilityMeasure 𝒟[mx] := inferInstance
+example (mx : ProbComp (Fin 3)) (f : Fin 3 → ProbComp (Fin 2)) : 𝒟[mx >>= f] Set.univ = 1 := by
+  simp
 /-! ## A unit-test program
 
 A coin and a die drawn independently, closed on the measure side by the same calls as the

--- a/VCVioTest/EvalDist/MeasureBridge.lean
+++ b/VCVioTest/EvalDist/MeasureBridge.lean
@@ -114,6 +114,23 @@ example (mx : OptionT ProbComp Bool) (x : Bool) :
 example (mx : ProbComp Bool) : IsProbabilityMeasure 𝒟[mx] := inferInstance
 example (mx : ProbComp (Fin 3)) (f : Fin 3 → ProbComp (Fin 2)) : 𝒟[mx >>= f] Set.univ = 1 := by
   simp
+
+/-- A lossy computation that succeeds exactly on the `true` outcome of a fair coin. -/
+def lossyCoin : OptionT ProbComp Bool := do
+  let b ← liftM ($ᵗ Bool)
+  if b then pure true else failure
+
+example : 𝒟[lossyCoin] {true} = 2⁻¹ := by
+  simp [lossyCoin, OptionT.probOutput_eq, probOutput_bind_eq_tsum]
+example : 𝒟[lossyCoin] {false} = 0 := by
+  simp [lossyCoin, OptionT.probOutput_eq, probOutput_bind_eq_tsum]
+example : (𝒟[lossyCoin]).withFailure {none} = 2⁻¹ := by
+  simp [lossyCoin, OptionT.probFailure_eq, probOutput_bind_eq_tsum]
+example : (𝒟[lossyCoin]).withFailure {some true} = 2⁻¹ := by
+  simp [lossyCoin, OptionT.probOutput_eq, probOutput_bind_eq_tsum]
+example : 𝒟[lossyCoin] = (𝒟[lossyCoin.run]).dropNone :=
+  OptionT.evalDist_eq_dropNone lossyCoin
+
 /-! ## A unit-test program
 
 A coin and a die drawn independently, closed on the measure side by the same calls as the

--- a/VCVioTest/KernelSemantics.lean
+++ b/VCVioTest/KernelSemantics.lean
@@ -6,6 +6,7 @@ Authors: Devon Tuma
 module
 
 public import VCVio.OracleComp.Coinductive.Responder
+public import VCVio.EvalDist.FailureMeasure
 public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 
 /-!
@@ -38,32 +39,16 @@ example (input : Bool) : lossyKernel input Set.univ ≤ 1 := by
   exact Kernel.measure_univ_le (evalDistKernelOfDiscrete lossyFamily) input
 
 example : lossyKernel true = Measure.dirac true := by
-  rw [lossyKernel, evalDistKernelOfDiscrete_apply]
-  change (lossyFamily true).toMeasure = Measure.dirac true
-  rw [lossyFamily, if_pos rfl]
-  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+  simp [lossyKernel, lossyFamily]
 
 example : lossyKernel false = 0 := by
-  rw [lossyKernel, evalDistKernelOfDiscrete_apply]
-  change (lossyFamily false).toMeasure = 0
-  rw [lossyFamily, if_neg (by decide)]
-  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+  simp [lossyKernel, lossyFamily]
 
 example : lossyKernel true Set.univ = 1 := by
-  rw [show lossyKernel true = Measure.dirac true by
-    rw [lossyKernel, evalDistKernelOfDiscrete_apply]
-    change (lossyFamily true).toMeasure = Measure.dirac true
-    rw [lossyFamily, if_pos rfl]
-    simp [SPMF.toMeasure, PMF.toMeasure_pure]]
-  simp
+  simp [lossyKernel, lossyFamily]
 
 example : lossyKernel false Set.univ = 0 := by
-  rw [show lossyKernel false = 0 by
-    rw [lossyKernel, evalDistKernelOfDiscrete_apply]
-    change (lossyFamily false).toMeasure = 0
-    rw [lossyFamily, if_neg (by decide)]
-    simp [SPMF.toMeasure, PMF.toMeasure_pure]]
-  simp
+  simp [lossyKernel, lossyFamily]
 
 /-! ## Executable responders -/
 
@@ -134,26 +119,19 @@ example (p : Bool × Bool) :
 
 example (p : Bool × Bool) : togglingIterKernel 0 p = Measure.dirac p := by
   rw [togglingIterKernel, OracleStrategy.iterateAgainstKernel_eq_toMeasure]
-  change (pure p : SPMF (Bool × Bool)).toMeasure = Measure.dirac p
-  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+  simp
 
 example (p : Bool × Bool) :
     togglingIterKernel 1 p = Measure.dirac (!p.1, p.1) := by
   rw [togglingIterKernel, OracleStrategy.iterateAgainstKernel_eq_toMeasure]
-  rw [show OracleStrategy.iterateAgainst echoStrategy togglingResponder 1 p =
-    pure (!p.1, p.1) by
-      simp [OracleStrategy.iterateAgainst_succ, OracleStrategy.stepAgainst_apply,
-        togglingResponder, echoStrategy]]
-  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+  simp [OracleStrategy.iterateAgainst_succ, OracleStrategy.stepAgainst_apply, togglingResponder,
+    echoStrategy]
 
 example (p : Bool × Bool) :
     togglingIterKernel 2 p = Measure.dirac (p.1, !p.1) := by
   rw [togglingIterKernel, OracleStrategy.iterateAgainstKernel_eq_toMeasure]
-  rw [show OracleStrategy.iterateAgainst echoStrategy togglingResponder 2 p =
-    pure (p.1, !p.1) by
-      simp [OracleStrategy.iterateAgainst_succ, OracleStrategy.stepAgainst_apply,
-        togglingResponder, echoStrategy]]
-  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+  simp [OracleStrategy.iterateAgainst_succ, OracleStrategy.stepAgainst_apply, togglingResponder,
+    echoStrategy]
 
 end DiscreteWiredCanaries
 

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -30,6 +30,12 @@ measure specification in scope; `evalDist_eq_evalSPMF_toMeasure` is its definiti
 `evalDist_bind`/`evalDist_map` are deliberately not `@[simp]` on either side: a bind is expanded
 only on request (`gotchas.md` §10), and the measure side has no separate family of sum lemmas.
 
+Failure on the measure side is missing mass, recorded in `VCVio/EvalDist/FailureMeasure.lean`:
+`Pr[⊥ | mx] = 1 - 𝒟[mx] univ`, `IsProbabilityMeasure 𝒟[mx] ↔ Pr[⊥ | mx] = 0` (an instance under
+`NeverFail mx`), `𝒟[failure] = 0`, the failure-completed `(𝒟[mx]).withFailure : Measure (Option α)`
+with `{none}` mass `Pr[⊥ | mx]`, the success mass of `bind`/`map` in `expectedValue` form, and
+`OptionT.evalDist_eq_dropNone` (an `OptionT` computation denotes the `dropNone` of its run).
+
 ## Core Definitions
 
 | Definition | Type | Notation | Defined in |

--- a/scripts/pmf_boundary_baseline.tsv
+++ b/scripts/pmf_boundary_baseline.tsv
@@ -44,7 +44,7 @@ VCVio/CryptoFoundations/SymmEncAlg.lean	13
 VCVio/CryptoFoundations/SymmEncAlg/MeasureCompatibility.lean	4
 VCVio/EvalDist/BitVec.lean	2
 VCVio/EvalDist/Bool.lean	4
-VCVio/EvalDist/Defs/AlternativeMonad.lean	6
+VCVio/EvalDist/Defs/AlternativeMonad.lean	10
 VCVio/EvalDist/Defs/Basic.lean	138
 VCVio/EvalDist/Defs/Instances.lean	29
 VCVio/EvalDist/Defs/Measure.lean	33
@@ -53,6 +53,7 @@ VCVio/EvalDist/Defs/Semantics.lean	12
 VCVio/EvalDist/Defs/Support.lean	1
 VCVio/EvalDist/Expectation.lean	4
 VCVio/EvalDist/ExpectationMeasure.lean	1
+VCVio/EvalDist/FailureMeasure.lean	8
 VCVio/EvalDist/Fintype.lean	6
 VCVio/EvalDist/IndepProduct.lean	6
 VCVio/EvalDist/Inequalities.lean	1


### PR DESCRIPTION
## Summary

The measure-side account of failure, stacked on the reworked #637. On the measure side failure is missing mass, and until now only `evalDist_apply_univ` said so.

- **Failure as missing mass.** `Pr[⊥ | mx] = 1 - 𝒟[mx] univ`; `𝒟[mx] univ = 1 ↔ Pr[⊥ | mx] = 0`; `IsProbabilityMeasure 𝒟[mx] ↔ Pr[⊥ | mx] = 0`, with an `IsProbabilityMeasure 𝒟[mx]` instance from `NeverFail mx` (so `Kernel.lean`'s `IsProbabilityMeasure` hypotheses are discharged by `inferInstance` on never-failing computations).
- **`𝒟[failure] = 0`** (`@[simp]`), generic over any `LawfulFailure` lift. `SPMF` itself lacked the `HasEvalSet.LawfulFailure` instance, so the generic failure laws (`probFailure_failure`, `evalSPMF_failure`, now `evalDist_failure`) did not apply to the finite backend directly; the instance is added.
- **The failure-completed denotation.** `(𝒟[mx]).withFailure : Measure (Option α)` is a probability measure with `{none}` mass `Pr[⊥ | mx]` and `{some x}` mass `Pr[= x | mx]` (both `@[simp]`), the measure-native reading of the option-valued backend.
- **Mass through `bind` and `map`.** `𝒟[mx >>= f] univ = expectedValue mx fun x => 𝒟[f x] univ`, `𝒟[f <$> mx] univ = 𝒟[mx] univ`, and `probFailure_bind_eq_add_expectedValue` (the `expectedValue` form of `probFailure_bind_eq_add_tsum`, a `gcongr` head).
- **`OptionT`.** `𝒟[mx] = (𝒟[mx.run]).dropNone`: the `none` branch is discarded mass, not an output.
- **Smell test.** The four scripted `lossyKernel` proofs in `VCVioTest/KernelSemantics.lean` are one `simp` call each; the measure gate gains the failure entries.

Everything stated against `𝒟` and `DiscreteEvalDistCompatible` survives the PMF retirement. PMF-boundary baseline: one line for the new module (8 tokens, the façade's `[MonadLiftT m SPMF]` hypotheses plus the `SPMF.toMeasure_bind` step of the `OptionT` proof) and `AlternativeMonad.lean` 6 → 10 for the `LawfulFailure SPMF` instance; both are transitional glue that the retirement deletes.

## Verification

- `lake build VCVio Examples VCVioTest` clean, zero warnings; `lake exe axiomsweep --check` baseline unchanged; `scripts/check-pmf-boundary.sh` and `lake exe lint-style` clean; `scripts/update-lib.sh` registers the new module.

## Spike: what the idiom shortens (2026-09-05)

The last commit adds the failure-side facts about the gate's unit-test program `coinDie`: total mass one, no mass at `none` in the failure-completed denotation, and `IsProbabilityMeasure 𝒟[coinDie]` by `inferInstance` through `NeverFail`, one call each.

No library proof shortened (a finding, per the vision's rule). The natural consumers of `probFailure_bind_eq_add_expectedValue` are `probFailure_bind_le_add_of_forall`, `probFailure_bind_le_of_forall'`, and `probFailure_bind_congr` in `EvalDist/Monad/Basic.lean`, which sit below `Expectation.lean` on this branch; once #636 (which moves `expectedValue` into `Defs/Basic.lean`) merges, the lemma can move next to `probFailure_bind_eq_add_tsum` and those three proofs take the #642 shape (`rw` + `gcongr` + `expectedValue_const`). The `IsProbabilityMeasure` instance has no library consumer either: the only sites that need a probability measure of a `𝒟` term are the Markov-kernel lemmas in `EvalDist/Kernel.lean`, which take it as an explicit hypothesis, and their one test consumer (`lossyFamily`) fails by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVfC71YUdB39wUWfC2MBUH

