### PR TITLE
ci: pin actions to commit SHAs and add dependabot and PR/issue templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Line endings: sources and scripts are LF everywhere so that Lean, Lake, and the shell scripts
+# behave the same on every platform.
+* text=auto
+*.lean text eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.tsv text eol=lf
+lean-toolchain text eol=lf
+
+# Binary content.
+*.pdf binary
+
+# Generated or vendored content, kept out of language statistics and collapsed in diffs.
+lake-manifest.json linguist-generated
+scripts/axiom_baseline.json linguist-generated
+scripts/*_baseline.tsv linguist-generated
+third_party/** linguist-vendored

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/proof-obligation.yml
+++ b/.github/ISSUE_TEMPLATE/proof-obligation.yml
@@ -1,0 +1,44 @@
+name: Proof obligation
+description: Track a `sorry`, or an assumption a theorem depends on, until it is discharged.
+title: "Proof obligation for `<declaration>` in `<file>`"
+labels: ["proof wanted"]
+body:
+  - type: input
+    id: declaration
+    attributes:
+      label: Declaration
+      description: >-
+        Name and location, for example `ind_cca_security` in `LatticeCrypto/MLKEM/Security.lean:163`.
+    validations:
+      required: true
+  - type: textarea
+    id: statement
+    attributes:
+      label: Statement and current proof
+      description: >-
+        The declaration with its docstring and the `sorry` (or the axiom or hypothesis it relies on).
+      render: lean
+    validations:
+      required: true
+  - type: textarea
+    id: consumers
+    attributes:
+      label: What depends on it
+      description: >-
+        Theorems whose sorry-free status is transitively false while this stays open, and the PR
+        that introduced the obligation.
+  - type: textarea
+    id: plan
+    attributes:
+      label: Proof sketch or blockers
+      description: >-
+        The intended argument or the paper result it follows, missing Mathlib or ToMathlib lemmas,
+        or a design decision that has to come first.
+  - type: checkboxes
+    id: baseline
+    attributes:
+      label: Baseline
+      options:
+        - label: >-
+            The obligation is listed in `scripts/axiom_baseline.json` (the PR that adds a `sorry`
+            runs `lake exe axiomsweep --update-baseline` and commits the diff).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What changes and why. When a Mathlib, core, or Batteries lemma or idiom replaces a local
+one, cite the row in docs/reading/upstream-alignment.md. -->
+
+## Verification
+
+<!-- The commands run locally, e.g. `lake build <libs> VCVioTest`, `lake exe axiomsweep --check`,
+`./scripts/update-lib.sh`, `bash scripts/check-pmf-boundary.sh`, `lake exe lint-style <libs>`,
+`python3 scripts/check-agent-docs.py`. -->
+
+## Checklist
+
+- [ ] New files carry the standard header and module docstring (`CONTRIBUTING.md`, *Attribution
+      And File Headers*); docstrings are intrinsic, with no change history or "renamed from" wording.
+- [ ] New files use plain `public section` with per-declaration `@[expose]` (*Module Scopes*), and
+      the expose-boundary baseline was lowered in this PR if a file was converted.
+- [ ] `./scripts/update-lib.sh` leaves the umbrella files unchanged, and
+      `lake exe axiomsweep --check` passes with `scripts/axiom_baseline.json` untouched (or the
+      baseline diff is explained above).
+- [ ] No `set_option linter.* false`, no deprecated aliases (`docs/agents/gotchas.md` §18, §23),
+      and no native FFI test executables on the PR path.
+- [ ] Documentation touched by the change is updated and `python3 scripts/check-agent-docs.py`
+      passes.
+- [ ] If a simp/grind/gcongr set changed: the gate files under `VCVioTest/` gained one-call
+      entries, no proof gained a second tactic call outside a dated gap pair, and the before/after
+      line counts of the touched proofs are listed above.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Workflow actions are pinned to commit SHAs (with the tag in a trailing comment); this keeps
+  # the pins current. The native backends under third_party/ are deliberately not bumped here.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -11,8 +11,8 @@ jobs:
     name: Check Agent Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Validate doc references

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
     name: Check Library File Imports
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # The PMF/SPMF boundary ratchet diffs against the pull-request base.
           fetch-depth: 0
 
       - name: Set up Lean environment
-        uses: leanprover/lean-action@v1
+        uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           auto-config: false
           build: false
@@ -79,10 +79,9 @@ jobs:
     name: Optional Complexity Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Set up Lean environment
-        uses: leanprover/lean-action@v1
+        uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           auto-config: false
           build: false
@@ -112,9 +111,9 @@ jobs:
       # downstream `require VCVio` never has the third_party/ submodules
       # checked out, yet Lake links every dependency `extern_lib` into any
       # consumer `lean_exe`, so the native targets must degrade gracefully.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Set up Lean environment
-        uses: leanprover/lean-action@v1
+        uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           auto-config: false
           build: false
@@ -188,7 +187,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -219,14 +218,14 @@ jobs:
           echo "BUILD_TIMING_BASE_REF=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_ENV"
       - name: Restore Lake cache
         id: lake-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .lake
           key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
           restore-keys: |
             lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
       - name: Set up Lean environment
-        uses: leanprover/lean-action@v1
+        uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           auto-config: false
           build: false
@@ -321,7 +320,7 @@ jobs:
       #     .lake/build/bin/mlkem_test
       - name: Save Lake cache
         if: success() && steps.lake-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .lake
           key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
@@ -338,7 +337,7 @@ jobs:
           fi
       - name: Upload timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.BUILD_TIMING_ARTIFACT_NAME }}
           path: ${{ env.BUILD_TIMING_ARTIFACT_DIR }}
@@ -347,7 +346,7 @@ jobs:
       - name: Determine comparison baseline artifact
         if: always() && github.event_name == 'pull_request'
         id: timing-baseline
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -434,7 +433,7 @@ jobs:
             core.setOutput('label', '');
       - name: Download comparison baseline artifact
         if: always() && steps.timing-baseline.outputs.run-id != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.BUILD_TIMING_ARTIFACT_NAME }}
           path: ${{ env.BUILD_TIMING_BASELINE_DIR }}
@@ -462,7 +461,7 @@ jobs:
           always() &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ffi-check.yml
+++ b/.github/workflows/ffi-check.yml
@@ -21,12 +21,12 @@ jobs:
     name: Build + run FFI test executables
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
 
       - name: Set up Lean environment
-        uses: leanprover/lean-action@v1
+        uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           auto-config: false
           build: false

--- a/.github/workflows/interop-isolation.yml
+++ b/.github/workflows/interop-isolation.yml
@@ -26,8 +26,7 @@ jobs:
     name: Check Interop TCB Isolation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Run isolation check
         run: bash scripts/check-interop-isolation.sh
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -64,8 +64,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       # Repo-wide hygiene checks that the old `scripts/lint-style.sh` enforced.
       - name: Check for executable Lean files
         run: |
@@ -86,7 +85,7 @@ jobs:
           fi
 
       - name: Set up Lean environment
-        uses: leanprover/lean-action@v1
+        uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           auto-config: false
           build: false

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
     - name: lean-release-tag action
-      uses: leanprover-community/lean-release-tag@v4.18804.0
+      uses: leanprover-community/lean-release-tag@e3858bd52f5d8e45dc5a0166ae18334bf7d23c76 # v4.18804.0
       with:
         do-release: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -46,7 +46,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
         shell: bash
 
-      - uses: alexanderlhicks/lean4repo-utils/review@0.3
+      - uses: alexanderlhicks/lean4repo-utils/review@9404cc0f9aa10d65e4a08d3741a1d41638fb590f # 0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           api_key: ${{ secrets.OPENROUTER_KEY }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate PR Summary
-        uses: alexanderlhicks/lean4repo-utils/summary@0.3
+        uses: alexanderlhicks/lean4repo-utils/summary@9404cc0f9aa10d65e4a08d3741a1d41638fb590f # 0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary

GitHub-side hygiene for the repository, folded into one PR:

- **Actions pinned to commit SHAs** (24 `uses:` lines across the eight workflows), with the tag kept in a trailing comment so the pin stays readable, and `.github/dependabot.yml` (monthly, grouped into one PR) to keep the pins current. The `third_party/` submodules are deliberately not managed by dependabot: bumping a native reference implementation is a decision, not a chore.
- **Pull request template** whose checklist restates the repo's own rules (`CONTRIBUTING.md` headers and module scopes, umbrella regeneration, the axiom and PMF baselines, the linter and FFI guardrails, the agent-docs check, and the gate-file rule for tactic-set changes) and asks for the ledger row when an upstream lemma replaces a local one.
- **Issue form for proof obligations** (`proof wanted` label, the same shape as the existing "Proof obligation for …" issues: declaration, statement, dependents, sketch, baseline checkbox).
- **`.gitattributes`**: LF endings for sources and scripts, binary marking for the PDF, generated marking for the baselines and the lockfile, `third_party/` marked vendored. No tracked file has CRLF endings, so nothing is renormalised.

The template references `docs/reading/upstream-alignment.md` (#632), the expose-boundary baseline (the transparency PR) and the gate-file rules (#641); those land in the same queue.

## Verification

- `git diff --check`; every `uses:` line matches `@<40-hex> # <tag>`; SHAs resolved with `gh api repos/<owner>/<repo>/commits/<tag>` at the time of writing (`leanprover/lean-action` `50fcf42d…` is v1.6.0).
- No job added, no script added; `actionlint` was not run (not installed).

Track E of the upstream-alignment plan, with the A3 pinning folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVfC71YUdB39wUWfC2MBUH

