### PR TITLE
refactor: selectively expose tests, FFI bundles, and lattice implementations

### DIFF
--- a/Extern/Falcon/ApproxArith.lean
+++ b/Extern/Falcon/ApproxArith.lean
@@ -42,7 +42,7 @@ This factoring separates two concerns:
 - IEEE 754-2019, Section 4 (rounding).
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Extern/Falcon/FFI.lean
+++ b/Extern/Falcon/FFI.lean
@@ -24,7 +24,7 @@ The C side is compiled from `csrc/falcon/lean_falcon_ffi.c`, which links
 against the c-fn-dsa SCU amalgamation (`csrc/falcon/fndsa_native.c`).
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Concrete.FFI

--- a/Extern/Falcon/FPRBridge.lean
+++ b/Extern/Falcon/FPRBridge.lean
@@ -47,7 +47,7 @@ where `ε_renyi < 2^{-64}` for 53-bit mantissa precision.
 - Falcon specification v1.2, Section 2.5.2 (sampler quality)
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Concrete.FPRBridge

--- a/Extern/Hashing.lean
+++ b/Extern/Hashing.lean
@@ -15,7 +15,7 @@ implementation from [mlkem-native](https://github.com/pq-code-package/mlkem-nati
 These primitives are shared across ML-KEM (FIPS 203) and ML-DSA (FIPS 204).
 -/
 
-@[expose] public section
+public section
 
 
 namespace FFI.Hashing

--- a/Extern/MLDSA/FFI.lean
+++ b/Extern/MLDSA/FFI.lean
@@ -20,7 +20,7 @@ The C side is compiled from `csrc/mldsa/lean_mldsa{,44,87}_ffi.c`, linking
 against mldsa-native's monolithic `mldsa_native.c`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLDSA.Concrete.FFI

--- a/Extern/MLDSA/Instance.lean
+++ b/Extern/MLDSA/Instance.lean
@@ -18,7 +18,7 @@ Wires the concrete rounding, NTT, sampling, hashing, and byte encoding layers in
 abstract `Primitives` and `Encoding` bundles used by the ML-DSA specification.
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLDSA.Concrete
@@ -30,6 +30,7 @@ def hintWeightVec {k : Nat} (h : Vector Hint k) : Nat :=
 
 /-- Concrete ML-DSA primitives obtained by wiring the concrete FIPS 204 algorithms into the
 abstract `Primitives` interface. -/
+@[expose]
 def concretePrimitives (p : Params) : Primitives p where
   High := High
   Power2High := Power2High
@@ -56,6 +57,7 @@ def concretePrimitives (p : Params) : Primitives p where
   hintWeight := hintWeightVec
 
 /-- Concrete ML-DSA byte encoding bundle for a parameter set. -/
+@[expose]
 def concreteEncoding (p : Params) : Encoding p (concretePrimitives p) where
   EncodedPK := ByteArray
   EncodedSK := ByteArray
@@ -72,6 +74,7 @@ def mldsa44Primitives : Primitives mldsa44 :=
   concretePrimitives mldsa44
 
 /-- Concrete primitives specialized to ML-DSA-65. -/
+@[expose]
 def mldsa65Primitives : Primitives mldsa65 :=
   concretePrimitives mldsa65
 
@@ -84,6 +87,7 @@ def mldsa44Encoding : Encoding mldsa44 mldsa44Primitives :=
   concreteEncoding mldsa44
 
 /-- Concrete encoding bundle specialized to ML-DSA-65. -/
+@[expose]
 def mldsa65Encoding : Encoding mldsa65 mldsa65Primitives :=
   concreteEncoding mldsa65
 

--- a/Extern/MLDSA/Instance.lean
+++ b/Extern/MLDSA/Instance.lean
@@ -70,6 +70,7 @@ def concreteEncoding (p : Params) : Encoding p (concretePrimitives p) where
   sigDecode := MLDSA.Concrete.sigDecode p
 
 /-- Concrete primitives specialized to ML-DSA-44. -/
+@[expose]
 def mldsa44Primitives : Primitives mldsa44 :=
   concretePrimitives mldsa44
 
@@ -79,10 +80,12 @@ def mldsa65Primitives : Primitives mldsa65 :=
   concretePrimitives mldsa65
 
 /-- Concrete primitives specialized to ML-DSA-87. -/
+@[expose]
 def mldsa87Primitives : Primitives mldsa87 :=
   concretePrimitives mldsa87
 
 /-- Concrete encoding bundle specialized to ML-DSA-44. -/
+@[expose]
 def mldsa44Encoding : Encoding mldsa44 mldsa44Primitives :=
   concreteEncoding mldsa44
 
@@ -92,6 +95,7 @@ def mldsa65Encoding : Encoding mldsa65 mldsa65Primitives :=
   concreteEncoding mldsa65
 
 /-- Concrete encoding bundle specialized to ML-DSA-87. -/
+@[expose]
 def mldsa87Encoding : Encoding mldsa87 mldsa87Primitives :=
   concreteEncoding mldsa87
 

--- a/Extern/MLDSA/Laws.lean
+++ b/Extern/MLDSA/Laws.lean
@@ -80,7 +80,7 @@ The abstract `Primitives.Laws` statement is **not** modified by this file; the b
 theorems make explicit which concrete obligations are discharged and which remain.
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLDSA.Concrete

--- a/Extern/MLDSA/NonVacuity.lean
+++ b/Extern/MLDSA/NonVacuity.lean
@@ -42,7 +42,7 @@ since `concreteNTTRingOps` is the only `NTTRingLaws` instance in the tree.  The 
 hypothesis can be met by the concrete layer (whose NTT-correctness trust assumption it inherits).
 -/
 
-@[expose] public section
+public section
 
 open MLDSA
 

--- a/Extern/MLKEM/FFI.lean
+++ b/Extern/MLKEM/FFI.lean
@@ -26,7 +26,7 @@ The C side is compiled from `csrc/mlkem/lean_mlkem_ffi.c`, which `#include`s
 mlkem-native's monolithic `mlkem_native.c` (pinned at `v1.1.0`).
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLKEM.Concrete.FFI

--- a/Extern/MLKEM/Instance.lean
+++ b/Extern/MLKEM/Instance.lean
@@ -19,7 +19,7 @@ SHA-3 / SHAKE primitives to produce fully executable `NTTRingOps`, `Encoding`, a
 instances for ML-KEM.
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLKEM.Concrete

--- a/HashSigTest/SLHDSA/Hypertree.lean
+++ b/HashSigTest/SLHDSA/Hypertree.lean
@@ -15,7 +15,7 @@ These examples cover the two observable contracts of the `d = 1` hypertree layer
 transparent XMSS composition, and verification recovers a root before its final comparison.
 -/
 
-@[expose] public section
+public section
 
 namespace SLHDSA.HypertreeTest
 

--- a/HashSigTest/SLHDSA/WotsConstructionTests.lean
+++ b/HashSigTest/SLHDSA/WotsConstructionTests.lean
@@ -19,7 +19,7 @@ every WOTS secret, hash-step, and public-key address used by these executions th
 fallback cannot mask the equality.
 -/
 
-@[expose] public section
+public section
 
 
 namespace SLHDSA.WotsConstructionTests

--- a/HashSigTest/SLHDSA/WotsEncoding.lean
+++ b/HashSigTest/SLHDSA/WotsEncoding.lean
@@ -16,7 +16,7 @@ is byte aligned and therefore exercises the outer modulus in the padding formula
 shift-by-eight interpretation truncates to a different digit vector.
 -/
 
-@[expose] public section
+public section
 
 
 namespace SLHDSA.WotsEncodingTest
@@ -27,6 +27,7 @@ def limited : Params := slhdsaSha2_128_24
 def zeroDigits : List ℕ := List.replicate limited.len1 0
 
 /-- Minimal byte-backed context used to exercise the operational WOTS digit path. -/
+@[expose]
 def limitedCore : CorePrimitives limited where
   PkSeed := Unit
   SkSeed := Unit

--- a/LatticeCrypto/Falcon/Concrete/BigInt31.lean
+++ b/LatticeCrypto/Falcon/Concrete/BigInt31.lean
@@ -40,7 +40,7 @@ We also port the small modular-arithmetic helpers from `kgen_inner.h`:
 - `zint_sub_scaled` — scaled subtract
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Concrete.BigInt31

--- a/LatticeCrypto/Falcon/Concrete/Encoding.lean
+++ b/LatticeCrypto/Falcon/Concrete/Encoding.lean
@@ -35,7 +35,7 @@ packed 4 coefficients into 7 bytes.
 - Falcon specification v1.2, Section 3.12 (Algorithms 17–18)
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Concrete

--- a/LatticeCrypto/Falcon/Concrete/GMTable.lean
+++ b/LatticeCrypto/Falcon/Concrete/GMTable.lean
@@ -18,7 +18,7 @@ The `invSigmaRaw` array stores 11 `UInt64` values (for `logn` 0..10) representin
 inverse of the normalization factor `sigma`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Concrete.GMTable

--- a/LatticeCrypto/Falcon/Concrete/PolyBigInt.lean
+++ b/LatticeCrypto/Falcon/Concrete/PolyBigInt.lean
@@ -31,7 +31,7 @@ in NTRU equation solving.
 - `poly_sub_scaled_ntt` — subtract scaled polynomial using NTT
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Concrete.PolyBigInt

--- a/LatticeCrypto/Falcon/Concrete/SmallPrimeNTT.lean
+++ b/LatticeCrypto/Falcon/Concrete/SmallPrimeNTT.lean
@@ -28,7 +28,7 @@ Each entry of the `PRIMES` table stores:
 Ported from `c-fn-dsa/kgen_mp31.c` and `c-fn-dsa/kgen_inner.h`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Concrete.SmallPrimeNTT

--- a/LatticeCrypto/MLDSA/Concrete/LawBounds.lean
+++ b/LatticeCrypto/MLDSA/Concrete/LawBounds.lean
@@ -42,7 +42,7 @@ The `Primitives.Laws` fields that mention the assembled bundle `MLDSA.Concrete.c
 are proven in `Extern/MLDSA/Laws.lean`, on top of the lemmas banked here.
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLDSA.Concrete

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -29,7 +29,7 @@ ML-DSA ring layer and avoiding conversion overhead in the verifier equation
 `Az - c · (t₁ · 2^d)`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLDSA.Concrete
@@ -104,6 +104,7 @@ def useHintCoeff (h : Bool) (r : Coeff) (gamma2 : ℕ) : ℕ :=
     r1
 
 /-- Coefficient-wise `Power2Round` high part. -/
+@[expose]
 def power2RoundHigh (r : Rq) : Power2High :=
   Vector.ofFn fun i => ((power2RoundCoeff (r.get i)).1 : Coeff)
 
@@ -112,10 +113,12 @@ def power2RoundLow (r : Rq) : Rq :=
   Vector.ofFn fun i => (power2RoundCoeff (r.get i)).2
 
 /-- Coefficient-wise `Power2Round`. -/
+@[expose]
 def power2Round (r : Rq) : Power2High × Rq :=
   (power2RoundHigh r, power2RoundLow r)
 
 /-- Reconstruct `t₁ · 2^d` from a power-2 rounded high representative. -/
+@[expose]
 def power2RoundShift (r1 : Power2High) : Rq :=
   Vector.map (fun x => (power2Scale : Coeff) * x) r1
 

--- a/LatticeCryptoTest/Falcon/Helpers.lean
+++ b/LatticeCryptoTest/Falcon/Helpers.lean
@@ -23,7 +23,7 @@ Shared test infrastructure: pass/fail counter, hex formatting, and utility
 functions used by the Falcon test suite.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Test

--- a/LatticeCryptoTest/Falcon/TestVectors.lean
+++ b/LatticeCryptoTest/Falcon/TestVectors.lean
@@ -17,7 +17,7 @@ All vectors use `logn = 9` (Falcon-512) with raw message mode (no pre-hashing,
 no domain-separation context).
 -/
 
-@[expose] public section
+public section
 
 
 namespace Falcon.Test

--- a/LatticeCryptoTest/MLDSA/ACVPVectors.lean
+++ b/LatticeCryptoTest/MLDSA/ACVPVectors.lean
@@ -18,7 +18,7 @@ signs the message with both Lean and mldsa-native (deterministic, `rnd = 0`), an
 results byte-exactly.
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLDSA.Test.ACVP

--- a/LatticeCryptoTest/MLDSA/Helpers.lean
+++ b/LatticeCryptoTest/MLDSA/Helpers.lean
@@ -16,7 +16,7 @@ Shared test infrastructure: pass/fail counter, hex formatting, and FIPS 204 seri
 helpers used by the ML-DSA test suite.
 -/
 
-@[expose] public section
+public section
 
 
 open MLDSA MLDSA.Concrete

--- a/LatticeCryptoTest/MLDSA/Helpers.lean
+++ b/LatticeCryptoTest/MLDSA/Helpers.lean
@@ -23,6 +23,30 @@ open MLDSA MLDSA.Concrete
 
 namespace MLDSA.Test
 
+/-! ## Concrete parameter-set interfaces -/
+
+-- All parameter sets expose their byte encodings and arithmetic carrier types to importers.
+example (bytes : ByteArray) : mldsa44Encoding.EncodedPK := bytes
+example (bytes : ByteArray) : mldsa44Encoding.EncodedSK := bytes
+example (bytes : ByteArray) : mldsa44Encoding.EncodedSig := bytes
+example (value : High) : mldsa44Primitives.High := value
+example (value : Power2High) : mldsa44Primitives.Power2High := value
+example (value : Hint) : mldsa44Primitives.Hint := value
+
+example (bytes : ByteArray) : mldsa65Encoding.EncodedPK := bytes
+example (bytes : ByteArray) : mldsa65Encoding.EncodedSK := bytes
+example (bytes : ByteArray) : mldsa65Encoding.EncodedSig := bytes
+example (value : High) : mldsa65Primitives.High := value
+example (value : Power2High) : mldsa65Primitives.Power2High := value
+example (value : Hint) : mldsa65Primitives.Hint := value
+
+example (bytes : ByteArray) : mldsa87Encoding.EncodedPK := bytes
+example (bytes : ByteArray) : mldsa87Encoding.EncodedSK := bytes
+example (bytes : ByteArray) : mldsa87Encoding.EncodedSig := bytes
+example (value : High) : mldsa87Primitives.High := value
+example (value : Power2High) : mldsa87Primitives.Power2High := value
+example (value : Hint) : mldsa87Primitives.Hint := value
+
 /-! ## Test harness -/
 
 /-- Mutable pass/fail counters for the ML-DSA test suite. -/

--- a/LatticeCryptoTest/MLDSA/Main.lean
+++ b/LatticeCryptoTest/MLDSA/Main.lean
@@ -24,7 +24,7 @@ lake build mldsa_test
 ```
 -/
 
-@[expose] public section
+public section
 
 open MLDSA MLDSA.Concrete MLDSA.Test
 

--- a/LatticeCryptoTest/MLKEM/ACVPVectors.lean
+++ b/LatticeCryptoTest/MLKEM/ACVPVectors.lean
@@ -18,7 +18,7 @@ The test generates keys, encapsulates, decapsulates, and compares Lean vs mlkem-
 byte-exactly.
 -/
 
-@[expose] public section
+public section
 
 
 namespace MLKEM.Test.ACVP

--- a/LatticeCryptoTest/MLKEM/Helpers.lean
+++ b/LatticeCryptoTest/MLKEM/Helpers.lean
@@ -16,7 +16,7 @@ Shared test infrastructure: pass/fail counter, hex formatting, and FIPS 203 seri
 helpers used by the ML-KEM test suite.
 -/
 
-@[expose] public section
+public section
 
 
 open MLKEM MLKEM.Concrete

--- a/LatticeCryptoTest/MLKEM/Main.lean
+++ b/LatticeCryptoTest/MLKEM/Main.lean
@@ -24,7 +24,7 @@ lake build mlkem_test
 ```
 -/
 
-@[expose] public section
+public section
 
 open MLKEM MLKEM.Concrete MLKEM.Test
 

--- a/VCVioTest/Computability.lean
+++ b/VCVioTest/Computability.lean
@@ -26,7 +26,7 @@ No `#eval` is used: outputs are random, so any runtime assertion would be flaky.
 is compilation itself.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec
 

--- a/VCVioTest/CryptoFoundations/ComplexityAdapters.lean
+++ b/VCVioTest/CryptoFoundations/ComplexityAdapters.lean
@@ -17,7 +17,7 @@ ranked-certificate and uniform-security-family facades, while the adaptive and p
 make the rank depend observably on an oracle answer and on the runtime input.
 -/
 
-@[expose] public section
+public section
 
 namespace OracleComp.Complexity.ComplexityAdaptersTest
 
@@ -27,6 +27,7 @@ open PFunctor.DynSystem.DynComputation
 
 /-! ## Synthetic structural fixture -/
 
+@[expose]
 def zeroBackend : QuantitativeStepClass.{0, 0, 0} StepClass.unconstrained.{0, 0} where
   Realizer _ _ _ := PUnit
   size _ _ := 0
@@ -59,6 +60,7 @@ instance : zeroBackend.IsDistributive where
 
 /-! ## Ranked strict PPT for one genuinely uniform security family -/
 
+@[expose]
 def familySpec (_n : ℕ) : OracleSpec PUnit := fun _ ↦ PEmpty
 
 /-- The member input and output types vary with the security parameter. -/
@@ -75,6 +77,7 @@ abbrev familyBoundary : Boundary StepClass.unconstrained
   Boundary.unconstrained _ _ _
 
 /-- One machine implements every member of the nonconstant family. -/
+@[expose]
 def familyRealization : QuantitativeRealization zeroBackend familyBoundary where
   machine := ofFn id
   state := PUnit.unit
@@ -99,6 +102,7 @@ def familyOutputRecovery : zeroBackend.PolyOutputSizeRecovery familyBoundary whe
   output_le _ := le_rfl
 
 /-- Local ranked resource evidence for the packed immediate-return realization. -/
+@[expose]
 def familyResourcePotential : RankedRun.ResourcePotentialCertificate familyRealization
     familyResourceModel.allows (fun _ ↦ 0) where
   toRankedRunCertificate := {
@@ -156,6 +160,7 @@ def adaptiveView : AdaptiveState → Bool ⊕ coinSpec.toPFunctor.Obj AdaptiveSt
   | .second => Sum.inr ⟨(), fun answer ↦ .done answer⟩
   | .done result => Sum.inl result
 
+@[expose]
 def adaptiveMachine : DynComputation coinSpec.toPFunctor Unit Bool where
   State := AdaptiveState
   toDynSystem :=
@@ -246,6 +251,7 @@ def parityView : (ℕ × Bool) → Bool ⊕ coinSpec.toPFunctor.Obj (ℕ × Bool
   | (remaining + 1, parity) =>
       Sum.inr ⟨(), fun answer ↦ (remaining, Bool.xor parity answer)⟩
 
+@[expose]
 def parityMachine : DynComputation coinSpec.toPFunctor ℕ Bool where
   State := ℕ × Bool
   toDynSystem :=

--- a/VCVioTest/CryptoFoundations/SignatureAlg.lean
+++ b/VCVioTest/CryptoFoundations/SignatureAlg.lean
@@ -15,7 +15,7 @@ two valid signatures for each message, while honest signing returns only one of 
 the distinction between message freshness and exact returned-pair freshness observable.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec
 

--- a/VCVioTest/CryptoFoundations/SymmEncAlgMeasure.lean
+++ b/VCVioTest/CryptoFoundations/SymmEncAlgMeasure.lean
@@ -17,7 +17,7 @@ reveals its Boolean message has unequal measure rows and therefore cannot satisf
 perfect secrecy.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory
 

--- a/VCVioTest/Forking/WithoutReplacement.lean
+++ b/VCVioTest/Forking/WithoutReplacement.lean
@@ -21,7 +21,7 @@ collect `r` successes and instead drains the pool, and the closed form is then s
 why the coordinate-wise extractor can use one bound for both cases.
 -/
 
-@[expose] public section
+public section
 
 open ProbComp NegHypergeom OracleComp.EvalDist
 

--- a/VCVioTest/GrindFailFast.lean
+++ b/VCVioTest/GrindFailFast.lean
@@ -38,7 +38,7 @@ as mirrors at the end). The gate is loud in both failure directions:
   not in the default set.)
 -/
 
-@[expose] public section
+public section
 
 open OracleComp ProbComp ENNReal
 

--- a/VCVioTest/LongChainPrograms.lean
+++ b/VCVioTest/LongChainPrograms.lean
@@ -36,7 +36,7 @@ Conventions (as in the sibling files):
 * **Only stable tactics.** No example hangs or explodes.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp ProbComp ENNReal
 

--- a/VCVioTest/MerkleTreeExtractability.lean
+++ b/VCVioTest/MerkleTreeExtractability.lean
@@ -17,7 +17,7 @@ queries sample independently, and `extractabilityGame`, where the full experimen
 through one shared cache.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec
 

--- a/VCVioTest/MerkleTreeMonadic.lean
+++ b/VCVioTest/MerkleTreeMonadic.lean
@@ -16,7 +16,7 @@ cover traversal and child order, mixed authentication paths, global subtree addr
 and the height-zero boundary.
 -/
 
-@[expose] public section
+public section
 
 namespace VCVioTest.MerkleTreeMonadicCanary
 

--- a/VCVioTest/MerkleTreeMultiExtractability.lean
+++ b/VCVioTest/MerkleTreeMultiExtractability.lean
@@ -15,7 +15,7 @@ Small compile-time instantiations of the whole-adversary game theorem with real 
 checkpoint-dependent claims, and proof-frontier disagreement.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec
 
@@ -37,6 +37,7 @@ def model : MerkleTreeExtractability.NodeQueryModel Query Unit Bool where
   address_mkQuery := by intros; rfl
   input_mkQuery := by intros; rfl
 
+@[expose]
 def skeleton : Skeleton :=
   .internal .leaf .leaf
 
@@ -181,6 +182,7 @@ theorem claimingGlobalStrongBound (rounds : ℕ) :
 
 /-! ## Proof-only full-opening disagreement -/
 
+@[expose]
 def selectRight : LeafData Bool skeleton :=
   .internal (.leaf false) (.leaf true)
 

--- a/VCVioTest/MonadProbability.lean
+++ b/VCVioTest/MonadProbability.lean
@@ -27,7 +27,7 @@ closer; see *Normal forms and the tactic contract* in `docs/agents/probability.m
 with no probability API yet are recorded as prose gaps at the end.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp ProbComp ENNReal
 

--- a/VCVioTest/OracleComp/SecurityFamily.lean
+++ b/VCVioTest/OracleComp/SecurityFamily.lean
@@ -16,11 +16,12 @@ The equations ensure packing retains the parameter and both branch-dependent pay
 collapsing the family to a pointwise collection.
 -/
 
-@[expose] public section
+public section
 
 namespace OracleComp.SecurityFamily
 
 /-- A genuinely nonconstant oracle family: at parameter `n`, a query returns `Fin (n + 1)`. -/
+@[expose]
 def indexedSpec (n : Nat) : OracleSpec Unit :=
   fun _ ↦ Fin (n + 1)
 

--- a/VCVioTest/PerfectMerkleTree.lean
+++ b/VCVioTest/PerfectMerkleTree.lean
@@ -17,7 +17,7 @@ root reconstruction, and oriented collision extraction. The hashes are deliberat
 noncommutative or collision-heavy so that an address, order, or endpoint regression is visible.
 -/
 
-@[expose] public section
+public section
 
 namespace VCVioTest.PerfectMerkleTreeCanary
 

--- a/VCVioTest/ProbabilityTactics.lean
+++ b/VCVioTest/ProbabilityTactics.lean
@@ -35,7 +35,7 @@ Conventions (see *Normal forms and the tactic contract* in `docs/agents/probabil
 reachable. `ProbComp` itself never fails — interesting `Pr[⊥ | _]` lives in `OptionT ProbComp`.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp ProbComp ENNReal
 

--- a/VCVioTest/QueryHom.lean
+++ b/VCVioTest/QueryHom.lean
@@ -16,7 +16,7 @@ Producer-level tests for identity, composition, and free-oracle interpretation t
 checks that `QueryHom.ofSimulateQ` preserves a nontrivial handler's state evolution.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec
 

--- a/VCVioTest/RoundByRound/OneRound.lean
+++ b/VCVioTest/RoundByRound/OneRound.lean
@@ -55,7 +55,7 @@ so that `extract`'s output satisfies it, and then:
   each hypothesis separately inhabited is weaker than a witness for the whole bundle.
 -/
 
-@[expose] public section
+public section
 
 open scoped ENNReal
 

--- a/VCVioTest/SampleableType.lean
+++ b/VCVioTest/SampleableType.lean
@@ -16,7 +16,7 @@ changes so that it no longer fires), the build fails and the regression surfaces
 without needing a runtime check.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp ProbComp ENNReal
 

--- a/VCVioTest/Smoke.lean
+++ b/VCVioTest/Smoke.lean
@@ -14,6 +14,6 @@ Minimal executable that imports the full VCVio library and runs a trivial comput
 Used by CI to measure build timing and verify the library typechecks end-to-end.
 -/
 
-@[expose] public section
+public section
 def main : IO Unit := do
   IO.println "VCVio smoke test OK"

--- a/VCVioTest/UniformOn.lean
+++ b/VCVioTest/UniformOn.lean
@@ -15,7 +15,7 @@ the independent-pair characterization, and the bijective pushforward used by one
 arguments.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory ProbabilityTheory
 open scoped ENNReal

--- a/VCVioTest/Unpredictability.lean
+++ b/VCVioTest/Unpredictability.lean
@@ -17,7 +17,7 @@ distinct target values rather than the number of positions from which those valu
 They also exercise the bound in a strictly nonzero universe.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec ENNReal
 

--- a/docs/agents/module-system.md
+++ b/docs/agents/module-system.md
@@ -337,6 +337,19 @@ The boundary has three canaries and one ratchet:
   in the PR that converts a file so the ceiling follows the decrease; raise
   it only with a stated reason in the PR description.
 
+Converting a file is compiler-guided: switch it to plain `public section`,
+build, and add `@[expose]` to exactly the definitions the errors name (the
+module-system compiler lists them under "may need to be `@[expose]`d", and a
+public `rfl` theorem reports the unexposed definition it would have to unfold).
+Two kinds of file behave differently under that procedure. Proof-style modules
+(examples, tactic gates, lemma canaries) convert with a handful of marks, since
+their definitions are consumed through lemmas. Executable fixtures (a `main`,
+`decide`/`rfl` over the file's own test data, structures whose every field is
+projected by a later example) need nearly every definition exposed, and for
+them `@[expose] public section` is the honest spelling; leave those broad and
+say so in the file's docstring only when the reason is not obvious from the
+content.
+
 Changes that add PolyFun API and consume it from VCVio require two coordinated
 repository changes:
 

--- a/docs/agents/module-system.md
+++ b/docs/agents/module-system.md
@@ -337,18 +337,19 @@ The boundary has three canaries and one ratchet:
   in the PR that converts a file so the ceiling follows the decrease; raise
   it only with a stated reason in the PR description.
 
-Converting a file is compiler-guided: switch it to plain `public section`,
-build, and add `@[expose]` to exactly the definitions the errors name (the
-module-system compiler lists them under "may need to be `@[expose]`d", and a
-public `rfl` theorem reports the unexposed definition it would have to unfold).
-Two kinds of file behave differently under that procedure. Proof-style modules
-(examples, tactic gates, lemma canaries) convert with a handful of marks, since
-their definitions are consumed through lemmas. Executable fixtures (a `main`,
-`decide`/`rfl` over the file's own test data, structures whose every field is
-projected by a later example) need nearly every definition exposed, and for
-them `@[expose] public section` is the honest spelling; leave those broad and
-say so in the file's docstring only when the reason is not obvious from the
-content.
+Start a conversion by switching to plain `public section` and building. The
+compiler identifies definitions that existing public declarations need exposed
+under "may need to be `@[expose]`d". Then review the intended downstream API:
+repository callers may exercise only some parameter sets. In particular,
+bundles with concrete type fields must expose those projections when callers
+need to supply ordinary values of those types. Add public-import canaries for
+such interfaces, including every exported specialization.
+
+Proof modules often need only a few selectively exposed definitions. Fixtures
+whose public proofs intentionally unfold nearly every definition may retain
+`@[expose] public section`; explain that need in the module docstring when it
+is not apparent from the contents. Runtime execution alone (including `main`)
+does not require exposing definition bodies to proof reduction.
 
 Changes that add PolyFun API and consume it from VCVio require two coordinated
 repository changes:

--- a/scripts/expose_boundary_baseline.tsv
+++ b/scripts/expose_boundary_baseline.tsv
@@ -1,10 +1,10 @@
 Examples	64
 Extern	10
 HashSig	46
-HashSigTest	6
+HashSigTest	3
 LatticeCrypto	44
-LatticeCryptoTest	8
+LatticeCryptoTest	0
 ToMathlib	56
 VCVio	272
-VCVioTest	29
+VCVioTest	9
 VCVioWidgets	0

--- a/scripts/expose_boundary_baseline.tsv
+++ b/scripts/expose_boundary_baseline.tsv
@@ -1,8 +1,8 @@
 Examples	64
-Extern	10
+Extern	0
 HashSig	46
 HashSigTest	3
-LatticeCrypto	44
+LatticeCrypto	37
 LatticeCryptoTest	0
 ToMathlib	56
 VCVio	272


### PR DESCRIPTION
Replace broad `@[expose] public section` with selective exposure in 48 files: 20 framework tests, eight lattice test files, three hash-signature tests, all ten previously broad Extern files, and seven lattice concrete implementations. The exposure ceilings decrease accordingly.

Keep the concrete ML-DSA primitive and encoding bundles exposed for all three parameter sets (44, 65, and 87). Without the 44/87 annotations, ordinary importers cannot supply `ByteArray` values to the public encoding types or use their concrete arithmetic carriers. The regression examples in `LatticeCryptoTest/MLDSA/Helpers.lean` cover all three encodings and all three carrier types for every parameter set.

The module-system guide explains how to combine compiler diagnostics with review of the intended downstream API. Runtime execution alone does not require exposing bodies to proof reduction. Detailed guidance stays in that guide.

Compatibility: selected definitions now become opaque to downstream proof reduction. Existing callers that unfold those implementation bodies may need public equations or deliberate selective exposure. Function bodies, theorem statements, and algorithms are unchanged; ML-DSA byte/carrier interfaces remain concrete.

Exposure ceilings relative to merged #650:

| Library | Before | After |
| --- | ---: | ---: |
| VCVioTest | 29 | 9 |
| LatticeCryptoTest | 8 | 0 |
| HashSigTest | 6 | 3 |
| Extern | 10 | 0 |
| LatticeCrypto | 44 | 37 |

Validation for `bf606288` (rebased onto main after #650 merged, with identical validated file contents):

- All seven production and three test libraries pass (4,110 jobs), with no non-sorry source warnings or test warnings.
- Public-import ML-DSA probe reproduces failures for 44/87 before the fix and passes afterward; all 18 committed carrier/encoding canaries compile.
- Compiled `lake exe slhdsa_wots_tests` passes for all 12 SHA2/SHAKE profiles and checks SHA2 addresses.
- Axiom sweep passes: 17,847 declarations across 549 modules, 40 existing sorry-tainted declarations, zero nonstandard axiom taint; baseline unchanged.
- Style on every touched Lean module, docs/fragments, five boundary checks, exposure fixtures, umbrella regeneration, and whitespace checks pass.
- Fresh GitHub CI runs on the published head before queueing.
