### PR TITLE
docs(program-logic): pin the vcgen name collision, record the Loom boundary, refresh the toolchain claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ For the tactic reference, proof-mode entry points, and workflow details, see
 `Lean.Meta.Sym.Pattern` / `Lean.Meta.Sym.DiscrTree`. `Sym.*` is under active
 development in core Lean; see the *Internal Architecture* and *SymM
 Stability Note* sections of that doc for the churn classes to watch at each
-toolchain bump and the re-entry plan for the deferred `mvcgen'`/`SymM`
+toolchain bump and the re-entry plan for the deferred symbolic
 rewriter bridge (when it lands, `Sym.Simp.mkTheoremFromDecl` rebuilds the
 bundle on demand).
 

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -37,3 +37,4 @@ public import VCVioTest.Smoke
 public import VCVioTest.UniformOn
 public import VCVioTest.UniversePolymorphism
 public import VCVioTest.Unpredictability
+public import VCVioTest.VCGenAmbiguity

--- a/VCVioTest/VCGenAmbiguity.lean
+++ b/VCVioTest/VCGenAmbiguity.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import VCVio
+
+/-!
+# `vcgen` name-collision canary
+
+Core Lean ships a tactic spelled `vcgen` (`Std.Tactic.Do`), and VCVio's program logic ships its
+own `vcgen` (`VCVio.ProgramLogic.Tactics.Unary`). Both are in scope in any file that imports the
+root `VCVio` module, because the `Std.Do` bridges under `VCVio/ProgramLogic/Unary/` import
+core's syntax. The parser then produces a `choice` node and the elaborator tries the
+alternatives in turn; this file pins the behaviour that VCVio proofs rely on, namely that a
+`wp`-triple goal is still closed by `vcgen` in that setting. If a toolchain bump makes the choice
+node stop falling through (an error from core's `vcgen` no longer counts as "try the next
+alternative"), this file fails first, and the fix is the planned rename of VCVio's tactic
+rather than a reorder of imports.
+-/
+
+public section
+
+open ENNReal OracleSpec OracleComp
+open Lean.Order
+open OracleComp.ProgramLogic
+open scoped OracleComp.ProgramLogic
+
+namespace VCVioTest.VCGenAmbiguity
+
+universe u
+
+variable {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec] {α : Type}
+
+example (oa : OracleComp spec α) (post : Nat × α → Nat → ℝ≥0∞) :
+    ⦃fun s => wp⟦oa⟧ (fun a => post (s, a) (s + 1))⦄
+      (do
+        let s ← (MonadStateOf.get : StateT Nat (OracleComp spec) Nat)
+        MonadStateOf.set (s + 1)
+        let a ← (MonadLift.monadLift oa : StateT Nat (OracleComp spec) α)
+        pure (s, a))
+    ⦃post⦄ := by
+  vcgen
+
+example (s' : Nat) (oa : OracleComp spec α) (post : α → Nat → ℝ≥0∞) :
+    ⦃fun _ => wp⟦oa⟧ (fun a => post a s')⦄
+      (do
+        MonadStateOf.set s'
+        MonadLift.monadLift oa : StateT Nat (OracleComp spec) α)
+    ⦃post⦄ := by
+  vcgen
+
+end VCVioTest.VCGenAmbiguity

--- a/VCVioTest/VCGenAmbiguity.lean
+++ b/VCVioTest/VCGenAmbiguity.lean
@@ -5,7 +5,6 @@ Authors: Devon Tuma
 -/
 
 module
-
 public import VCVio
 
 /-!
@@ -16,10 +15,9 @@ own `vcgen` (`VCVio.ProgramLogic.Tactics.Unary`). Both are in scope in any file 
 root `VCVio` module, because the `Std.Do` bridges under `VCVio/ProgramLogic/Unary/` import
 core's syntax. The parser then produces a `choice` node and the elaborator tries the
 alternatives in turn; this file pins the behaviour that VCVio proofs rely on, namely that a
-`wp`-triple goal is still closed by `vcgen` in that setting. If a toolchain bump makes the choice
-node stop falling through (an error from core's `vcgen` no longer counts as "try the next
-alternative"), this file fails first, and the fix is the planned rename of VCVio's tactic
-rather than a reorder of imports.
+`wp`-triple goal is still closed by `vcgen` in that setting. These examples exercise
+StateT state operations and lifted oracle computations under the combined tactic imports.
+Changes to tactic dispatch or the imported syntax must preserve this proof-mode behavior.
 -/
 
 public section

--- a/docs/agents/module-system.md
+++ b/docs/agents/module-system.md
@@ -242,6 +242,24 @@ application, composition, or extensionality law, or add that law at the owning
 module boundary. Constructor equations and definitions whose reduction is an
 intentional documented API may still use `rfl` directly.
 
+## The Loom import boundary
+
+The pinned `loom2` fork supplies the Loom-style `WP`/`Triple` abstractions
+and the `ℝ≥0∞`/`Prob` lattice instances the program logic runs on. Its blast
+radius is kept explicit so the migration to core's WP layer (`Std.WP`, once it
+is public) touches a known set of files. `Loom.*` may be imported only by:
+
+- `ToMathlib/Control/Monad/RelWP.lean`;
+- `VCVio/ProgramLogic/Unary/Loom/Qualitative.lean`,
+  `VCVio/ProgramLogic/Unary/Loom/Quantitative.lean`, and
+  `VCVio/ProgramLogic/Unary/Loom/Probabilistic.lean`; and
+- `VCVio/ProgramLogic/Tactics/Unary/Internals.lean`.
+
+Everything else reaches Loom through those modules' public surface. A new
+`import Loom.…` elsewhere is a review blocker unless it comes with an entry
+here and a reason the existing bridges cannot carry it. This is a convention
+enforced at review, not a script.
+
 ## Restoring `private` correctly
 
 The module migration changed the meaning of `private`: a public exposed body

--- a/docs/agents/module-system.md
+++ b/docs/agents/module-system.md
@@ -245,9 +245,12 @@ intentional documented API may still use `rfl` directly.
 ## The Loom import boundary
 
 The pinned `loom2` fork supplies the Loom-style `WP`/`Triple` abstractions
-and the `ℝ≥0∞`/`Prob` lattice instances the program logic runs on. Its blast
-radius is kept explicit so the migration to core's WP layer (`Std.WP`, once it
-is public) touches a known set of files. `Loom.*` may be imported only by:
+and the `ℝ≥0∞`/`Prob` lattice instances the program logic runs on. Its import
+boundary keeps a future migration to core's WP layer limited to a known set
+of files. `Std.Do.WP` is already public at the Lean v4.33.1 pin and is used by
+VCVio's `StdDoBridge`; migrating Loom's quantitative and relational clients
+from its three-parameter `PredTrans` and `EPost` APIs to core's `PostShape`
+API is separate work. `Loom.*` may be imported only by:
 
 - `ToMathlib/Control/Monad/RelWP.lean`;
 - `VCVio/ProgramLogic/Unary/Loom/Qualitative.lean`,

--- a/docs/agents/program-logic.md
+++ b/docs/agents/program-logic.md
@@ -565,8 +565,9 @@ abbreviations, beta/zeta/eta-reduces, and elaborates universes); `Sym.DiscrTree`
 is a thin wrapper over `Lean.Meta.DiscrTree` whose insertion keys come from
 those preprocessed patterns and whose lookup is the pure structural
 `getMatch`. Core also ships a `Sym.Simp.Theorems` bundle (discrimination-tree
-+ `Sym.Simp.Theorem` records) used by the upcoming `mvcgen'` frontend; we do
-not consume it today (see *Future `mvcgen` bridge (deferred)* below) but
++ `Sym.Simp.Theorem` records) that core's own Sym-based `vcgen` consumes
+(`Lean.Elab.Tactic.Do.Internal`); we do not consume it today (see *Future
+`vcgen` bridge (deferred)* below) but
 `Sym.Simp.mkTheoremFromDecl` lets us reconstruct it on demand from the
 `@[wpStep]` registry once the `SymM → TacticM` proof-application bridge
 stabilises in core.
@@ -639,7 +640,7 @@ same candidate pool.
 `Lean.Meta.Sym.*` is still under active development in core Lean. The APIs
 we depend on today (`Sym.Pattern`, `Sym.DiscrTree`, `Sym.insertPattern`,
 `Sym.getMatch`, `Sym.mkPatternFromDeclWithKey`, and `SpecProof` in
-`Lean.Elab.Tactic.Do.SpecAttr`) are all used by `mvcgen`/`mvcgen'` in core
+`Lean.Elab.Tactic.Do.SpecAttr`) are all used by core's `mvcgen` and `vcgen`
 too, so their direction is broadly stable, but none of them carry a
 compat-preservation promise yet. Expect the following classes of churn each
 time we bump the toolchain:
@@ -656,7 +657,7 @@ time we bump the toolchain:
   clearly-marked `Preprocessed-body head matchers` section.
 - **`Sym.Simp.Theorem` field renames / `mkTheoremFromDecl` moves**. We do
   *not* call `mkTheoremFromDecl` today (the dispatcher works off the
-  `Sym.DiscrTree` alone). When the deferred `mvcgen'`/`SymM` bridge lands,
+  `Sym.DiscrTree` alone). When the deferred `vcgen`/`SymM` bridge lands,
   this is where we'll need to pick the bundle back up; until then this
   churn class is no-op for us.
 - **`SpecProof` variants**. We only use `.global` today. If core splits or
@@ -674,12 +675,20 @@ structural `getMatch` over `isDefEq`, and keep an explicit `TacticM`
 fallback path (`rw` / `simp only`) so failures in any single `Sym` lookup
 stage degrade gracefully.
 
-### Future `mvcgen` bridge (deferred)
+### Future `vcgen` bridge (deferred)
 
-Lean v4.29.0 ships `mvcgen` with the classical `Std.Do` handler catalogue
-but does *not* expose a `SymM`-level rewriter we can hand a goal to (the
-`mvcgen'` pilot lives on a newer toolchain). The planned shape of that
-bridge, for when the API lands:
+Lean v4.33 ships two frontends side by side: the classical `mvcgen` over the
+`Std.Do` handler catalogue, and the Sym-based `vcgen` (`Std.Tactic.Do`, with
+its elaborator under `Lean.Elab.Tactic.Do.Internal`). Neither is deprecated at
+this pin. The `SymM`-level rewriter and the `SymM → TacticM` reifier that
+`vcgen` runs on are internal, so there is still no public entry point we can
+hand a goal to. Core's `vcgen` also collides by name with VCVio's `vcgen`
+(`Tactics/Unary.lean`): both are in scope wherever the root `VCVio` module is
+imported, the parser produces a `choice` node, and
+`VCVioTest/VCGenAmbiguity.lean` pins that a `wp`-triple goal still closes in
+that setting. The rename of VCVio's tactic is scheduled for the toolchain bump
+that publishes the WP layer (`Std.WP`), together with the retarget below. The
+planned shape of that bridge, for when the API lands:
 
 1. Build a `Sym.Simp.Theorems` bundle from the union of `@[wpStep]` and
    `@[vcspec]` registries by mapping `Sym.Simp.mkTheoremFromDecl` over
@@ -690,9 +699,9 @@ bridge, for when the API lands:
    `Sym.Simp.Theorems.rewrite thms goal` (or whichever `simpImpl` variant
    core exposes). Results come back as a `Sym.Simp.Step`.
 3. Reify the resulting rewritten goal and proof term back into `TacticM`
-   via the standard `SymM → MetaM` reifier that accompanies `mvcgen'` in
-   core. Until that reifier is public, we cannot close the loop; the
-   current `TacticM`-side dispatch covers the same rules without it.
+   via the `SymM → MetaM` reifier that core's `vcgen` uses internally.
+   Until that reifier is public, we cannot close the loop; the current
+   `TacticM`-side dispatch covers the same rules without it.
 
 Treat any `Sym.*` bump to Lean core as a signal to re-read the two
 registry files and the `runWpStepRules` docstring. If a bump breaks us,

--- a/docs/agents/program-logic.md
+++ b/docs/agents/program-logic.md
@@ -569,8 +569,8 @@ those preprocessed patterns and whose lookup is the pure structural
 (`Lean.Elab.Tactic.Do.Internal`); we do not consume it today (see *Future
 `vcgen` bridge (deferred)* below) but
 `Sym.Simp.mkTheoremFromDecl` lets us reconstruct it on demand from the
-`@[wpStep]` registry once the `SymM → TacticM` proof-application bridge
-stabilises in core.
+`@[wpStep]` registry when VCVio's symbolic proof-application bridge is
+implemented and validated.
 
 Building on `Sym.Pattern` + `Sym.DiscrTree` means our registries share the
 same pattern preprocessing and lookup cost profile as future core tactics,
@@ -677,31 +677,40 @@ stage degrade gracefully.
 
 ### Future `vcgen` bridge (deferred)
 
-Lean v4.33 ships two frontends side by side: the classical `mvcgen` over the
+Lean v4.33.1 ships two frontends side by side: the classical `mvcgen` over the
 `Std.Do` handler catalogue, and the Sym-based `vcgen` (`Std.Tactic.Do`, with
-its elaborator under `Lean.Elab.Tactic.Do.Internal`). Neither is deprecated at
-this pin. The `SymM`-level rewriter and the `SymM → TacticM` reifier that
-`vcgen` runs on are internal, so there is still no public entry point we can
-hand a goal to. Core's `vcgen` also collides by name with VCVio's `vcgen`
+its elaborator under `Lean.Elab.Tactic.Do.Internal`). Both are experimental;
+neither is deprecated at this pin. Core's `vcgen` collides by name with VCVio's `vcgen`
 (`Tactics/Unary.lean`): both are in scope wherever the root `VCVio` module is
 imported, the parser produces a `choice` node, and
 `VCVioTest/VCGenAmbiguity.lean` pins that a `wp`-triple goal still closes in
-that setting. The rename of VCVio's tactic is scheduled for the toolchain bump
-that publishes the WP layer (`Std.WP`), together with the retarget below. The
-planned shape of that bridge, for when the API lands:
+that setting. Resolve the tactic naming when coordinating a future migration
+of this proof mode.
+
+The pinned core already publicly exposes `Sym.Simp.Theorems.rewrite`,
+`Sym.Simp.SimpM.run`, and `SymM.run` through `Lean.Meta.Sym.Simp.Rewrite`
+and its public imports. `SymM.run` executes symbolic computations in `MetaM`;
+rewriting returns a `Sym.Simp.Result` carrying the equality proof when an
+expression changes. VCVio's deferred work is the adapter from its registries
+and quantitative goals to those operations, including expression sharing,
+normal forms, side conditions, and proof application. Likewise, `Std.Do.WP`
+is already public and used by `StdDoBridge`; Loom's quantitative and relational
+clients need a separate migration to the `PostShape` API. The planned shape
+of the symbolic bridge is:
 
 1. Build a `Sym.Simp.Theorems` bundle from the union of `@[wpStep]` and
    `@[vcspec]` registries by mapping `Sym.Simp.mkTheoremFromDecl` over
    `getAllWpStepEntries` (and the analogous `@[vcspec]` accessor). We do
    not eagerly maintain the bundle in the env extension because it only
    feeds the deferred SymM rewriter and pulls in `Lean.Meta.Sym.Simp.*`.
-2. Translate the current `wp`-bearing goal into `Sym.Simp.SimpM` and run
-   `Sym.Simp.Theorems.rewrite thms goal` (or whichever `simpImpl` variant
-   core exposes). Results come back as a `Sym.Simp.Step`.
-3. Reify the resulting rewritten goal and proof term back into `TacticM`
-   via the `SymM → MetaM` reifier that core's `vcgen` uses internally.
-   Until that reifier is public, we cannot close the loop; the current
-   `TacticM`-side dispatch covers the same rules without it.
+2. Prepare the expression from the current `wp`-bearing goal with the sharing
+   and normalization required by `SymM`, then run
+   `Sym.Simp.Theorems.rewrite` through `Sym.Simp.SimpM.run`. Inspect the
+   resulting `Sym.Simp.Result` and any side conditions.
+3. Execute the symbolic computation through `SymM.run`, apply its equality
+   proof to the current goal, and return the remaining goals to `TacticM`.
+   Validate this adapter against the existing tactic examples before adopting
+   it; the current dispatch continues to use `rw` and `simp only`.
 
 Treat any `Sym.*` bump to Lean core as a signal to re-read the two
 registry files and the `runWpStepRules` docstring. If a bump breaks us,


### PR DESCRIPTION
## Summary

VCVio and Lean core both provide a tactic named `vcgen`. Add two StateT regression examples that close quantitative `wp` triples with `vcgen` after importing the root `VCVio` module, where both parsers are in scope.

Document the five permitted direct Loom importers and refresh the program-logic migration notes against Lean v4.33.1. Core's `mvcgen` and symbolic `vcgen` are experimental, and neither is deprecated at this pin. `Std.Do.WP`, `Sym.Simp.Theorems.rewrite`, `Sym.Simp.SimpM.run`, and `SymM.run` are already public. The deferred work is VCVio's adapter for its quantitative goals and registries, plus the separate migration of Loom's quantitative and relational clients to `PostShape`.

Align the AGENTS.md cross-reference and the regression module's description with those facts. The parser probe confirms a `choice` node containing both tactic parsers; the regression examples check proof-mode behavior under their combined imports.

## Verification

Validated on current main (`ffd0ca19`) plus this PR:

- `lake build ToMathlib VCVio LatticeCrypto Extern HashSig Examples VCVioWidgets VCVioTest`; no non-sorry source warnings and no VCVioTest warnings.
- `./scripts/test-axiomsweep.sh` and `lake exe axiomsweep --check`: fixture matrix passes; baseline unchanged, 40 existing sorry-tainted declarations and zero non-standard axioms.
- `lake exe lint-style VCVioTest.VCGenAmbiguity`; umbrella regeneration unchanged.
- Agent documentation, generated doc fragments, PolyFun/PMF boundaries, Extern/Interop isolation, and `git diff --check` pass.
- Compiled probes verify the public WP/symbolic APIs and the two-parser syntax choice at the pinned toolchain.
