### PR TITLE
fix(Falcon): sign-extend the high halves in the fixed-point multiply

### DIFF
--- a/LatticeCrypto/Falcon/Concrete/FXR.lean
+++ b/LatticeCrypto/Falcon/Concrete/FXR.lean
@@ -74,13 +74,15 @@ def fxr_round (x : FXR) : Int32 :=
 
 -- fxr_mul: fixed-point multiply.
 -- Portable 4-part decomposition of the 128-bit product:
---   xl, xh = unsigned low / signed high 32-bit halves
+--   xl, xh = unsigned low / signed high 32-bit halves (the high half is an arithmetic
+--   shift of the signed word, as in the reference; a logical shift would drop the sign
+--   and break every product with a negative operand and a nonzero low half)
 --   result = (xl*yl)>>32 + xl*(int)yh + (int)xh*yl + ((int)xh*(int)yh)<<32
 def fxr_mul (x y : FXR) : FXR :=
   let xl : UInt64 := x &&& 0xFFFFFFFF
-  let xh : Int64 := (x >>> 32).toInt64
+  let xh : Int64 := x.toInt64 >>> (32 : Int64)
   let yl : UInt64 := y &&& 0xFFFFFFFF
-  let yh : Int64 := (y >>> 32).toInt64
+  let yh : Int64 := y.toInt64 >>> (32 : Int64)
   let z0 : UInt64 := (xl * yl) >>> 32
   let z1 : UInt64 := xl * yh.toUInt64
   let z2 : UInt64 := xh.toUInt64 * yl
@@ -90,7 +92,7 @@ def fxr_mul (x y : FXR) : FXR :=
 -- fxr_sqr: specialized squaring.
 def fxr_sqr (x : FXR) : FXR :=
   let xl : UInt64 := x &&& 0xFFFFFFFF
-  let xh : Int64 := (x >>> 32).toInt64
+  let xh : Int64 := x.toInt64 >>> (32 : Int64)
   let z0 : UInt64 := (xl * xl) >>> 32
   let z1 : UInt64 := xl * xh.toUInt64
   let z3 : UInt64 := (xh * xh).toUInt64 <<< 32

--- a/LatticeCryptoTest/Falcon/Main.lean
+++ b/LatticeCryptoTest/Falcon/Main.lean
@@ -661,6 +661,27 @@ def runFalconLowLevelTests (st : IO.Ref TestState) : IO Unit := do
       (Falcon.Concrete.FXR.fxr_double one == two)
     check st "fxr_half(2) = 1"
       (Falcon.Concrete.FXR.fxr_half two == one)
+    -- Signed operands: `fxr_mul` and `fxr_sqr` are the floor of the exact product in 32.32
+    -- units, as in the reference (`int128` product shifted right by 32).
+    let exactMul (x y : UInt64) : UInt64 :=
+      (Int64.ofInt ((x.toInt64.toInt * y.toInt64.toInt) >>> 32)).toUInt64
+    check st "fxr_mul(-1.0, 0.5) = -0.5"
+      (Falcon.Concrete.FXR.fxr_mul 0xFFFFFFFF00000000 0x80000000 == 0xFFFFFFFF80000000)
+    check st "fxr_mul(0.5, -1.0) = -0.5"
+      (Falcon.Concrete.FXR.fxr_mul 0x80000000 0xFFFFFFFF00000000 == 0xFFFFFFFF80000000)
+    check st "fxr_sqr(-1.25) = 1.5625"
+      (Falcon.Concrete.FXR.fxr_sqr 0xFFFFFFFEC0000000 == 0x190000000)
+    let signedVals : List UInt64 :=
+      [0xFFFFFFFC40000000, 0xFFFFFFFEC0000000, 0xFFFFFFFF00000000, 0xFFFFFFFF80000000, 0,
+        0x80000000, 0x100000000, 0x140000000, 0x280000000, 0x7FFFFFFF00000000]
+    let mut mulOk := true
+    let mut sqrOk := true
+    for x in signedVals do
+      sqrOk := sqrOk && (Falcon.Concrete.FXR.fxr_sqr x == exactMul x x)
+      for y in signedVals do
+        mulOk := mulOk && (Falcon.Concrete.FXR.fxr_mul x y == exactMul x y)
+    check st "fxr_mul = floor(x·y / 2^32) on a signed grid" mulOk
+    check st "fxr_sqr = floor(x² / 2^32) on a signed grid" sqrOk
   IO.println ""
   flush
   -- ── 27. Diagnostic: target vector & NTRU relation check ──────────


### PR DESCRIPTION
`FXR.fxr_mul` and `FXR.fxr_sqr` (the 32.32 fixed-point arithmetic ported from `kgen_fxp.c` / `kgen_inner.h`) read the high half of each operand with a logical shift, `(x >>> 32).toInt64`, where the reference uses an arithmetic shift of the signed word (`(int64_t)x >> 32`). The four-part product is then wrong for every pair with a negative operand whose partner has a nonzero low half, by `2^32·[x<0]·yl + 2^32·[y<0]·xl (mod 2^64)`:

```
fxr_mul (-1.0) 0.5  = 0x7fffffff80000000   -- Lean, before
                    = 0xffffffff80000000   -- C reference (= -0.5)
```

`fxr_sqr` is off in the same way except when the low half is `0` or `2^31`, which is why `fxr_sqr (-1.5)` happened to be right. Squares of the key polynomials and every twiddle multiplication in `vect_FFT` hit the bug (the fixed-point FFT of a real Falcon-512 key is off by ~2·10⁹ against the exact transform; after the fix, 6·10⁻⁸). Since `FXR` is the key-generation arithmetic, `NTRUSolver` sees this on any negative intermediate.

Fix: take the high halves as `x.toInt64 >>> (32 : Int64)` (arithmetic shift), matching the reference decomposition comment already in the file. The test executable now checks both against the exact `int128` semantics `floor(x·y / 2^32)` on a signed grid, plus the three witnesses above. `lake exe falcon_test` passes.
