### PR TITLE
fix(Falcon): make the packed FFT recursion an evaluation map; prove verification correctness at the concrete primitives

### DIFF
--- a/Extern.lean
+++ b/Extern.lean
@@ -9,6 +9,7 @@ public import Extern.Falcon.KeyGen
 public import Extern.Falcon.SamplerZ
 public import Extern.Falcon.Sampling
 public import Extern.Falcon.Sign
+public import Extern.Falcon.SignCorrectness
 public import Extern.Hashing
 public import Extern.MLDSA.FFI
 public import Extern.MLDSA.Instance

--- a/Extern/Falcon/Instance.lean
+++ b/Extern/Falcon/Instance.lean
@@ -9,10 +9,10 @@ public import Batteries.Data.Float.Rat
 public import Mathlib.Algebra.Order.Floor.Ring
 public import Mathlib.Analysis.SpecialFunctions.Exp
 public import LatticeCrypto.Falcon.Primitives
+public import LatticeCrypto.Falcon.PackedFFT
 public import LatticeCrypto.Falcon.Concrete.FloatLike
 public import LatticeCrypto.Falcon.Concrete.NTT
 public import LatticeCrypto.Falcon.Concrete.Encoding
-public import LatticeCrypto.Falcon.Concrete.FXR
 public import Extern.Falcon.SamplerZ
 public import Extern.Falcon.Sampling
 public import VCVio.OracleComp.Constructions.SampleableType
@@ -31,9 +31,14 @@ function for testing.
    the testable surface.
 
 2. **`concretePrimitives`**: Fills the abstract `Primitives` structure with
-   concrete implementations for the executable fields and a concrete FXR-backed
-   bridge for the FFT conversion fields. Used to connect the proof-level Falcon
-   interface to the concrete packed FFT representation.
+   concrete implementations for the executable fields (hash, codec, sampler, NTT)
+   and with the exact packed FFT of the specification for the three FFT
+   conversion fields (`Primitives.exactFftTarget`, `exactFftInt`, `exactIfftRound`).
+   The FFT fields are real-valued and never executed; the executable signing path
+   in `Extern.Falcon.Sign` carries its own floating-point FFT over `FloatLike`, as
+   the reference implementation signs in floating point (`sign_fpr.c`) and uses
+   32.32 fixed point only inside key generation (`kgen_fxp.c`). Relating that
+   floating-point pipeline to the exact one is the remaining bridge obligation.
 -/
 
 public section
@@ -143,44 +148,6 @@ private def sampleSamplerSeed : ProbComp ByteArray := do
   let bytes ← ProbComp.sampleIID samplerSeedBytes ($ᵗ UInt8)
   return ByteArray.mk <| Array.ofFn fun i : Fin samplerSeedBytes => bytes i
 
-private noncomputable def fxrScale : ℝ := (2 : ℝ) ^ (32 : Nat)
-
-/-- Interpret an `FXR` word as its signed 32.32 fixed-point real value. -/
-private noncomputable def fxrToReal (x : FXR.FXR) : ℝ :=
-  (x.toInt64.toInt : ℝ) / fxrScale
-
-/-- Encode a real number into Falcon's signed 32.32 fixed-point format by rounding
-to the nearest scaled integer. -/
-private noncomputable def realToFXR (x : ℝ) : FXR.FXR :=
-  (round (x * fxrScale)).toInt64.toUInt64
-
-/-- Convert an `R_q` polynomial to the coefficient array expected by the concrete FFT code. -/
-private def rqToInt32Array (p : Params) (f : Rq p.n) : Array Int32 :=
-  (Array.range p.n).map fun i => (ZMod.val (f.getD i 0)).toInt32
-
-/-- Convert an integer polynomial to the coefficient array expected by the concrete FFT code. -/
-private def intPolyToInt32Array (p : Params) (f : IntPoly p.n) : Array Int32 :=
-  (Array.range p.n).map fun i => (f.getD i 0).toInt32
-
-/-- Read Falcon's packed FXR FFT layout into the proof-level packed real vector. -/
-private noncomputable def fxrArrayToRealFFTPoly (p : Params) (f : Array FXR.FXR) :
-    RealFFTPoly p.fftDepth :=
-  Vector.ofFn fun i => fxrToReal (f.getD i.1 0)
-
-/-- Re-encode a proof-level packed FFT vector into Falcon's concrete FXR layout. -/
-private noncomputable def realFFTPolyToFXRArray (p : Params) (f : RealFFTPoly p.fftDepth) :
-    Array FXR.FXR :=
-  (Array.range p.n).map fun i =>
-    if h : i < 2 * 2 ^ p.fftDepth then
-      realToFXR (f.get ⟨i, h⟩)
-    else
-      0
-
-/-- Convert concrete FXR coefficients back to an integer polynomial via Falcon's
-reference fixed-point rounding rule. -/
-private def fxrArrayToIntPoly (p : Params) (f : Array FXR.FXR) : IntPoly p.n :=
-  Vector.ofFn fun i => (FXR.fxr_round (f.getD i.1 0)).toInt
-
 /-- Concrete Falcon primitive bundle used to connect the executable code to the abstract
 Falcon interfaces. -/
 noncomputable def concretePrimitives (p : Params) (hn : p.n = 2 ^ p.logn) :
@@ -193,12 +160,9 @@ noncomputable def concretePrimitives (p : Params) (hn : p.n = 2 ^ p.logn) :
     letI : FloatLike ℝ := realSamplerFloatLike
     let (z, _) := SamplerZ.samplerZ p.logn state μ σ⁻¹
     return z.toInt
-  fftTarget := fun c =>
-    fxrArrayToRealFFTPoly p <| FXR.vect_FFT p.logn <| FXR.vect_set p.logn (rqToInt32Array p c)
-  fftInt := fun f =>
-    fxrArrayToRealFFTPoly p <| FXR.vect_FFT p.logn <| FXR.vect_set p.logn (intPolyToInt32Array p f)
-  ifftRound := fun f =>
-    fxrArrayToIntPoly p <| FXR.vect_iFFT p.logn (realFFTPolyToFXRArray p f)
+  fftTarget := Primitives.exactFftTarget p
+  fftInt := Primitives.exactFftInt p
+  ifftRound := Primitives.exactIfftRound p
   compress := compress p.n
   decompress := decompress p.n
   nttOps := hn ▸ concreteNTTRingOps p.logn
@@ -207,6 +171,11 @@ noncomputable def concretePrimitives (p : Params) (hn : p.n = 2 ^ p.logn) :
 @[simp] theorem concretePrimitives_publicKeyBytes_eq
     (p : Params) (hn : p.n = 2 ^ p.logn) (h : Rq p.n) :
     (concretePrimitives p hn).publicKeyBytes h = publicKeyBytes p.logn h := by rfl
+
+/-- The FFT fields of `concretePrimitives` are the exact packed FFT of the specification. -/
+theorem concretePrimitives_exactFFT (p : Params) (hn : p.n = 2 ^ p.logn)
+    (h : 2 * 2 ^ p.fftDepth = p.n) : (concretePrimitives p hn).ExactFFT h :=
+  Primitives.exactFFT_of_eq _ h rfl rfl
 
 /-- `hashToPointForPublicKey` for `concretePrimitives` unfolds to the concrete FN-DSA hash path. -/
 @[simp] theorem concretePrimitives_hashToPointForPublicKey_eq

--- a/Extern/Falcon/SignCorrectness.lean
+++ b/Extern/Falcon/SignCorrectness.lean
@@ -9,6 +9,7 @@ import all Extern.Falcon.Instance
 import all Extern.Falcon.FPRBridge
 public import Extern.Falcon.FPRBridge
 public import LatticeCrypto.Falcon.Security
+public import LatticeCrypto.Falcon.Coset
 
 /-!
 # Verification correctness at the concrete Falcon primitives
@@ -17,7 +18,9 @@ public import LatticeCrypto.Falcon.Security
 trapdoor sampler lands on the coset. At `Falcon.Concrete.FPRBridge.verifyPrimitives` and
 `Falcon.Concrete.concretePrimitives` the codec is the concrete Golomb-Rice codec, whose round-trip
 `Falcon.Concrete.decompress_compress` is a theorem, so only the coset condition `hpreimage`
-remains: the lattice-point obligation of the floating-point inverse FFT.
+remains. `Falcon.hpreimage_of_landsOnLattice` reduces that condition further, to the
+lattice-point condition `Falcon.LandsOnLattice` on the fixed-point FFT pipeline together with
+the key relations; the `_of_landsOnLattice` variants below take only those.
 -/
 
 public section
@@ -51,6 +54,42 @@ theorem verify_sign_correct_concretePrimitives
     verify p (concretePrimitives p hn) pk msg sig = true :=
   verify_sign_correct p (concretePrimitives p hn) pk sk msg maxAttempts sig
     (fun s slen bytes h => decompress_compress p.n s slen bytes h) hpreimage hsig
+
+/-- Verification correctness at the concrete primitives bundle from key validity, invertibility
+of `f` modulo `q`, and the lattice-point condition on the fixed-point FFT pipeline. -/
+theorem verify_sign_correct_concretePrimitives_of_landsOnLattice
+    (p : Params) (hn : p.n = 2 ^ p.logn) (pk : PublicKey p) (sk : SecretKey p)
+    (hvalid : validKeyPair p pk sk = true)
+    (hunit : ∃ u : Rq p.n, negacyclicMul (IntPoly.toRq sk.f) u = 1)
+    (hz : ∀ c : Rq p.n, ∀ z ∈ support (Primitives.ffSampling (concretePrimitives p hn)
+      p.fftDepth (toFFTTarget p (concretePrimitives p hn) c sk) sk.tree),
+      LandsOnLattice p (concretePrimitives p hn) sk z)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hsig : some sig ∈ support (sign p (concretePrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (concretePrimitives p hn) pk msg sig = true := by
+  have hpos : 0 < p.n := by rw [hn]; positivity
+  have hkey := (validKeyPair_eq_true_iff p pk sk).mp hvalid |>.2
+  exact verify_sign_correct_concretePrimitives p hn pk sk msg maxAttempts sig
+    (hpreimage_of_landsOnLattice p (concretePrimitives p hn) hpos pk sk hkey
+      (capRelation_of_validKeyPair p hpos pk sk hvalid hunit) hz) hsig
+
+/-- The same at the FPR-backed verification primitives. -/
+theorem verify_sign_correct_verifyPrimitives_of_landsOnLattice
+    (p : Params) (hn : p.n = 2 ^ p.logn) (pk : PublicKey p) (sk : SecretKey p)
+    (hvalid : validKeyPair p pk sk = true)
+    (hunit : ∃ u : Rq p.n, negacyclicMul (IntPoly.toRq sk.f) u = 1)
+    (hz : ∀ c : Rq p.n, ∀ z ∈ support (Primitives.ffSampling (FPRBridge.verifyPrimitives p hn)
+      p.fftDepth (toFFTTarget p (FPRBridge.verifyPrimitives p hn) c sk) sk.tree),
+      LandsOnLattice p (FPRBridge.verifyPrimitives p hn) sk z)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hsig : some sig ∈ support
+      (sign p (FPRBridge.verifyPrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (FPRBridge.verifyPrimitives p hn) pk msg sig = true := by
+  have hpos : 0 < p.n := by rw [hn]; positivity
+  have hkey := (validKeyPair_eq_true_iff p pk sk).mp hvalid |>.2
+  exact verify_sign_correct_verifyPrimitives p hn pk sk msg maxAttempts sig
+    (hpreimage_of_landsOnLattice p (FPRBridge.verifyPrimitives p hn) hpos pk sk hkey
+      (capRelation_of_validKeyPair p hpos pk sk hvalid hunit) hz) hsig
 
 end Falcon.Concrete
 

--- a/Extern/Falcon/SignCorrectness.lean
+++ b/Extern/Falcon/SignCorrectness.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oleksandr Vovkotrub
+-/
+
+module
+import all Extern.Falcon.Instance
+import all Extern.Falcon.FPRBridge
+public import Extern.Falcon.FPRBridge
+public import LatticeCrypto.Falcon.Security
+
+/-!
+# Verification correctness at the concrete Falcon primitives
+
+`Falcon.verify_sign_correct` takes two facts about the primitives: the codec round-trips and the
+trapdoor sampler lands on the coset. At `Falcon.Concrete.FPRBridge.verifyPrimitives` and
+`Falcon.Concrete.concretePrimitives` the codec is the concrete Golomb-Rice codec, whose round-trip
+`Falcon.Concrete.decompress_compress` is a theorem, so only the coset condition `hpreimage`
+remains: the lattice-point obligation of the floating-point inverse FFT.
+-/
+
+public section
+
+open OracleComp OracleSpec Falcon
+
+namespace Falcon.Concrete
+
+/-- Verification correctness at the FPR-backed verification primitives, given only that the
+trapdoor sampler lands on the coset. -/
+theorem verify_sign_correct_verifyPrimitives
+    (p : Params) (hn : p.n = 2 ^ p.logn) (pk : PublicKey p) (sk : SecretKey p)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hpreimage : ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p (FPRBridge.verifyPrimitives p hn)).trapdoorSample pk sk c) →
+        (falconPSF p (FPRBridge.verifyPrimitives p hn)).eval pk x = c)
+    (hsig : some sig ∈ support (sign p (FPRBridge.verifyPrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (FPRBridge.verifyPrimitives p hn) pk msg sig = true :=
+  verify_sign_correct p (FPRBridge.verifyPrimitives p hn) pk sk msg maxAttempts sig
+    (fun s slen bytes h => decompress_compress p.n s slen bytes h) hpreimage hsig
+
+/-- Verification correctness at the concrete primitives bundle, given only that the trapdoor
+sampler lands on the coset. -/
+theorem verify_sign_correct_concretePrimitives
+    (p : Params) (hn : p.n = 2 ^ p.logn) (pk : PublicKey p) (sk : SecretKey p)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hpreimage : ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p (concretePrimitives p hn)).trapdoorSample pk sk c) →
+        (falconPSF p (concretePrimitives p hn)).eval pk x = c)
+    (hsig : some sig ∈ support (sign p (concretePrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (concretePrimitives p hn) pk msg sig = true :=
+  verify_sign_correct p (concretePrimitives p hn) pk sk msg maxAttempts sig
+    (fun s slen bytes h => decompress_compress p.n s slen bytes h) hpreimage hsig
+
+end Falcon.Concrete
+
+end

--- a/Extern/Falcon/SignCorrectness.lean
+++ b/Extern/Falcon/SignCorrectness.lean
@@ -18,9 +18,12 @@ public import LatticeCrypto.Falcon.Coset
 trapdoor sampler lands on the coset. At `Falcon.Concrete.FPRBridge.verifyPrimitives` and
 `Falcon.Concrete.concretePrimitives` the codec is the concrete Golomb-Rice codec, whose round-trip
 `Falcon.Concrete.decompress_compress` is a theorem, so only the coset condition `hpreimage`
-remains. `Falcon.hpreimage_of_landsOnLattice` reduces that condition further, to the
-lattice-point condition `Falcon.LandsOnLattice` on the fixed-point FFT pipeline together with
-the key relations; the `_of_landsOnLattice` variants below take only those.
+remains. `Falcon.hpreimage_of_landsOnLattice` reduces that condition to the lattice-point
+condition `Falcon.LandsOnLattice` on the FFT fields together with the key relations (the
+`_of_landsOnLattice` variants), and at `concretePrimitives`, whose FFT fields are the exact packed
+FFT, `Falcon.hpreimage_of_exactFFT` discharges it:
+`verify_sign_correct_concretePrimitives_of_validKeyPair` needs only a valid key pair with `f`
+invertible modulo `q`.
 -/
 
 public section
@@ -90,6 +93,24 @@ theorem verify_sign_correct_verifyPrimitives_of_landsOnLattice
   exact verify_sign_correct_verifyPrimitives p hn pk sk msg maxAttempts sig
     (hpreimage_of_landsOnLattice p (FPRBridge.verifyPrimitives p hn) hpos pk sk hkey
       (capRelation_of_validKeyPair p hpos pk sk hvalid hunit) hz) hsig
+
+/-- **Verification correctness at the concrete primitives** from key validity and invertibility
+of `f` modulo `q` alone. The coset condition is a theorem at the exact packed FFT
+(`hpreimage_of_exactFFT`); `hlogn` excludes the degenerate degree `n = 1`. -/
+theorem verify_sign_correct_concretePrimitives_of_validKeyPair
+    (p : Params) (hn : p.n = 2 ^ p.logn) (hlogn : 1 ≤ p.logn) (pk : PublicKey p)
+    (sk : SecretKey p) (hvalid : validKeyPair p pk sk = true)
+    (hunit : ∃ u : Rq p.n, negacyclicMul (IntPoly.toRq sk.f) u = 1)
+    (msg : List Byte) (maxAttempts : ℕ) (sig : Signature)
+    (hsig : some sig ∈ support (sign p (concretePrimitives p hn) pk sk msg maxAttempts)) :
+    verify p (concretePrimitives p hn) pk msg sig = true := by
+  have h : 2 * 2 ^ p.fftDepth = p.n := by
+    rw [hn, Params.fftDepth, ← pow_succ', Nat.sub_add_cancel hlogn]
+  have hpos : 0 < p.n := by rw [hn]; positivity
+  have hkey := (validKeyPair_eq_true_iff p pk sk).mp hvalid |>.2
+  exact verify_sign_correct_concretePrimitives p hn pk sk msg maxAttempts sig
+    (hpreimage_of_exactFFT p (concretePrimitives p hn) h (concretePrimitives_exactFFT p hn h)
+      pk sk hkey (capRelation_of_validKeyPair p hpos pk sk hvalid hunit)) hsig
 
 end Falcon.Concrete
 

--- a/LatticeCrypto.lean
+++ b/LatticeCrypto.lean
@@ -12,6 +12,7 @@ public import LatticeCrypto.Falcon.Concrete.NTRUSolver
 public import LatticeCrypto.Falcon.Concrete.NTT
 public import LatticeCrypto.Falcon.Concrete.PolyBigInt
 public import LatticeCrypto.Falcon.Concrete.SmallPrimeNTT
+public import LatticeCrypto.Falcon.Coset
 public import LatticeCrypto.Falcon.Encoding
 public import LatticeCrypto.Falcon.Params
 public import LatticeCrypto.Falcon.Primitives

--- a/LatticeCrypto.lean
+++ b/LatticeCrypto.lean
@@ -14,6 +14,7 @@ public import LatticeCrypto.Falcon.Concrete.PolyBigInt
 public import LatticeCrypto.Falcon.Concrete.SmallPrimeNTT
 public import LatticeCrypto.Falcon.Coset
 public import LatticeCrypto.Falcon.Encoding
+public import LatticeCrypto.Falcon.PackedFFT
 public import LatticeCrypto.Falcon.Params
 public import LatticeCrypto.Falcon.Primitives
 public import LatticeCrypto.Falcon.Scheme

--- a/LatticeCrypto/Falcon/Concrete/Encoding.lean
+++ b/LatticeCrypto/Falcon/Concrete/Encoding.lean
@@ -42,85 +42,291 @@ namespace Falcon.Concrete
 
 open Falcon
 
-/-! ## Signature compression -/
+/-! ## Signature compression
 
-/-- Compress a Falcon signature polynomial into at most `dlen` bytes. -/
-def compress (n : ℕ) (s : IntPoly n) (dlen : ℕ) : Option (List UInt8) := Id.run do
-  let mut acc : UInt32 := 0
-  let mut accLen : UInt32 := 0
-  let mut out : Array UInt8 := #[]
-  for i in [0:n] do
-    let x : Int := s[i]!
-    if x < -2047 || x > 2047 then
-      return none
-    let sw : UInt32 := if x < 0 then 0xFFFFFFFF else 0
-    let w : UInt32 := x.natAbs.toUInt32
-    acc := (acc <<< 8) ||| ((sw &&& 0x80) ||| (w &&& 0x7F))
-    accLen := accLen + 8
-    let wh := (w >>> 7).toNat + 1
-    acc := (acc <<< wh.toUInt32) ||| 1
-    accLen := accLen + wh.toUInt32
-    while accLen ≥ 8 do
-      accLen := accLen - 8
-      if out.size ≥ dlen then
-        return none
-      out := out.push (acc >>> accLen).toUInt8
-  if accLen > 0 then
-    if out.size ≥ dlen then
-      return none
-    out := out.push (acc <<< (8 - accLen)).toUInt8
-  while out.size < dlen do
-    out := out.push 0
-  return some out.toList
+Falcon stores the signature polynomial `s₂` with the Golomb-Rice style code of the specification
+(Algorithms 17–18): a coefficient `x` with `|x| ≤ 2047` becomes a sign bit, the seven low bits of
+`|x|` (most significant first), `|x| / 128` zero bits, and a terminating one bit. The bits of all
+coefficients are packed most significant first and the output is zero-padded to exactly `dlen`
+bytes; the decoder accepts exactly that length and only zero padding. Both directions are written
+over the bit stream, which is what the round-trip theorem `decompress_compress` reasons about. -/
+
+/-- The `k`-bit big-endian representation of `v` (bits `k-1` down to `0`). -/
+def natBits : ℕ → ℕ → List Bool
+  | 0, _ => []
+  | k + 1, v => v.testBit k :: natBits k v
+
+/-- The number whose big-endian bits are `bits`. -/
+def natOfBits : List Bool → ℕ
+  | [] => 0
+  | b :: bs => (if b then 2 ^ bs.length else 0) + natOfBits bs
+
+/-- The bits of a byte, most significant first. -/
+def byteBits (b : UInt8) : List Bool := natBits 8 b.toNat
+
+/-- The bit stream of a byte string, most significant bit of each byte first. -/
+def bytesToBits (d : List UInt8) : List Bool := d.flatMap byteBits
+
+/-- Pack a bit stream into bytes, most significant bit first; the last byte is zero-padded. -/
+def bitsToBytes (bits : List Bool) : List UInt8 :=
+  if bits.isEmpty then []
+  else
+    (natOfBits (bits.take 8 ++ List.replicate (8 - (bits.take 8).length) false)).toUInt8 ::
+      bitsToBytes (bits.drop 8)
+termination_by bits.length
+decreasing_by
+  simp only [List.length_drop]
+  have : bits.length ≠ 0 := by simpa [List.isEmpty_iff_length_eq_zero] using ‹¬bits.isEmpty›
+  omega
+
+/-- The code of one coefficient: sign, seven low bits of `|x|`, `|x| / 128` zeros, a one. -/
+def coeffBits (x : ℤ) : List Bool :=
+  decide (x < 0) :: (natBits 7 (x.natAbs % 128) ++ List.replicate (x.natAbs / 128) false ++ [true])
+
+/-- Compress a Falcon signature polynomial into exactly `dlen` bytes, or `none` when a
+coefficient is out of range or the code does not fit. -/
+def compress (n : ℕ) (s : IntPoly n) (dlen : ℕ) : Option (List UInt8) :=
+  if ∀ i : Fin n, -2047 ≤ s.get i ∧ s.get i ≤ 2047 then
+    let bits := (List.finRange n).flatMap fun i => coeffBits (s.get i)
+    if 8 * dlen < bits.length then none
+    else some (bitsToBytes bits ++ List.replicate (dlen - (bitsToBytes bits).length) 0)
+  else none
+
+/-- Read the unary part of a coefficient code: each zero adds `128` to the magnitude `m`, a one
+terminates. Fails past `2047`, on the negative zero `-0`, and at the end of the stream. -/
+def parseUnary (t : Bool) : ℕ → List Bool → Option (ℤ × List Bool)
+  | m, true :: rest => if m = 0 ∧ t then none else some (if t then -(m : ℤ) else (m : ℤ), rest)
+  | m, false :: rest => if 2047 < m + 128 then none else parseUnary t (m + 128) rest
+  | _, [] => none
+
+/-- Read one coefficient code from the bit stream. -/
+def parseCoeff : List Bool → Option (ℤ × List Bool)
+  | t :: rest =>
+    if 7 ≤ rest.length then parseUnary t (natOfBits (rest.take 7)) (rest.drop 7) else none
+  | [] => none
+
+/-- Read `k` coefficient codes from the bit stream. -/
+def parseCoeffs : ℕ → List Bool → Option (List ℤ × List Bool)
+  | 0, bits => some ([], bits)
+  | k + 1, bits => do
+    let (x, rest) ← parseCoeff bits
+    let (xs, rest') ← parseCoeffs k rest
+    pure (x :: xs, rest')
 
 /-- Decompress a fixed-length Falcon signature polynomial.
 
 `compress` pads every successful output to exactly `dlen` bytes. Accordingly, this decoder
-accepts exactly that length; the optional unpadded Falcon representation is outside its format. -/
-def decompress (n : ℕ) (d : List UInt8) (dlen : ℕ) : Option (IntPoly n) := Id.run do
-  if d.length ≠ dlen then return none
-  let bytes := d.toArray
-  let mut acc : UInt32 := 0
-  let mut accLen : UInt32 := 0
-  let mut j := 0
-  let mut result : Array ℤ := Array.replicate n 0
-  for i in [0:n] do
-    if j ≥ dlen then return none
-    acc := (acc <<< 8) ||| bytes[j]!.toUInt32
-    j := j + 1
-    let full := acc >>> accLen
-    let t := (full >>> 7) &&& 1
-    let mut m : UInt32 := full &&& 0x7F
-    let mut done := false
-    while !done do
-      if accLen == 0 then
-        if j ≥ dlen then return none
-        acc := (acc <<< 8) ||| bytes[j]!.toUInt32
-        j := j + 1
-        accLen := 8
-      accLen := accLen - 1
-      if ((acc >>> accLen) &&& 1) != 0 then
-        done := true
-      else
-        m := m + 0x80
-        if m > 2047 then return none
-    if m == 0 && t != 0 then return none
-    let val : UInt32 := (m ^^^ (0 - t)) + t
-    let signedVal : ℤ :=
-      if val &&& 0x80000000 != 0 then -(((~~~val) + 1).toNat : ℤ)
-      else (val.toNat : ℤ)
-    result := result.set! i signedVal
-  if accLen > 0 then
-    if (acc &&& ((1 <<< accLen) - 1)) != 0 then
-      return none
-  while j < dlen do
-    if bytes[j]! != 0 then return none
-    j := j + 1
-  return some (Vector.ofFn fun ⟨i, _⟩ => result.getD i 0)
+accepts exactly that length and rejects any nonzero padding; the optional unpadded Falcon
+representation is outside its format. -/
+def decompress (n : ℕ) (d : List UInt8) (dlen : ℕ) : Option (IntPoly n) :=
+  if d.length ≠ dlen then none
+  else
+    match parseCoeffs n (bytesToBits d) with
+    | none => none
+    | some (vals, rest) =>
+      if rest.all (fun b => !b) then some (Vector.ofFn fun i => vals.getD i.val 0) else none
 
 @[simp] theorem decompress_eq_none_of_length_ne (n d dlen) (h : d.length ≠ dlen) :
     decompress n d dlen = none := by
   simp [decompress, h]
+
+/-! ### Bit-level lemmas -/
+
+theorem natBits_length (k v : ℕ) : (natBits k v).length = k := by
+  induction k generalizing v with
+  | zero => rfl
+  | succ k ih => simp [natBits, ih]
+
+theorem natOfBits_lt (bs : List Bool) : natOfBits bs < 2 ^ bs.length := by
+  induction bs with
+  | nil => simp [natOfBits]
+  | cons b bs ih =>
+    simp only [natOfBits, List.length_cons, pow_succ]
+    split <;> omega
+
+/-- `natBits k` reads only the low `k` bits. -/
+theorem natBits_congr {k v w : ℕ} (h : ∀ j, j < k → v.testBit j = w.testBit j) :
+    natBits k v = natBits k w := by
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+    simp only [natBits, h k (Nat.lt_succ_self k)]
+    congr 1
+    exact ih fun j hj => h j (Nat.lt_succ_of_lt hj)
+
+theorem natBits_natOfBits (bs : List Bool) : natBits bs.length (natOfBits bs) = bs := by
+  induction bs with
+  | nil => rfl
+  | cons b bs ih =>
+    have hlt := natOfBits_lt bs
+    have hval : natOfBits (b :: bs) = 2 ^ bs.length * (if b then 1 else 0) + natOfBits bs := by
+      simp only [natOfBits]; split <;> simp
+    simp only [List.length_cons, natBits, hval]
+    rw [List.cons.injEq]
+    refine ⟨?_, ?_⟩
+    · rw [Nat.testBit_two_pow_mul_add _ hlt]
+      simp
+      cases b <;> simp
+    · refine (natBits_congr fun j hj => ?_).trans ih
+      rw [Nat.testBit_two_pow_mul_add _ hlt, if_pos hj]
+
+theorem natOfBits_natBits {k v : ℕ} (h : v < 2 ^ k) : natOfBits (natBits k v) = v := by
+  induction k generalizing v with
+  | zero => simp [natBits, natOfBits]; omega
+  | succ k ih =>
+    have hmod : natBits k v = natBits k (v % 2 ^ k) :=
+      natBits_congr fun j hj => by rw [Nat.testBit_mod_two_pow]; simp [hj]
+    simp only [natBits, natOfBits, natBits_length, hmod, ih (Nat.mod_lt _ (by positivity))]
+    rw [Nat.testBit_eq_decide_div_mod_eq]
+    have hdiv : v / 2 ^ k < 2 := by
+      rw [Nat.div_lt_iff_lt_mul (by positivity)]; rw [pow_succ] at h; omega
+    have := Nat.div_add_mod v (2 ^ k)
+    have hcases : v / 2 ^ k = 0 ∨ v / 2 ^ k = 1 :=
+      Nat.le_one_iff_eq_zero_or_eq_one.mp (Nat.lt_succ_iff.mp hdiv)
+    rcases hcases with h0 | h0 <;> simp [h0] at this ⊢ <;> omega
+
+theorem byteBits_toUInt8 (bs : List Bool) (h : bs.length = 8) :
+    byteBits (natOfBits bs).toUInt8 = bs := by
+  have hlt : natOfBits bs < 256 := by have := natOfBits_lt bs; rw [h] at this; exact this
+  have : (natOfBits bs).toUInt8.toNat = natOfBits bs := by
+    change (UInt8.ofNat _).toNat = _
+    rw [UInt8.toNat_ofNat']; exact Nat.mod_eq_of_lt hlt
+  rw [byteBits, this, ← h, natBits_natOfBits]
+
+theorem bytesToBits_append (a b : List UInt8) :
+    bytesToBits (a ++ b) = bytesToBits a ++ bytesToBits b := by
+  simp [bytesToBits, List.flatMap_append]
+
+theorem bytesToBits_replicate_zero (k : ℕ) :
+    bytesToBits (List.replicate k 0) = List.replicate (8 * k) false := by
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+    rw [List.replicate_succ, bytesToBits, List.flatMap_cons, ← bytesToBits, ih,
+      show byteBits 0 = List.replicate 8 false from rfl, List.replicate_append_replicate]
+    congr 1
+    omega
+
+theorem bytesToBits_bitsToBytes (bits : List Bool) :
+    bytesToBits (bitsToBytes bits) =
+      bits ++ List.replicate ((8 - bits.length % 8) % 8) false := by
+  fun_induction bitsToBytes bits with
+  | case1 bits hempty =>
+    rw [List.isEmpty_iff] at hempty
+    subst hempty
+    rfl
+  | case2 bits hempty ih =>
+    rw [bytesToBits, List.flatMap_cons, ← bytesToBits, ih,
+      byteBits_toUInt8 _ (by simp [List.length_take])]
+    have hne : bits.length ≠ 0 := by simpa [List.isEmpty_iff_length_eq_zero] using hempty
+    rcases Nat.lt_or_ge bits.length 8 with hlt | hge
+    · rw [List.drop_of_length_le (by omega), List.take_of_length_le (by omega)]
+      simp only [List.length_nil, Nat.zero_mod, Nat.sub_zero, Nat.mod_self, List.replicate_zero,
+        List.append_nil]
+      congr 2
+      rw [Nat.mod_eq_of_lt hlt, Nat.mod_eq_of_lt (by omega)]
+    · rw [List.length_take, min_eq_left hge, Nat.sub_self, List.replicate_zero, List.append_nil,
+        ← List.append_assoc, List.take_append_drop, List.length_drop]
+      congr 3
+      omega
+
+theorem bitsToBytes_length (bits : List Bool) :
+    (bitsToBytes bits).length = (bits.length + 7) / 8 := by
+  fun_induction bitsToBytes bits with
+  | case1 bits hempty =>
+    rw [List.isEmpty_iff] at hempty
+    subst hempty
+    rfl
+  | case2 bits hempty ih =>
+    rw [List.length_cons, ih, List.length_drop]
+    have hne : bits.length ≠ 0 := by simpa [List.isEmpty_iff_length_eq_zero] using hempty
+    omega
+
+/-! ### Coefficient-level lemmas -/
+
+theorem parseUnary_replicate (t : Bool) (m q : ℕ) (rest : List Bool)
+    (hle : m + 128 * q ≤ 2047) (hz : ¬ (m + 128 * q = 0 ∧ t = true)) :
+    parseUnary t m (List.replicate q false ++ true :: rest) =
+      some (if t then -((m + 128 * q : ℕ) : ℤ) else ((m + 128 * q : ℕ) : ℤ), rest) := by
+  induction q generalizing m with
+  | zero =>
+    simp only [List.replicate_zero, List.nil_append, parseUnary, Nat.mul_zero, Nat.add_zero] at *
+    rw [if_neg hz]
+  | succ q ih =>
+    rw [List.replicate_succ, List.cons_append, parseUnary, if_neg (by omega)]
+    rw [ih (m + 128) (by omega) (by omega), show m + 128 + 128 * q = m + 128 * (q + 1) by ring]
+
+theorem parseCoeff_coeffBits (x : ℤ) (hx : -2047 ≤ x ∧ x ≤ 2047) (rest : List Bool) :
+    parseCoeff (coeffBits x ++ rest) = some (x, rest) := by
+  have habs : x.natAbs ≤ 2047 := by omega
+  simp only [coeffBits, List.cons_append, parseCoeff, List.append_assoc]
+  rw [if_pos (by simp [natBits_length]), List.take_append_of_le_length (by simp [natBits_length]),
+    List.take_of_length_le (by simp [natBits_length]),
+    List.drop_append_of_le_length (by simp [natBits_length]),
+    List.drop_of_length_le (by simp [natBits_length]), List.nil_append,
+    natOfBits_natBits (k := 7)
+      (by have := Nat.mod_lt x.natAbs (by norm_num : 0 < 128); simpa using this),
+    List.nil_append,
+    parseUnary_replicate _ _ _ _ (by rw [Nat.mod_add_div]; exact habs)]
+  · rw [Nat.mod_add_div]
+    congr 2
+    split_ifs with hneg <;> simp only [decide_eq_true_eq] at hneg <;> omega
+  · rw [Nat.mod_add_div]
+    rintro ⟨h0, ht⟩
+    have : x < 0 := by simpa using ht
+    omega
+
+theorem parseCoeffs_flatMap (xs : List ℤ) (hxs : ∀ x ∈ xs, -2047 ≤ x ∧ x ≤ 2047)
+    (tail : List Bool) :
+    parseCoeffs xs.length (xs.flatMap coeffBits ++ tail) = some (xs, tail) := by
+  induction xs with
+  | nil => rfl
+  | cons x xs ih =>
+    simp [List.flatMap_cons, parseCoeffs, parseCoeff_coeffBits x (hxs x (List.mem_cons_self ..)),
+      ih (fun y hy => hxs y (List.mem_cons_of_mem _ hy))]
+
+/-! ### The round-trip -/
+
+/-- **Decompression inverts compression**: every byte string `compress` produces decodes back to
+the polynomial it came from. This is the `compress_decompress` law of `Primitives.Laws` for the
+concrete codec. -/
+theorem decompress_compress (n : ℕ) (s : IntPoly n) (dlen : ℕ) (d : List UInt8)
+    (h : compress n s dlen = some d) : decompress n d dlen = some s := by
+  unfold compress at h
+  dsimp only at h
+  split_ifs at h with hbound hfit
+  rw [Option.some.injEq] at h
+  subst h
+  set bits := (List.finRange n).flatMap fun i => coeffBits (s.get i) with hbits
+  set L := bits.length with hL
+  set NB := (bitsToBytes bits).length with hNB
+  have hnb : NB ≤ dlen := by
+    rw [hNB, bitsToBytes_length]; omega
+  have hlen : (bitsToBytes bits ++ List.replicate (dlen - NB) 0).length = dlen := by
+    simp only [List.length_append, List.length_replicate, ← hNB]; omega
+  set T := List.replicate ((8 - L % 8) % 8) false ++ List.replicate (8 * (dlen - NB)) false
+    with hT
+  have hstream : bytesToBits (bitsToBytes bits ++ List.replicate (dlen - NB) 0) = bits ++ T := by
+    rw [bytesToBits_append, bytesToBits_bitsToBytes, bytesToBits_replicate_zero, List.append_assoc]
+  set xs := (List.finRange n).map fun i => s.get i with hxsdef
+  have hxs : bits = xs.flatMap coeffBits := by
+    rw [hbits, hxsdef, List.flatMap_map]
+  have hparse : parseCoeffs n (xs.flatMap coeffBits ++ T) = some (xs, T) := by
+    have h := parseCoeffs_flatMap xs
+      (fun x hx => by
+        obtain ⟨i, -, rfl⟩ := List.mem_map.mp hx
+        exact hbound i) T
+    rwa [hxsdef, List.length_map, List.length_finRange, ← hxsdef] at h
+  unfold decompress
+  rw [if_neg (by rw [hlen]; exact fun h => h rfl), hstream, hxs, hparse]
+  dsimp only
+  rw [if_pos (by simp [hT, List.all_replicate])]
+  congr 1
+  apply LatticeCrypto.Poly.ext_get_eq
+  intro i
+  rw [Vector.get_ofFn, List.getD_eq_getElem?_getD, hxsdef, List.getElem?_map,
+    List.getElem?_eq_getElem (by simp [List.length_finRange]), Option.map_some, Option.getD_some]
+  simp [List.getElem_finRange]
 
 /-! ## Public key encoding (14 bits per coefficient) -/
 

--- a/LatticeCrypto/Falcon/Coset.lean
+++ b/LatticeCrypto/Falcon/Coset.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oleksandr Vovkotrub
+-/
+
+module
+public import LatticeCrypto.Falcon.Scheme
+
+/-!
+# The coset condition of Falcon's trapdoor sampler
+
+`Falcon.verify_sign_correct` and the GPV correctness law `CorrectAt` ask that every output
+`(s₁, s₂)` of the trapdoor sampler at target `c` satisfy `s₁ + s₂ · h = c`. This file reduces
+that condition to a statement about the primitives alone. `fromFFTPreimage` multiplies the
+sampler's FFT-domain output by the FFT of the secret basis, inverse-transforms, and rounds;
+`LandsOnLattice` says the rounded result is an integer lattice point `z · B`. Given that and
+the key relations `f · h = g` and `F · h = G`, the coset identity is ring algebra in `R_q`,
+carried out in the semantic quotient `ℤ_q[X]/(X^n + 1)` through the soundness certificate
+`coeffSemantics` (`eval_fromFFTPreimage_of_landsOnLattice`, `hpreimage_of_landsOnLattice`).
+
+`F · h = G` follows from the NTRU equation and `f · h = g` once `f` is invertible modulo `q`
+(`capRelation_of_validKeyPair`), which Falcon's key generation guarantees and which is what
+makes `h = g · f⁻¹` exist in the first place.
+
+What remains for the concrete primitives is `LandsOnLattice` itself: that the fixed-point FFT
+pipeline `fftInt`/`ifftRound` rounds to the exact lattice point, a deterministic rounding-error
+bound on those two primitives.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec LatticeCrypto
+
+namespace Falcon
+
+/-! ## Coefficients in `R_q` and reduction modulo `q` -/
+
+theorem Rq.get_add {n : ℕ} (a b : Rq n) (i : Fin n) : (a + b).get i = a.get i + b.get i :=
+  NegacyclicRing.coeff_add (coeffRing n) a b i
+
+theorem Rq.get_sub {n : ℕ} (a b : Rq n) (i : Fin n) : (a - b).get i = a.get i - b.get i :=
+  NegacyclicRing.coeff_sub (coeffRing n) a b i
+
+theorem Rq.get_neg {n : ℕ} (a : Rq n) (i : Fin n) : (-a).get i = -a.get i :=
+  NegacyclicRing.coeff_neg (coeffRing n) a i
+
+theorem Rq.get_zero {n : ℕ} (i : Fin n) : (0 : Rq n).get i = 0 :=
+  NegacyclicRing.coeff_zero (coeffRing n) i
+
+theorem Rq.get_mul {n : ℕ} (a b : Rq n) (i : Fin n) :
+    (negacyclicMul a b).get i = negacyclicConvCoeff a.get b.get i :=
+  vectorKernel_mul_get a b i
+
+theorem IntPoly.get_mul {n : ℕ} (a b : IntPoly n) (i : Fin n) :
+    (intPolyMul a b).get i = negacyclicConvCoeff a.get b.get i :=
+  vectorKernel_mul_get a b i
+
+theorem toRq_add {n : ℕ} (a b : IntPoly n) :
+    IntPoly.toRq (a + b) = IntPoly.toRq a + IntPoly.toRq b := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, Poly.get_add, Rq.get_add, toRq_get, toRq_get]
+  push_cast
+  rfl
+
+theorem toRq_sub {n : ℕ} (a b : IntPoly n) :
+    IntPoly.toRq (a - b) = IntPoly.toRq a - IntPoly.toRq b := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, Poly.get_sub, Rq.get_sub, toRq_get, toRq_get]
+  push_cast
+  rfl
+
+theorem toRq_neg {n : ℕ} (a : IntPoly n) : IntPoly.toRq (-a) = -IntPoly.toRq a := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, Poly.get_neg, Rq.get_neg, toRq_get]
+  push_cast
+  rfl
+
+/-- Reduction modulo `q` turns the integer negacyclic product into the product in `R_q`. -/
+theorem toRq_mul {n : ℕ} (a b : IntPoly n) :
+    IntPoly.toRq (intPolyMul a b) = negacyclicMul (IntPoly.toRq a) (IntPoly.toRq b) := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, IntPoly.get_mul, Rq.get_mul]
+  simp only [negacyclicConvCoeff, toRq_get]
+  push_cast
+  rfl
+
+/-- The constant `q` reduces to zero modulo `q`. -/
+theorem toRq_const_modulus (n : ℕ) :
+    IntPoly.toRq (intPolyConst (modulus : ℤ) : IntPoly n) = 0 := by
+  apply Poly.ext_get_eq
+  intro i
+  rw [toRq_get, Rq.get_zero]
+  simp [intPolyConst, integralLift, vectorIntegralLift, constPoly]
+
+/-! ## The semantic quotient -/
+
+section Quotient
+
+variable {n : ℕ} (hn : 0 < n)
+
+theorem quotientOf_add (a b : Rq n) :
+    (coeffSemantics hn).quotientOf (a + b) =
+      (coeffSemantics hn).quotientOf a + (coeffSemantics hn).quotientOf b :=
+  (coeffSemantics hn).add_sound a b
+
+theorem quotientOf_sub (a b : Rq n) :
+    (coeffSemantics hn).quotientOf (a - b) =
+      (coeffSemantics hn).quotientOf a - (coeffSemantics hn).quotientOf b :=
+  (coeffSemantics hn).sub_sound a b
+
+theorem quotientOf_neg (a : Rq n) :
+    (coeffSemantics hn).quotientOf (-a) = -(coeffSemantics hn).quotientOf a :=
+  (coeffSemantics hn).neg_sound a
+
+theorem quotientOf_mul (a b : Rq n) :
+    (coeffSemantics hn).quotientOf (negacyclicMul a b) =
+      (coeffSemantics hn).quotientOf a * (coeffSemantics hn).quotientOf b :=
+  (coeffSemantics hn).mul_sound a b
+
+theorem quotientOf_zero : (coeffSemantics hn).quotientOf (0 : Rq n) = 0 :=
+  (coeffSemantics hn).zero_sound
+
+theorem quotientOf_one : (coeffSemantics hn).quotientOf (1 : Rq n) = 1 :=
+  (coeffSemantics hn).one_sound
+
+theorem quotientOf_injective {a b : Rq n}
+    (h : (coeffSemantics hn).quotientOf a = (coeffSemantics hn).quotientOf b) : a = b :=
+  NegacyclicQuotient.ofBackend_injective (vectorBackend Coeff n) h
+
+end Quotient
+
+/-! ## The lattice-point condition and the coset identity -/
+
+variable (p : Params) (prims : Primitives p)
+
+/-- **The basis application lands on the lattice.** For the sampler's FFT-domain output `z`,
+the two rounded inverse transforms of `fromFFTPreimage` are the integer polynomials
+`z₀ · g + z₁ · G` and `-(z₀ · f + z₁ · F)` for some integer `(z₀, z₁)`: the lattice point
+`z · B` for the secret basis `B = [[g, -f], [G, -F]]`. -/
+def LandsOnLattice (sk : SecretKey p) (z : FFTPair p.fftDepth) : Prop :=
+  ∃ z₀ z₁ : IntPoly p.n,
+    prims.ifftRound (Primitives.mulFFT z.1 (prims.fftInt sk.g) +
+        Primitives.mulFFT z.2 (prims.fftInt sk.capG)) =
+      intPolyMul z₀ sk.g + intPolyMul z₁ sk.capG ∧
+    prims.ifftRound (-(Primitives.mulFFT z.1 (prims.fftInt sk.f) +
+        Primitives.mulFFT z.2 (prims.fftInt sk.capF))) =
+      -(intPolyMul z₀ sk.f + intPolyMul z₁ sk.capF)
+
+/-- **The coset identity.** On a lattice point, `fromFFTPreimage` returns a preimage of the
+target: `s₁ + s₂ · h = c` follows from `f · h = g` and `F · h = G` by ring algebra. -/
+theorem eval_fromFFTPreimage_of_landsOnLattice (hn : 0 < p.n) (pk : PublicKey p)
+    (sk : SecretKey p)
+    (hkey : negacyclicMul (IntPoly.toRq sk.f) pk.h = IntPoly.toRq sk.g)
+    (hcap : negacyclicMul (IntPoly.toRq sk.capF) pk.h = IntPoly.toRq sk.capG)
+    (c : Rq p.n) (z : FFTPair p.fftDepth) (hz : LandsOnLattice p prims sk z) :
+    (falconPSF p prims).eval pk (fromFFTPreimage p prims c sk z) = c := by
+  obtain ⟨z₀, z₁, h₀, h₁⟩ := hz
+  change (c - IntPoly.toRq (prims.ifftRound _)) +
+    negacyclicMul (-IntPoly.toRq (prims.ifftRound _)) pk.h = c
+  rw [h₀, h₁, toRq_add, toRq_neg, toRq_add, toRq_mul, toRq_mul, toRq_mul, toRq_mul]
+  apply quotientOf_injective hn
+  have hk := congrArg (coeffSemantics hn).quotientOf hkey
+  have hc := congrArg (coeffSemantics hn).quotientOf hcap
+  simp only [quotientOf_mul] at hk hc
+  simp only [quotientOf_add, quotientOf_sub, quotientOf_neg, quotientOf_mul]
+  linear_combination ((coeffSemantics hn).quotientOf (IntPoly.toRq z₀)) * hk +
+    ((coeffSemantics hn).quotientOf (IntPoly.toRq z₁)) * hc
+
+/-- **The coset condition from the lattice-point condition.** Every output of the trapdoor
+sampler is a preimage of its target once the basis application lands on the lattice for every
+sample. This is the `hpreimage` hypothesis of `verify_sign_correct` and the `eval` half of
+`CorrectAt`. -/
+theorem hpreimage_of_landsOnLattice (hn : 0 < p.n) (pk : PublicKey p) (sk : SecretKey p)
+    (hkey : negacyclicMul (IntPoly.toRq sk.f) pk.h = IntPoly.toRq sk.g)
+    (hcap : negacyclicMul (IntPoly.toRq sk.capF) pk.h = IntPoly.toRq sk.capG)
+    (hz : ∀ c : Rq p.n, ∀ z ∈ support
+      (Primitives.ffSampling prims p.fftDepth (toFFTTarget p prims c sk) sk.tree),
+      LandsOnLattice p prims sk z) :
+    ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p prims).trapdoorSample pk sk c) →
+        (falconPSF p prims).eval pk x = c := by
+  intro c x hx
+  change x ∈ support (do
+    let z ← Primitives.ffSampling prims p.fftDepth (toFFTTarget p prims c sk) sk.tree
+    return fromFFTPreimage p prims c sk z) at hx
+  rw [mem_support_bind_iff] at hx
+  obtain ⟨z, hzmem, hx⟩ := hx
+  rw [support_pure, Set.mem_singleton_iff] at hx
+  subst hx
+  exact eval_fromFFTPreimage_of_landsOnLattice p prims hn pk sk hkey hcap c z (hz c z hzmem)
+
+/-- **`F · h = G` on a valid key with `f` invertible modulo `q`.** From the NTRU equation
+`f · G − g · F = q` reduced modulo `q` and `f · h = g`, cancelling `f`. -/
+theorem capRelation_of_validKeyPair (hn : 0 < p.n) (pk : PublicKey p) (sk : SecretKey p)
+    (hvalid : validKeyPair p pk sk = true)
+    (hunit : ∃ u : Rq p.n, negacyclicMul (IntPoly.toRq sk.f) u = 1) :
+    negacyclicMul (IntPoly.toRq sk.capF) pk.h = IntPoly.toRq sk.capG := by
+  rw [validKeyPair_eq_true_iff] at hvalid
+  obtain ⟨hntru, hkey⟩ := hvalid
+  obtain ⟨u, hu⟩ := hunit
+  have hq : IntPoly.toRq (intPolyMul sk.f sk.capG - intPolyMul sk.g sk.capF) =
+      IntPoly.toRq (intPolyConst (modulus : ℤ)) := by
+    unfold ntruEquation at hntru
+    rw [hntru]
+  rw [toRq_sub, toRq_mul, toRq_mul, toRq_const_modulus] at hq
+  apply quotientOf_injective hn
+  have hq' := congrArg (coeffSemantics hn).quotientOf hq
+  have hk := congrArg (coeffSemantics hn).quotientOf hkey
+  have hu' := congrArg (coeffSemantics hn).quotientOf hu
+  simp only [quotientOf_sub, quotientOf_mul, quotientOf_zero, quotientOf_one] at hq' hk hu'
+  rw [quotientOf_mul]
+  set Q := (coeffSemantics hn).quotientOf with hQ
+  linear_combination (-(Q u)) * hq' + (Q u * Q (IntPoly.toRq sk.capF)) * hk +
+    (Q (IntPoly.toRq sk.capG) - Q (IntPoly.toRq sk.capF) * Q pk.h) * hu'
+
+end Falcon
+
+end

--- a/LatticeCrypto/Falcon/Coset.lean
+++ b/LatticeCrypto/Falcon/Coset.lean
@@ -6,6 +6,7 @@ Authors: Oleksandr Vovkotrub
 
 module
 public import LatticeCrypto.Falcon.Scheme
+public import LatticeCrypto.Falcon.PackedFFT
 
 /-!
 # The coset condition of Falcon's trapdoor sampler
@@ -23,9 +24,12 @@ carried out in the semantic quotient `ℤ_q[X]/(X^n + 1)` through the soundness 
 (`capRelation_of_validKeyPair`), which Falcon's key generation guarantees and which is what
 makes `h = g · f⁻¹` exist in the first place.
 
-What remains for the concrete primitives is `LandsOnLattice` itself: that the fixed-point FFT
-pipeline `fftInt`/`ifftRound` rounds to the exact lattice point, a deterministic rounding-error
-bound on those two primitives.
+At exact FFT primitives (`Primitives.ExactFFT`) the lattice-point condition is a theorem: every
+sampler output is the packed FFT of an integer pair (`Primitives.ffSampling_support_ofCoeffs`),
+the packed FFT is multiplicative and inverted by the split recursion
+(`RealFFTPoly.ofCoeffs_negacyclic`, `RealFFTPoly.toCoeffs_ofCoeffs`), so the rounded inverse
+transform returns the integer polynomials `z₀ · g + z₁ · G` and `-(z₀ · f + z₁ · F)` exactly
+(`landsOnLattice_of_exactFFT`, `hpreimage_of_exactFFT`).
 -/
 
 public section
@@ -217,6 +221,81 @@ theorem capRelation_of_validKeyPair (hn : 0 < p.n) (pk : PublicKey p) (sk : Secr
   set Q := (coeffSemantics hn).quotientOf with hQ
   linear_combination (-(Q u)) * hq' + (Q u * Q (IntPoly.toRq sk.capF)) * hk +
     (Q (IntPoly.toRq sk.capG) - Q (IntPoly.toRq sk.capF) * Q pk.h) * hu'
+
+/-! ## The lattice-point condition at exact FFT primitives -/
+
+/-- The integer cast commutes with the negacyclic convolution. -/
+theorem intCast_negacyclicConvCoeff {n : ℕ} (a b : Fin n → ℤ) (k : Fin n) :
+    ((negacyclicConvCoeff a b k : ℤ) : ℝ) =
+      negacyclicConvCoeff (fun i => (a i : ℝ)) (fun i => (b i : ℝ)) k := by
+  simp only [negacyclicConvCoeff]
+  push_cast
+  rfl
+
+/-- Reindexing a negacyclic convolution along an equality of lengths. -/
+theorem negacyclicConvCoeff_cast {m n : ℕ} (h : m = n) (f g : Fin n → ℝ) (k : Fin m) :
+    negacyclicConvCoeff (fun i => f (Fin.cast h i)) (fun i => g (Fin.cast h i)) k =
+      negacyclicConvCoeff f g (Fin.cast h k) := by
+  subst h
+  rfl
+
+/-- **The lattice-point condition at exact FFT primitives.** The packed FFT of any integer pair
+`(z₀, z₁)` is mapped by the basis application to `z₀ · g + z₁ · G` and `-(z₀ · f + z₁ · F)`:
+`fftInt` is the packed FFT, `mulFFT` is negacyclic multiplication under it, the split recursion
+inverts the merge recursion, and rounding fixes integers. -/
+theorem landsOnLattice_of_exactFFT (hn : 2 * 2 ^ p.fftDepth = p.n) (hex : prims.ExactFFT hn)
+    (sk : SecretKey p) (z : FFTPair p.fftDepth)
+    (hz : ∃ a b : Fin (2 * 2 ^ p.fftDepth) → ℤ,
+      z.1 = RealFFTPoly.ofCoeffs p.fftDepth (fun i => (a i : ℝ)) ∧
+      z.2 = RealFFTPoly.ofCoeffs p.fftDepth (fun i => (b i : ℝ))) :
+    LandsOnLattice p prims sk z := by
+  obtain ⟨a, b, ha, hb⟩ := hz
+  set z₀ : IntPoly p.n := Poly.ofPi fun i => a (Fin.cast hn.symm i) with hz₀
+  set z₁ : IntPoly p.n := Poly.ofPi fun i => b (Fin.cast hn.symm i) with hz₁
+  have ha' : (fun i => (a i : ℝ)) = fun i => ((z₀.get (Fin.cast hn i) : ℤ) : ℝ) := by
+    funext i
+    rw [hz₀, Poly.get_ofPi]
+    congr 2
+  have hb' : (fun i => (b i : ℝ)) = fun i => ((z₁.get (Fin.cast hn i) : ℤ) : ℝ) := by
+    funext i
+    rw [hz₁, Poly.get_ofPi]
+    congr 2
+  have key : ∀ (u v : IntPoly p.n) (i : Fin p.n),
+      negacyclicConvCoeff (fun j => ((u.get (Fin.cast hn j) : ℤ) : ℝ))
+        (fun j => ((v.get (Fin.cast hn j) : ℤ) : ℝ)) (Fin.cast hn.symm i) =
+        (((intPolyMul u v).get i : ℤ) : ℝ) := by
+    intro u v i
+    rw [negacyclicConvCoeff_cast hn (fun j => ((u.get j : ℤ) : ℝ)) (fun j => ((v.get j : ℤ) : ℝ)),
+      IntPoly.get_mul, intCast_negacyclicConvCoeff]
+    congr 1
+  refine ⟨z₀, z₁, ?_, ?_⟩
+  · rw [ha, hb, ha', hb', hex.fftInt_eq, hex.fftInt_eq, ← RealFFTPoly.ofCoeffs_negacyclic,
+      ← RealFFTPoly.ofCoeffs_negacyclic, ← RealFFTPoly.ofCoeffs_add, hex.ifftRound_eq,
+      RealFFTPoly.toCoeffs_ofCoeffs]
+    apply Poly.ext_get_eq
+    intro i
+    rw [Poly.get_ofPi, Poly.get_add, key, key, ← Int.cast_add, round_intCast]
+  · rw [ha, hb, ha', hb', hex.fftInt_eq, hex.fftInt_eq, ← RealFFTPoly.ofCoeffs_negacyclic,
+      ← RealFFTPoly.ofCoeffs_negacyclic, ← RealFFTPoly.ofCoeffs_add, ← RealFFTPoly.ofCoeffs_neg,
+      hex.ifftRound_eq, RealFFTPoly.toCoeffs_ofCoeffs]
+    apply Poly.ext_get_eq
+    intro i
+    rw [Poly.get_ofPi, Poly.get_neg, Poly.get_add, key, key, ← Int.cast_add, ← Int.cast_neg,
+      round_intCast]
+
+/-- **The coset condition at exact FFT primitives**, from the key relations alone: every sampler
+output is the packed FFT of an integer pair, on which the basis application lands on the
+lattice. -/
+theorem hpreimage_of_exactFFT (hn : 2 * 2 ^ p.fftDepth = p.n) (hex : prims.ExactFFT hn)
+    (pk : PublicKey p) (sk : SecretKey p)
+    (hkey : negacyclicMul (IntPoly.toRq sk.f) pk.h = IntPoly.toRq sk.g)
+    (hcap : negacyclicMul (IntPoly.toRq sk.capF) pk.h = IntPoly.toRq sk.capG) :
+    ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p prims).trapdoorSample pk sk c) →
+        (falconPSF p prims).eval pk x = c :=
+  hpreimage_of_landsOnLattice p prims (by rw [← hn]; positivity) pk sk hkey hcap
+    fun _ z hz => landsOnLattice_of_exactFFT p prims hn hex sk z
+      (Primitives.ffSampling_support_ofCoeffs prims _ _ _ z hz)
 
 end Falcon
 

--- a/LatticeCrypto/Falcon/Coset.lean
+++ b/LatticeCrypto/Falcon/Coset.lean
@@ -28,7 +28,7 @@ pipeline `fftInt`/`ifftRound` rounds to the exact lattice point, a deterministic
 bound on those two primitives.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec LatticeCrypto
 

--- a/LatticeCrypto/Falcon/PackedFFT.lean
+++ b/LatticeCrypto/Falcon/PackedFFT.lean
@@ -1,0 +1,518 @@
+/-
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oleksandr Vovkotrub
+-/
+
+module
+public import LatticeCrypto.Falcon.Primitives
+
+/-!
+# The exact packed FFT
+
+`Primitives.mergeFFT` and `Primitives.splitFFT` recurse on the packed FFT layout of the Falcon
+specification. This file identifies the recursion with an evaluation map: `RealFFTPoly.ofCoeffs`
+builds the packed representation of a real polynomial by merging the representations of its
+even and odd parts, and `coord_ofCoeffs` shows that coordinate `j` at level `k` is the value of
+the polynomial at `exp(rootAngle k j · I)`. Everything else follows from that description:
+
+- `ofCoeffs_negacyclic`: the packed FFT turns negacyclic multiplication into the pointwise
+  complex multiplication `Primitives.mulFFT`, because each root angle is a root of
+  `X^n + 1` (`exp_rootAngle`);
+- `toCoeffs_ofCoeffs`: the split recursion `RealFFTPoly.toCoeffs` inverts `ofCoeffs`;
+- `Primitives.ffSampling_support_ofCoeffs`: every output of `ffSampling` is the packed FFT of a
+  pair of integer polynomials, because the leaves sample integers and the nodes merge.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec Complex
+
+namespace Falcon
+
+/-! ## Coordinates of a packed FFT polynomial -/
+
+namespace RealFFTPoly
+
+variable {k : ℕ}
+
+/-- The `j`-th packed coordinate as a complex number. -/
+noncomputable def coord (f : RealFFTPoly k) (j : Fin (2 ^ k)) : ℂ := ⟨f.re j, f.im j⟩
+
+@[simp] theorem coord_re (f : RealFFTPoly k) (j : Fin (2 ^ k)) : (coord f j).re = f.re j := rfl
+
+@[simp] theorem coord_im (f : RealFFTPoly k) (j : Fin (2 ^ k)) : (coord f j).im = f.im j := rfl
+
+@[simp] theorem re_pack (a b : Vector ℝ (2 ^ k)) (i : Fin (2 ^ k)) : (pack a b).re i = a.get i := by
+  simp [pack, re, i.isLt]
+
+@[simp] theorem im_pack (a b : Vector ℝ (2 ^ k)) (i : Fin (2 ^ k)) : (pack a b).im i = b.get i := by
+  simp only [pack, im, LatticeCrypto.Poly.get_vectorOfFn]
+  rw [dif_neg (by omega)]
+  congr 1
+  ext
+  simp
+
+theorem coord_pack (a b : Vector ℝ (2 ^ k)) (i : Fin (2 ^ k)) :
+    coord (pack a b) i = ⟨a.get i, b.get i⟩ := by
+  simp [coord]
+
+theorem get_eq_getElem {n : ℕ} (v : Vector ℝ n) (i : Fin n) : v.get i = v[i.1] := rfl
+
+/-- Two packed FFT polynomials with the same coordinates are equal. -/
+theorem ext_coord {a b : RealFFTPoly k} (h : ∀ j, coord a j = coord b j) : a = b := by
+  apply Vector.ext
+  intro m hm
+  by_cases hlt : m < 2 ^ k
+  · have := congrArg Complex.re (h ⟨m, hlt⟩)
+    simp only [coord_re, re, get_eq_getElem] at this
+    exact this
+  · have := congrArg Complex.im (h ⟨m - 2 ^ k, by omega⟩)
+    simp only [coord_im, im, get_eq_getElem] at this
+    have hmk : m - 2 ^ k + 2 ^ k = m := by omega
+    simp only [hmk] at this
+    exact this
+
+theorem coord_add (a b : RealFFTPoly k) (j : Fin (2 ^ k)) :
+    coord (a + b) j = coord a j + coord b j := by
+  apply Complex.ext
+  · simp only [coord_re, add_re]
+    exact LatticeCrypto.Poly.get_add (Coeff := ℝ) a b _
+  · simp only [coord_im, add_im]
+    exact LatticeCrypto.Poly.get_add (Coeff := ℝ) a b _
+
+theorem coord_neg (a : RealFFTPoly k) (j : Fin (2 ^ k)) : coord (-a) j = -coord a j := by
+  apply Complex.ext
+  · simp only [coord_re, neg_re]
+    exact LatticeCrypto.Poly.get_neg (Coeff := ℝ) a _
+  · simp only [coord_im, neg_im]
+    exact LatticeCrypto.Poly.get_neg (Coeff := ℝ) a _
+
+theorem coord_mulFFT (a b : RealFFTPoly k) (j : Fin (2 ^ k)) :
+    coord (Primitives.mulFFT a b) j = coord a j * coord b j := by
+  apply Complex.ext <;> simp [coord, Primitives.mulFFT]
+
+theorem two_pow_succ_eq (k : ℕ) : 2 ^ (k + 1) = 2 * 2 ^ k := by ring
+
+/-- Half of a coordinate index, as an index one level down. -/
+abbrev half (j : Fin (2 ^ (k + 1))) : Fin (2 ^ k) :=
+  ⟨j.1 / 2, by have := j.2; have := two_pow_succ_eq k; omega⟩
+
+theorem coord_mergeFFT_even (f₀ f₁ : RealFFTPoly k) (i : ℕ) (hi : i < 2 ^ k) :
+    coord (Primitives.mergeFFT f₀ f₁) ⟨2 * i, by have := two_pow_succ_eq k; omega⟩ =
+      coord f₀ ⟨i, hi⟩ +
+        Complex.exp ((Primitives.splitAngle ⟨i, hi⟩ : ℝ) * I) * coord f₁ ⟨i, hi⟩ := by
+  apply Complex.ext <;>
+    simp [coord, Primitives.mergeFFT, exp_ofReal_mul_I_re, exp_ofReal_mul_I_im] <;> ring
+
+theorem coord_mergeFFT_odd (f₀ f₁ : RealFFTPoly k) (i : ℕ) (hi : i < 2 ^ k) :
+    coord (Primitives.mergeFFT f₀ f₁) ⟨2 * i + 1, by have := two_pow_succ_eq k; omega⟩ =
+      coord f₀ ⟨i, hi⟩ -
+        Complex.exp ((Primitives.splitAngle ⟨i, hi⟩ : ℝ) * I) * coord f₁ ⟨i, hi⟩ := by
+  apply Complex.ext <;>
+    simp [coord, Primitives.mergeFFT, exp_ofReal_mul_I_re, exp_ofReal_mul_I_im,
+      Nat.mul_add_div] <;> ring
+
+end RealFFTPoly
+
+/-! ## Evaluation of a real polynomial on the unit circle -/
+
+/-- The value at `exp(θ · I)` of the real polynomial with coefficient function `f`. -/
+noncomputable def evalAngle {n : ℕ} (f : Fin n → ℝ) (θ : ℝ) : ℂ :=
+  ∑ m : Fin n, (f m : ℂ) * Complex.exp (((m.1 : ℝ) * θ : ℝ) * I)
+
+theorem sum_univ_two_mul {M : Type*} [AddCommMonoid M] {n N : ℕ} (h : n = 2 * N)
+    (g : Fin n → M) :
+    ∑ m, g m = ∑ i : Fin N, (g ⟨2 * i.1, by omega⟩ + g ⟨2 * i.1 + 1, by omega⟩) := by
+  subst h
+  let g' : ℕ → M := fun m => if hm : m < 2 * N then g ⟨m, hm⟩ else 0
+  have h1 : ∑ m : Fin (2 * N), g m = ∑ m ∈ Finset.range (2 * N), g' m := by
+    rw [← Fin.sum_univ_eq_sum_range]
+    apply Finset.sum_congr rfl
+    intro m _
+    simp [g', m.2]
+  have h2 : ∀ K, ∑ m ∈ Finset.range (2 * K), g' m =
+      ∑ i ∈ Finset.range K, (g' (2 * i) + g' (2 * i + 1)) := by
+    intro K
+    induction K with
+    | zero => simp
+    | succ K ih =>
+      rw [show 2 * (K + 1) = 2 * K + 1 + 1 by ring, Finset.sum_range_succ, Finset.sum_range_succ,
+        ih, Finset.sum_range_succ, add_assoc]
+  rw [h1, h2, ← Fin.sum_univ_eq_sum_range]
+  apply Finset.sum_congr rfl
+  intro i _
+  have h1 : 2 * i.1 < 2 * N := by omega
+  have h2 : 2 * i.1 + 1 < 2 * N := by omega
+  simp [g', h1, h2]
+
+theorem evalAngle_two_mul {n N : ℕ} (h : n = 2 * N) (f : Fin n → ℝ) (θ : ℝ) :
+    evalAngle f θ = evalAngle (fun i : Fin N => f ⟨2 * i.1, by omega⟩) (2 * θ) +
+      Complex.exp ((θ : ℂ) * I) *
+        evalAngle (fun i : Fin N => f ⟨2 * i.1 + 1, by omega⟩) (2 * θ) := by
+  unfold evalAngle
+  rw [sum_univ_two_mul h, Finset.sum_add_distrib, Finset.mul_sum]
+  congr 1
+  · apply Finset.sum_congr rfl
+    intro i _
+    congr 2
+    push_cast
+    ring
+  · apply Finset.sum_congr rfl
+    intro i _
+    rw [← mul_assoc, mul_comm (Complex.exp _) _, mul_assoc, ← Complex.exp_add]
+    congr 2
+    push_cast
+    ring
+
+theorem evalAngle_add {n : ℕ} (f g : Fin n → ℝ) (θ : ℝ) :
+    evalAngle (fun i => f i + g i) θ = evalAngle f θ + evalAngle g θ := by
+  unfold evalAngle
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro i _
+  push_cast
+  ring
+
+theorem evalAngle_neg {n : ℕ} (f : Fin n → ℝ) (θ : ℝ) :
+    evalAngle (fun i => -f i) θ = -evalAngle f θ := by
+  unfold evalAngle
+  rw [← Finset.sum_neg_distrib]
+  apply Finset.sum_congr rfl
+  intro i _
+  push_cast
+  ring
+
+theorem evalAngle_add_two_pi {n : ℕ} (f : Fin n → ℝ) (θ : ℝ) :
+    evalAngle f (θ + 2 * Real.pi) = evalAngle f θ := by
+  unfold evalAngle
+  apply Finset.sum_congr rfl
+  intro i _
+  congr 1
+  rw [show ((((i.1 : ℝ) * (θ + 2 * Real.pi) : ℝ)) : ℂ) * I =
+      (((i.1 : ℝ) * θ : ℝ) : ℂ) * I + (i.1 : ℂ) * (2 * (Real.pi : ℂ) * I) by push_cast; ring,
+    Complex.exp_add, Complex.exp_nat_mul_two_pi_mul_I, mul_one]
+
+/-! ## Root angles are roots of `X^n + 1` -/
+
+theorem exp_rootAngle : ∀ (k j : ℕ),
+    Complex.exp ((((2 * 2 ^ k : ℕ) : ℝ) * rootAngle k j : ℝ) * I) = -1
+  | 0, j => by
+    have h : (((2 * 2 ^ 0 : ℕ) : ℝ) * rootAngle 0 j : ℝ) = Real.pi := by
+      simp only [rootAngle_zero]
+      push_cast
+      ring
+    rw [h]
+    exact Complex.exp_pi_mul_I
+  | k + 1, j => by
+    have h : (((2 * 2 ^ (k + 1) : ℕ) : ℝ) * rootAngle (k + 1) j : ℝ) =
+        (((2 * 2 ^ k : ℕ) : ℝ) * rootAngle k (j / 2) : ℝ) +
+          (((2 ^ (k + 1) * (j % 2) : ℕ) : ℝ) * (2 * Real.pi) : ℝ) := by
+      simp only [rootAngle]
+      push_cast
+      ring
+    rw [h, Complex.ofReal_add, add_mul, Complex.exp_add, exp_rootAngle k (j / 2)]
+    rw [show (((((2 ^ (k + 1) * (j % 2) : ℕ) : ℝ) * (2 * Real.pi) : ℝ)) : ℂ) * I =
+        ((2 ^ (k + 1) * (j % 2) : ℕ) : ℂ) * (2 * (Real.pi : ℂ) * I) by push_cast; ring,
+      Complex.exp_nat_mul_two_pi_mul_I]
+    ring
+
+/-! ## Evaluation is a ring homomorphism on the roots of `X^n + 1` -/
+
+theorem evalAngle_negacyclicConvCoeff {n : ℕ} (a b : Fin n → ℝ) (θ : ℝ)
+    (hθ : Complex.exp ((((n : ℕ) : ℝ) * θ : ℝ) * I) = -1) :
+    evalAngle (fun m => LatticeCrypto.negacyclicConvCoeff a b m) θ =
+      evalAngle a θ * evalAngle b θ := by
+  unfold evalAngle
+  set E : ℕ → ℂ := fun m => Complex.exp (((m : ℝ) * θ : ℝ) * I) with hE
+  have hEmul : ∀ i j : ℕ, E (i + j) = E i * E j := by
+    intro i j
+    simp only [hE]
+    rw [← Complex.exp_add]
+    congr 1
+    push_cast
+    ring
+  have hEn : E n = -1 := hθ
+  change ∑ m : Fin n, ((LatticeCrypto.negacyclicConvCoeff a b m : ℝ) : ℂ) * E m.1 =
+    (∑ m : Fin n, (a m : ℂ) * E m.1) * ∑ m : Fin n, (b m : ℂ) * E m.1
+  rw [Finset.sum_mul_sum]
+  simp only [LatticeCrypto.negacyclicConvCoeff, Complex.ofReal_sum, Finset.sum_mul]
+  rw [Finset.sum_comm, Fintype.sum_prod_type]
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  have hn : 0 < n := Fin.pos i
+  set t : Fin n := ⟨(i.1 + j.1) % n, Nat.mod_lt _ hn⟩ with ht
+  set s : ℝ := if i.1 + j.1 < n then a i * b j else -(a i * b j) with hs
+  have hterm : ∀ m : Fin n,
+      ((if (i.1 + j.1) % n = m.1 then s else 0 : ℝ) : ℂ) * E m.1 =
+        if m = t then (s : ℂ) * E t.1 else 0 := by
+    intro m
+    by_cases hm : m = t
+    · subst hm
+      simp [ht]
+    · have : (i.1 + j.1) % n ≠ m.1 := fun h => hm (Fin.ext h.symm)
+      simp [this, hm]
+  simp only [hterm, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+  by_cases hlt : i.1 + j.1 < n
+  · have ht' : t.1 = i.1 + j.1 := Nat.mod_eq_of_lt hlt
+    rw [ht', hEmul]
+    simp only [hs, if_pos hlt]
+    push_cast
+    ring
+  · rw [not_lt] at hlt
+    have ht' : t.1 = i.1 + j.1 - n := by
+      change (i.1 + j.1) % n = _
+      rw [Nat.mod_eq_sub_mod hlt, Nat.mod_eq_of_lt (by omega)]
+    have hsplit : (a i : ℂ) * E i.1 * ((b j : ℂ) * E j.1) =
+        ((a i * b j : ℝ) : ℂ) * (E (i.1 + j.1 - n) * E n) := by
+      rw [← hEmul, Nat.sub_add_cancel hlt, hEmul]
+      push_cast
+      ring
+    rw [ht', hsplit, hEn]
+    simp only [hs, if_neg (not_lt.mpr hlt)]
+    push_cast
+    ring
+
+/-! ## The packed FFT of a real polynomial -/
+
+namespace RealFFTPoly
+
+variable {k : ℕ}
+
+/-- The packed FFT representation of the real polynomial with coefficient function `f`, built by
+the merge recursion of the specification. -/
+noncomputable def ofCoeffs : (k : ℕ) → (Fin (2 * 2 ^ k) → ℝ) → RealFFTPoly k
+  | 0, f =>
+      pack (Vector.ofFn fun _ => f ⟨0, by norm_num⟩) (Vector.ofFn fun _ => f ⟨1, by norm_num⟩)
+  | k + 1, f =>
+      Primitives.mergeFFT
+        (ofCoeffs k fun i => f ⟨2 * i.1, by have := i.2; have := two_pow_succ_eq k; omega⟩)
+        (ofCoeffs k fun i => f ⟨2 * i.1 + 1, by have := i.2; have := two_pow_succ_eq k; omega⟩)
+
+/-- The coefficients recovered from a packed FFT representation by the split recursion of the
+specification. -/
+noncomputable def toCoeffs : (k : ℕ) → RealFFTPoly k → (Fin (2 * 2 ^ k) → ℝ)
+  | 0, v => fun i => v.get i
+  | k + 1, v => fun i =>
+      if i.1 % 2 = 0 then
+        toCoeffs k (Primitives.splitFFT v).1
+          ⟨i.1 / 2, by have := i.2; have := two_pow_succ_eq k; omega⟩
+      else
+        toCoeffs k (Primitives.splitFFT v).2
+          ⟨i.1 / 2, by have := i.2; have := two_pow_succ_eq k; omega⟩
+
+/-- **The packed FFT is an evaluation map.** Coordinate `j` at level `k` is the value of the
+polynomial at `exp(rootAngle k j · I)`. -/
+theorem coord_ofCoeffs : ∀ (k : ℕ) (f : Fin (2 * 2 ^ k) → ℝ) (j : Fin (2 ^ k)),
+    coord (ofCoeffs k f) j = evalAngle f (rootAngle k j.1)
+  | 0, f, j => by
+    have hj : j = ⟨0, by norm_num⟩ := Fin.ext (by have := j.2; simp at this; omega)
+    subst hj
+    rw [ofCoeffs, coord_pack]
+    unfold evalAngle
+    rw [sum_univ_two_mul (N := 1) (by norm_num), Fin.sum_univ_one]
+    apply Complex.ext
+    · simp
+    · simp
+  | k + 1, f, j => by
+    rcases Nat.even_or_odd' j.1 with ⟨i, hi | hi⟩
+    · have hi' : i < 2 ^ k := by have := j.2; have := two_pow_succ_eq k; omega
+      have hj : j = ⟨2 * i, by have := two_pow_succ_eq k; omega⟩ := Fin.ext hi
+      rw [hj, ofCoeffs, coord_mergeFFT_even _ _ i hi', coord_ofCoeffs k, coord_ofCoeffs k,
+        evalAngle_two_mul (n := 2 * 2 ^ (k + 1)) (N := 2 * 2 ^ k) (by ring)]
+      simp only [rootAngle_two_mul, Primitives.splitAngle]
+      rw [show 2 * (rootAngle k i / 2) = rootAngle k i by ring]
+    · have hi' : i < 2 ^ k := by have := j.2; have := two_pow_succ_eq k; omega
+      have hj : j = ⟨2 * i + 1, by have := two_pow_succ_eq k; omega⟩ := Fin.ext hi
+      rw [hj, ofCoeffs, coord_mergeFFT_odd _ _ i hi', coord_ofCoeffs k, coord_ofCoeffs k,
+        evalAngle_two_mul (n := 2 * 2 ^ (k + 1)) (N := 2 * 2 ^ k) (by ring)]
+      simp only [rootAngle_two_mul_add_one, Primitives.splitAngle]
+      rw [show 2 * (rootAngle k i / 2 + Real.pi) = rootAngle k i + 2 * Real.pi by ring,
+        evalAngle_add_two_pi, evalAngle_add_two_pi, Complex.ofReal_add, add_mul, Complex.exp_add,
+        Complex.exp_pi_mul_I]
+      ring
+
+/-- **The packed FFT is multiplicative.** Negacyclic multiplication of coefficient functions
+becomes the pointwise complex multiplication `Primitives.mulFFT`. -/
+theorem ofCoeffs_negacyclic (k : ℕ) (a b : Fin (2 * 2 ^ k) → ℝ) :
+    ofCoeffs k (fun m => LatticeCrypto.negacyclicConvCoeff a b m) =
+      Primitives.mulFFT (ofCoeffs k a) (ofCoeffs k b) := by
+  apply ext_coord
+  intro j
+  rw [coord_mulFFT, coord_ofCoeffs, coord_ofCoeffs, coord_ofCoeffs,
+    evalAngle_negacyclicConvCoeff a b _ (exp_rootAngle k j.1)]
+
+theorem ofCoeffs_add (k : ℕ) (a b : Fin (2 * 2 ^ k) → ℝ) :
+    ofCoeffs k (fun m => a m + b m) = ofCoeffs k a + ofCoeffs k b := by
+  apply ext_coord
+  intro j
+  rw [coord_add, coord_ofCoeffs, coord_ofCoeffs, coord_ofCoeffs, evalAngle_add]
+
+theorem ofCoeffs_neg (k : ℕ) (a : Fin (2 * 2 ^ k) → ℝ) :
+    ofCoeffs k (fun m => -a m) = -ofCoeffs k a := by
+  apply ext_coord
+  intro j
+  rw [coord_neg, coord_ofCoeffs, coord_ofCoeffs, evalAngle_neg]
+
+/-! ## The split recursion inverts the merge recursion -/
+
+theorem splitFFT_mergeFFT (f₀ f₁ : RealFFTPoly k) :
+    Primitives.splitFFT (Primitives.mergeFFT f₀ f₁) = (f₀, f₁) := by
+  refine Prod.ext (ext_coord fun i => ?_) (ext_coord fun i => ?_)
+  · apply Complex.ext <;>
+      simp [coord, Primitives.splitFFT, Primitives.mergeFFT, Nat.mul_add_div]
+  · apply Complex.ext
+    · simp only [coord, Primitives.splitFFT, Primitives.mergeFFT, dite_eq_ite, re_pack,
+        Vector.get_ofFn, Nat.mul_mod_right, ↓reduceIte, ne_eq, OfNat.ofNat_ne_zero,
+        not_false_eq_true, mul_div_cancel_left₀, Fin.eta, Nat.mul_add_mod_self_left, Nat.mod_succ,
+        one_ne_zero, gt_iff_lt, Order.lt_two_iff, zero_le, Nat.mul_add_div, Nat.reduceDiv, add_zero,
+        add_add_sub_cancel, add_self_div_two, im_pack, add_sub_sub_cancel]
+      linear_combination f₁.re i * Real.cos_sq_add_sin_sq (Primitives.splitAngle i)
+    · simp only [coord, Primitives.splitFFT, Primitives.mergeFFT, dite_eq_ite, re_pack,
+        Vector.get_ofFn, Nat.mul_mod_right, ↓reduceIte, ne_eq, OfNat.ofNat_ne_zero,
+        not_false_eq_true, mul_div_cancel_left₀, Fin.eta, Nat.mul_add_mod_self_left, Nat.mod_succ,
+        one_ne_zero, gt_iff_lt, Order.lt_two_iff, zero_le, Nat.mul_add_div, Nat.reduceDiv, add_zero,
+        add_add_sub_cancel, add_self_div_two, im_pack, add_sub_sub_cancel]
+      linear_combination f₁.im i * Real.cos_sq_add_sin_sq (Primitives.splitAngle i)
+
+theorem toCoeffs_ofCoeffs : ∀ (k : ℕ) (f : Fin (2 * 2 ^ k) → ℝ), toCoeffs k (ofCoeffs k f) = f
+  | 0, f => by
+    funext i
+    rcases i with ⟨m, hm⟩
+    have hm' : m = 0 ∨ m = 1 := by norm_num at hm; omega
+    rcases hm' with rfl | rfl
+    · change (pack _ _).re ⟨0, by norm_num⟩ = _
+      rw [re_pack]
+      simp
+    · change (pack _ _).im ⟨0, by norm_num⟩ = _
+      rw [im_pack]
+      simp
+  | k + 1, f => by
+    funext i
+    simp only [toCoeffs, ofCoeffs, splitFFT_mergeFFT, toCoeffs_ofCoeffs k]
+    split_ifs with h
+    · congr 1
+      ext
+      simp only
+      omega
+    · congr 1
+      ext
+      simp only
+      omega
+
+/-! ## Interleaving even and odd coefficients -/
+
+/-- The coefficient function whose even coefficients are `a` and odd coefficients are `b`. -/
+def interleave {α : Type*} (k : ℕ) (a b : Fin (2 * 2 ^ k) → α) : Fin (2 * 2 ^ (k + 1)) → α :=
+  fun i =>
+    if i.1 % 2 = 0 then a ⟨i.1 / 2, by have := i.2; have := two_pow_succ_eq k; omega⟩
+    else b ⟨i.1 / 2, by have := i.2; have := two_pow_succ_eq k; omega⟩
+
+theorem interleave_cast (k : ℕ) (a b : Fin (2 * 2 ^ k) → ℤ) :
+    (fun i => ((interleave k a b i : ℤ) : ℝ)) =
+      interleave k (fun i => (a i : ℝ)) (fun i => (b i : ℝ)) := by
+  funext i
+  simp only [interleave]
+  split_ifs <;> rfl
+
+theorem ofCoeffs_interleave (k : ℕ) (a b : Fin (2 * 2 ^ k) → ℝ) :
+    ofCoeffs (k + 1) (interleave k a b) = Primitives.mergeFFT (ofCoeffs k a) (ofCoeffs k b) := by
+  simp only [ofCoeffs]
+  congr 1
+  · congr 1
+    funext i
+    simp [interleave]
+  · congr 1
+    funext i
+    simp [interleave, Nat.mul_add_div]
+
+end RealFFTPoly
+
+/-! ## The sampler outputs packed FFTs of integer polynomials -/
+
+/-- **Every `ffSampling` output is the packed FFT of a pair of integer polynomials.** The leaves
+sample integers into both coordinates and the nodes merge. -/
+theorem Primitives.ffSampling_support_ofCoeffs {p : Params} (prims : Primitives p) :
+    ∀ (κ : ℕ) (t : FFTPair κ) (tree : FalconTree κ) (z : FFTPair κ),
+      z ∈ support (prims.ffSampling κ t tree) →
+        ∃ a b : Fin (2 * 2 ^ κ) → ℤ,
+          z.1 = RealFFTPoly.ofCoeffs κ (fun i => (a i : ℝ)) ∧
+          z.2 = RealFFTPoly.ofCoeffs κ (fun i => (b i : ℝ))
+  | 0, (t₀, t₁), .leaf σ, z, hz => by
+    simp only [Primitives.ffSampling, mem_support_bind_iff, support_pure,
+      Set.mem_singleton_iff] at hz
+    obtain ⟨z₀Re, -, z₀Im, -, z₁Re, -, z₁Im, -, rfl⟩ := hz
+    refine ⟨fun i => if i.1 = 0 then z₀Re else z₀Im, fun i => if i.1 = 0 then z₁Re else z₁Im,
+      ?_, ?_⟩ <;> simp [RealFFTPoly.ofCoeffs]
+  | k + 1, (t₀, t₁), .node ℓ left right, z, hz => by
+    simp only [Primitives.ffSampling, mem_support_bind_iff, support_pure,
+      Set.mem_singleton_iff] at hz
+    obtain ⟨z₁Split, hz₁, z₀Split, hz₀, rfl⟩ := hz
+    obtain ⟨a₁, b₁, ha₁, hb₁⟩ := ffSampling_support_ofCoeffs prims k _ right z₁Split hz₁
+    obtain ⟨a₀, b₀, ha₀, hb₀⟩ := ffSampling_support_ofCoeffs prims k _ left z₀Split hz₀
+    refine ⟨RealFFTPoly.interleave k a₀ b₀, RealFFTPoly.interleave k a₁ b₁, ?_, ?_⟩
+    · rw [RealFFTPoly.interleave_cast, RealFFTPoly.ofCoeffs_interleave, ← ha₀, ← hb₀]
+    · rw [RealFFTPoly.interleave_cast, RealFFTPoly.ofCoeffs_interleave, ← ha₁, ← hb₁]
+
+/-! ## Specification-level FFT primitives -/
+
+namespace Primitives
+
+variable (p : Params)
+
+/-- The exact `fftTarget`: the packed FFT of the hash target, coefficients read as the integers
+in `[0, q)` of the reference `hm` array. Degenerate parameters with `p.n ≠ 2 * 2 ^ p.fftDepth`
+map to `0`. -/
+noncomputable def exactFftTarget (c : Rq p.n) : RealFFTPoly p.fftDepth :=
+  if h : 2 * 2 ^ p.fftDepth = p.n then
+    RealFFTPoly.ofCoeffs p.fftDepth fun i => (((c.get (Fin.cast h i)).val : ℕ) : ℝ)
+  else 0
+
+/-- The exact `fftInt`: the packed FFT of an integer polynomial. -/
+noncomputable def exactFftInt (f : IntPoly p.n) : RealFFTPoly p.fftDepth :=
+  if h : 2 * 2 ^ p.fftDepth = p.n then
+    RealFFTPoly.ofCoeffs p.fftDepth fun i => (f.get (Fin.cast h i) : ℝ)
+  else 0
+
+/-- The exact `ifftRound`: the coefficients recovered by the split recursion, rounded to the
+nearest integer. -/
+noncomputable def exactIfftRound (v : RealFFTPoly p.fftDepth) : IntPoly p.n :=
+  if h : 2 * 2 ^ p.fftDepth = p.n then
+    LatticeCrypto.Poly.ofPi fun i =>
+      round (RealFFTPoly.toCoeffs p.fftDepth v (Fin.cast h.symm i))
+  else 0
+
+/-- A primitive bundle whose `fftInt` and `ifftRound` are the exact packed FFT of the
+specification. `hn` identifies the ring degree with the packed length. -/
+structure ExactFFT {p : Params} (prims : Primitives p) (hn : 2 * 2 ^ p.fftDepth = p.n) :
+    Prop where
+  fftInt_eq : ∀ f : IntPoly p.n,
+    prims.fftInt f = RealFFTPoly.ofCoeffs p.fftDepth fun i => (f.get (Fin.cast hn i) : ℝ)
+  ifftRound_eq : ∀ v : RealFFTPoly p.fftDepth,
+    prims.ifftRound v =
+      LatticeCrypto.Poly.ofPi fun i =>
+        round (RealFFTPoly.toCoeffs p.fftDepth v (Fin.cast hn.symm i))
+
+theorem exactFftInt_eq (hn : 2 * 2 ^ p.fftDepth = p.n) (f : IntPoly p.n) :
+    exactFftInt p f = RealFFTPoly.ofCoeffs p.fftDepth fun i => (f.get (Fin.cast hn i) : ℝ) := by
+  simp [exactFftInt, hn]
+
+theorem exactIfftRound_eq (hn : 2 * 2 ^ p.fftDepth = p.n) (v : RealFFTPoly p.fftDepth) :
+    exactIfftRound p v =
+      LatticeCrypto.Poly.ofPi fun i =>
+        round (RealFFTPoly.toCoeffs p.fftDepth v (Fin.cast hn.symm i)) := by
+  simp [exactIfftRound, hn]
+
+/-- Any bundle built from the exact fields satisfies `ExactFFT`. -/
+theorem exactFFT_of_eq {p : Params} (prims : Primitives p) (hn : 2 * 2 ^ p.fftDepth = p.n)
+    (hfft : prims.fftInt = exactFftInt p) (hifft : prims.ifftRound = exactIfftRound p) :
+    prims.ExactFFT hn :=
+  ⟨fun f => by rw [hfft, exactFftInt_eq p hn], fun v => by rw [hifft, exactIfftRound_eq p hn]⟩
+
+end Primitives
+
+end Falcon
+
+end

--- a/LatticeCrypto/Falcon/PackedFFT.lean
+++ b/LatticeCrypto/Falcon/PackedFFT.lean
@@ -24,7 +24,7 @@ the polynomial at `exp(rootAngle k j · I)`. Everything else follows from that d
   pair of integer polynomials, because the leaves sample integers and the nodes merge.
 -/
 
-@[expose] public section
+public section
 
 open OracleComp OracleSpec Complex
 

--- a/LatticeCrypto/Falcon/PackedFFT.lean
+++ b/LatticeCrypto/Falcon/PackedFFT.lean
@@ -39,9 +39,11 @@ variable {k : ℕ}
 /-- The `j`-th packed coordinate as a complex number. -/
 noncomputable def coord (f : RealFFTPoly k) (j : Fin (2 ^ k)) : ℂ := ⟨f.re j, f.im j⟩
 
-@[simp] theorem coord_re (f : RealFFTPoly k) (j : Fin (2 ^ k)) : (coord f j).re = f.re j := rfl
+@[simp] theorem coord_re (f : RealFFTPoly k) (j : Fin (2 ^ k)) : (coord f j).re = f.re j := by
+  simp [coord]
 
-@[simp] theorem coord_im (f : RealFFTPoly k) (j : Fin (2 ^ k)) : (coord f j).im = f.im j := rfl
+@[simp] theorem coord_im (f : RealFFTPoly k) (j : Fin (2 ^ k)) : (coord f j).im = f.im j := by
+  simp [coord]
 
 @[simp] theorem re_pack (a b : Vector ℝ (2 ^ k)) (i : Fin (2 ^ k)) : (pack a b).re i = a.get i := by
   simp [pack, re, i.isLt]
@@ -93,10 +95,6 @@ theorem coord_mulFFT (a b : RealFFTPoly k) (j : Fin (2 ^ k)) :
   apply Complex.ext <;> simp [coord, Primitives.mulFFT]
 
 theorem two_pow_succ_eq (k : ℕ) : 2 ^ (k + 1) = 2 * 2 ^ k := by ring
-
-/-- Half of a coordinate index, as an index one level down. -/
-abbrev half (j : Fin (2 ^ (k + 1))) : Fin (2 ^ k) :=
-  ⟨j.1 / 2, by have := j.2; have := two_pow_succ_eq k; omega⟩
 
 theorem coord_mergeFFT_even (f₀ f₁ : RealFFTPoly k) (i : ℕ) (hi : i < 2 ^ k) :
     coord (Primitives.mergeFFT f₀ f₁) ⟨2 * i, by have := two_pow_succ_eq k; omega⟩ =

--- a/LatticeCrypto/Falcon/Primitives.lean
+++ b/LatticeCrypto/Falcon/Primitives.lean
@@ -76,6 +76,33 @@ namespace RealFFTPoly
 
 end RealFFTPoly
 
+/-- The root angle of packed coordinate `j` at recursion level `k`.
+
+A packed Falcon FFT polynomial of length `2 * 2^k` stores the values of a real polynomial of
+degree `2 * 2^k` at one root of `X^(2 · 2^k) + 1` from each conjugate pair; `rootAngle k j` is
+the argument of the root of coordinate `j`. Level `0` stores the single evaluation at
+`exp(π/2 · I) = I`. Splitting `f = f₀(X²) + X · f₁(X²)` places `f(ω)` and `f(-ω)` at the adjacent
+coordinates `2i` and `2i + 1`, where `ω²` is the level-`k` root of coordinate `i`, so
+
+- `rootAngle (k + 1) (2 * i) = rootAngle k i / 2`,
+- `rootAngle (k + 1) (2 * i + 1) = rootAngle k i / 2 + π`.
+
+This is the bit-reversed root order of Falcon's `fpoly_FFT` and of its twiddle table
+(`GM_TAB[m] = exp(π · bitrev₁₀(m) / 1024 · I)`): in closed form
+`rootAngle k j = (4 · bitrev_k j + 1) π / 2^(k+1)`. Indices `j ≥ 2^k` are never used. -/
+noncomputable def rootAngle : ℕ → ℕ → ℝ
+  | 0, _ => Real.pi / 2
+  | k + 1, j => rootAngle k (j / 2) / 2 + ((j % 2 : ℕ) : ℝ) * Real.pi
+
+@[simp] theorem rootAngle_zero (j : ℕ) : rootAngle 0 j = Real.pi / 2 := rfl
+
+theorem rootAngle_two_mul (k i : ℕ) : rootAngle (k + 1) (2 * i) = rootAngle k i / 2 := by
+  simp [rootAngle]
+
+theorem rootAngle_two_mul_add_one (k i : ℕ) :
+    rootAngle (k + 1) (2 * i + 1) = rootAngle k i / 2 + Real.pi := by
+  simp [rootAngle, Nat.mul_add_div]
+
 /-- The Falcon tree (LDL tree), a binary tree used by `ffSampling` (Algorithm 11).
 
 - At level 0 (leaves): stores `σ > 0`, the standard deviation for `SamplerZ` at that leaf.
@@ -126,14 +153,16 @@ namespace Primitives
 
 variable {p : Params} (prims : Primitives p)
 
-/-- The canonical split angle for the proof-level Falcon FFT specification.
+/-- The split angle of the proof-level Falcon FFT at level `k`: half the root angle of
+packed coordinate `i`.
 
-For `splitFFT` on a packed Falcon FFT polynomial of length `2 * 2^(k+1)`, we follow the
-implementation order used by Falcon's `fpoly_split_fft` and `fpoly_merge_fft`: the adjacent
-packed coordinates `(2i, 2i+1)` form the pair `f(ωᵢ), f(-ωᵢ)` where
-`ωᵢ = exp(((2i + 1)π / 2^(k+2)) · I)`. -/
+For `splitFFT` on a packed Falcon FFT polynomial of length `2 * 2^(k+1)`, the adjacent packed
+coordinates `(2i, 2i+1)` form the pair `f(ωᵢ), f(-ωᵢ)` with `ωᵢ = exp(splitAngle i · I)`, and
+`ωᵢ² = exp(rootAngle k i · I)` is the root of coordinate `i` one level down. This is what makes
+the split/merge recursion a consistent evaluation map (`RealFFTPoly.re_ofCoeffs`), and it is the
+implementation order of Falcon's `fpoly_split_fft` and `fpoly_merge_fft`. -/
 @[inline] noncomputable def splitAngle {k : ℕ} (i : Fin (2 ^ k)) : ℝ :=
-  (((2 * i.1 + 1 : ℕ) : ℝ) * Real.pi) / (((2 ^ (k + 2) : ℕ) : ℝ))
+  rootAngle k i.1 / 2
 
 /-- Hash a message using the verification-key bytes derived from `pk`. -/
 @[inline] def hashToPointForPublicKey (pk : Rq p.n) (salt : Bytes 40) (msg : List Byte) :
@@ -157,8 +186,7 @@ def mulFFT {k : ℕ} (a b : RealFFTPoly k) : RealFFTPoly k :=
 /-- Split a packed Falcon FFT polynomial into its even and odd parts.
 
 If `f = f₀(x²) + x · f₁(x²)` and the adjacent packed coordinates of `f` encode
-`a = f(ωᵢ)`, `b = f(-ωᵢ)` for the canonical implementation-order roots
-`ωᵢ = exp(((2i + 1)π / 2^(k+2)) · I)`, then
+`a = f(ωᵢ)`, `b = f(-ωᵢ)` for the implementation-order roots `ωᵢ = exp(splitAngle i · I)`, then
 
 - `f₀(ωᵢ²) = (a + b) / 2`
 - `f₁(ωᵢ²) = (a - b) / (2ωᵢ)`
@@ -201,7 +229,7 @@ noncomputable def splitFFT {k : ℕ}
 /-- Merge two half-size Falcon FFT polynomials into a full-size one.
 
 This inverts `splitFFT`: if `f = f₀(x²) + x · f₁(x²)`, then for each implementation-order
-root `ωᵢ = exp(((2i + 1)π / 2^(k+2)) · I)` we reconstruct the adjacent packed pair
+root `ωᵢ = exp(splitAngle i · I)` we reconstruct the adjacent packed pair
 
 - `f(ωᵢ) = f₀(ωᵢ²) + ωᵢ · f₁(ωᵢ²)`
 - `f(-ωᵢ) = f₀(ωᵢ²) - ωᵢ · f₁(ωᵢ²)` -/

--- a/LatticeCrypto/Falcon/Scheme.lean
+++ b/LatticeCrypto/Falcon/Scheme.lean
@@ -214,19 +214,54 @@ noncomputable def signAttempt (pk : PublicKey p) (sk : SecretKey p) (c : Rq p.n)
   else
     return none
 
-/-- Falcon signing (Falcon+, Algorithm 10).
+/-- The centered integer lift of an element of `R_q`: coefficientwise the representative in
+`(-q/2, q/2]`. This is the polynomial the signer hands to `compress`. -/
+noncomputable def rqToIntPolyCentered {n : ℕ} (f : Rq n) : IntPoly n :=
+  LatticeCrypto.Poly.ofPi fun i => LatticeCrypto.centeredRepr (f.get i)
 
-On each attempt:
+/-- The coefficients of the reduction of an integer polynomial modulo `q`. -/
+theorem toRq_get {n : ℕ} (a : IntPoly n) (i : Fin n) :
+    (IntPoly.toRq a : Rq n).get i = ((a.get i : ℤ) : Coeff) := by
+  simp [IntPoly.toRq, integralLift, LatticeCrypto.vectorIntegralLift,
+    LatticeCrypto.PolyBackend.mapCoeffs, LatticeCrypto.vectorBackend]
+
+/-- Reducing the centered integer lift modulo `q` recovers the original element. -/
+theorem toRq_rqToIntPolyCentered {n : ℕ} (f : Rq n) :
+    IntPoly.toRq (rqToIntPolyCentered f) = f := by
+  apply LatticeCrypto.Poly.ext_get_eq
+  intro i
+  rw [toRq_get, rqToIntPolyCentered, LatticeCrypto.Poly.get_ofPi]
+  exact (LatticeCrypto.centeredRepr_intCast (f.get i)).symm
+
+/-- Falcon signing (Falcon+, Algorithm 10), as a fuel-bounded rejection loop.
+
+On each of up to `maxAttempts` attempts:
 1. Sample a fresh 40-byte salt `r`.
 2. Hash `c = HashToPoint(r, pk, message)` to get the target in `R_q`.
 3. Use the secret key to sample a short preimage `(s₁, s₂)` via `signAttempt`.
-4. If the norm check passes and compression succeeds, return `(r, compress(s₂))`.
+4. If the norm check passes and compression succeeds, return `some (r, compress(s₂))`.
 5. Otherwise retry with a new salt.
 
+Returns `none` once the attempt budget is exhausted. Compression is a separate gate from
+the norm check: a preimage can pass the `ℓ₂` bound and still have a coefficient too large for
+`compress` at `p.sbytelen`, so the loop retries on either failure. The compression length is
+`p.sbytelen`, the length `verify` decompresses at.
+
 The fresh-salt-per-retry structure matches the Falcon+ convention and the concrete
-executable signer in `LatticeCrypto.Falcon.Concrete.Sign.concreteSign`. -/
+executable signer in `Extern.Falcon.Sign`. -/
 noncomputable def sign (pk : PublicKey p) (sk : SecretKey p) (msg : List Byte) :
-    ProbComp Signature := sorry
+    ℕ → ProbComp (Option Signature)
+  | 0 => return none
+  | maxAttempts + 1 => do
+    let salt ← ($ᵗ (Bytes 40) : ProbComp (Bytes 40))
+    let c := prims.hashToPointForPublicKey pk.h salt msg
+    let r ← signAttempt p prims pk sk c
+    match r with
+    | some (_, s₂) =>
+        match prims.compress (rqToIntPolyCentered s₂) p.sbytelen with
+        | some comp => return (some ⟨salt, comp⟩)
+        | none => sign pk sk msg maxAttempts
+    | none => sign pk sk msg maxAttempts
 
 /-- Falcon verification (Algorithm 16).
 

--- a/LatticeCrypto/Falcon/Security.lean
+++ b/LatticeCrypto/Falcon/Security.lean
@@ -99,28 +99,88 @@ variable (p : Params) (prims : Primitives p)
 
 /-! ### Correctness -/
 
-/-- Falcon verification correctness: if the key pair is valid and signing produces a
-signature (does not abort), then verification accepts.
+/-- **Falcon verification correctness, conditional on the sampler landing on the coset.**
 
-The proof relies on:
-1. The NTRU equation ensuring `s₁ + s₂ · h = c mod q`.
-2. The norm bound from `ffSampling` ensuring `‖(s₁, s₂)‖₂² ≤ ⌊β²⌋`.
-3. The compress/decompress roundtrip preserving `s₂`. -/
-theorem verify_sign_correct (pk : PublicKey p) (sk : SecretKey p)
-    (hvalid : validKeyPair p pk sk = true)
-    (msg : List Byte) (sig : Signature)
-    (h_laws : Primitives.Laws prims)
-    (hsig : sig ∈ support (Falcon.sign p pk sk msg)) :
-    Falcon.verify p prims pk msg sig = true := by
-  -- The proof proceeds by unfolding `sign` and `verify`:
-  -- 1. `sign` produces (salt, compressedS2) where s₂ came from trapdoorSample
-  -- 2. `verify` decompresses s₂, recomputes c, checks the norm bound
-  -- Key steps:
-  -- (a) compress/decompress roundtrip (from h_laws.compress_decompress)
-  -- (b) PSF correctness: trapdoorSample output satisfies eval pk (s₁,s₂) = c
-  --     and isShort (s₁,s₂) = true
-  -- (c) The norm bound from (b) matches the verify check
-  sorry
+If the fuel-bounded signer returns a signature, `verify` accepts it, given two facts about the
+primitives at the honest key:
+
+1. `hcompress`: the codec round-trips (the `compress_decompress` law of `Primitives.Laws`);
+2. `hpreimage`: every output of the trapdoor sampler is a preimage of its target,
+   `s₁ + s₂ · h = c`.
+
+Hypothesis 2 is the lattice-point obligation of the floating-point pipeline. `fromFFTPreimage`
+rounds an inverse FFT to obtain `v = z · B` and returns `(c − v₀, −v₁)`, and `s₁ + s₂ · h = c`
+holds exactly when the rounded `v` is the lattice point `z · B`, i.e. when the inverse FFT's
+rounding error stays below `1/2` in every coordinate. It is stated here rather than built into
+the model, so that it is discharged where the arithmetic is exact and stays visible where it is
+not. Neither the NTRU equation nor `validKeyPair` is needed: the signer emits only attempts that
+passed the norm check, and that check is `verify`'s own. -/
+theorem verify_sign_correct (pk : PublicKey p) (sk : SecretKey p) (msg : List Byte)
+    (maxAttempts : ℕ) (sig : Signature)
+    (hcompress : ∀ (s : IntPoly p.n) (slen : ℕ) (bytes : List Byte),
+      prims.compress s slen = some bytes → prims.decompress bytes slen = some s)
+    (hpreimage : ∀ (c : Rq p.n) (x : Rq p.n × Rq p.n),
+      x ∈ support ((falconPSF p prims).trapdoorSample pk sk c) →
+        (falconPSF p prims).eval pk x = c)
+    (hsig : some sig ∈ support (sign p prims pk sk msg maxAttempts)) :
+    verify p prims pk msg sig = true := by
+  induction maxAttempts with
+  | zero =>
+    simp only [sign, support_pure, Set.mem_singleton_iff] at hsig
+    exact absurd hsig (by simp)
+  | succ k ih =>
+    rw [sign, mem_support_bind_iff] at hsig
+    obtain ⟨salt, _hsalt, hsig⟩ := hsig
+    rw [mem_support_bind_iff] at hsig
+    obtain ⟨r, hr, hsig⟩ := hsig
+    match r, hr, hsig with
+    | none, _hr, hsig => exact ih hsig
+    | some (s₁, s₂), hr, hsig =>
+      dsimp only at hsig
+      cases hcomp : prims.compress (rqToIntPolyCentered s₂) p.sbytelen with
+      | none =>
+        rw [hcomp] at hsig
+        exact ih hsig
+      | some comp =>
+        rw [hcomp] at hsig
+        simp only [support_pure, Set.mem_singleton_iff, Option.some.injEq] at hsig
+        subst hsig
+        -- The accepting attempt is a `trapdoorSample` output that passed the norm check.
+        set c := prims.hashToPointForPublicKey pk.h salt msg with hc
+        rw [signAttempt, mem_support_bind_iff] at hr
+        obtain ⟨x, hx, hr⟩ := hr
+        have hshort_eval :
+            (s₁, s₂) ∈ support ((falconPSF p prims).trapdoorSample pk sk c) ∧
+              (falconPSF p prims).isShort (s₁, s₂) = true := by
+          by_cases hshort : (falconPSF p prims).isShort x = true
+          · rw [if_pos hshort, support_pure, Set.mem_singleton_iff, Option.some.injEq] at hr
+            subst hr
+            exact ⟨hx, hshort⟩
+          · rw [if_neg hshort, support_pure, Set.mem_singleton_iff] at hr
+            exact absurd hr (by simp)
+        obtain ⟨hmem, hshort⟩ := hshort_eval
+        have heval : (falconPSF p prims).eval pk (s₁, s₂) = c := hpreimage c (s₁, s₂) hmem
+        -- `verify` decompresses to the same `s₂`, recomputes the same `s₁`, and runs the norm
+        -- check the attempt already passed.
+        have hdec := hcompress _ _ _ hcomp
+        unfold verify
+        simp only [hdec]
+        rw [toRq_rqToIntPolyCentered]
+        have hs1 : c - negacyclicMul s₂ pk.h = s₁ := by
+          rw [← heval]
+          change s₁ + negacyclicMul s₂ pk.h - negacyclicMul s₂ pk.h = s₁
+          apply LatticeCrypto.Poly.ext_get_eq
+          intro i
+          calc (s₁ + negacyclicMul s₂ pk.h - negacyclicMul s₂ pk.h).get i
+              = (s₁ + negacyclicMul s₂ pk.h).get i - (negacyclicMul s₂ pk.h).get i :=
+                LatticeCrypto.NegacyclicRing.coeff_sub (coeffRing p.n) _ _ i
+            _ = s₁.get i + (negacyclicMul s₂ pk.h).get i - (negacyclicMul s₂ pk.h).get i :=
+                congrArg (· - (negacyclicMul s₂ pk.h).get i)
+                  (LatticeCrypto.NegacyclicRing.coeff_add (coeffRing p.n) _ _ i)
+            _ = s₁.get i := add_sub_cancel_right _ _
+        change decide (pairL2NormSq (c - negacyclicMul s₂ pk.h) s₂ ≤ p.betaSquared) = true
+        rw [hs1]
+        exact hshort
 
 /-! ### NTRU-SIS Hardness Assumption -/
 

--- a/LatticeCrypto/Falcon/Security.lean
+++ b/LatticeCrypto/Falcon/Security.lean
@@ -104,7 +104,8 @@ variable (p : Params) (prims : Primitives p)
 If the fuel-bounded signer returns a signature, `verify` accepts it, given two facts about the
 primitives at the honest key:
 
-1. `hcompress`: the codec round-trips (the `compress_decompress` law of `Primitives.Laws`);
+1. `hcompress`: the codec round-trips (the `compress_decompress` law of `Primitives.Laws`,
+   a theorem for the concrete codec: `Falcon.Concrete.decompress_compress`);
 2. `hpreimage`: every output of the trapdoor sampler is a preimage of its target,
    `s₁ + s₂ · h = c`.
 

--- a/LatticeCrypto/Ring/IntegralLift.lean
+++ b/LatticeCrypto/Ring/IntegralLift.lean
@@ -33,7 +33,8 @@ namespace LatticeCrypto
 
 Bundles a reduction map from integer polynomials to `R_q`, integer-polynomial
 multiplication in `ℤ[X]/(X^n + 1)`, and constant embedding. The multiplication
-uses `schoolbookNegacyclicMul` over the integer backend. -/
+is `negacyclicMulPure` over the integer backend, the `Finset`-sum specification whose
+runtime implementation is `schoolbookNegacyclicMul`. -/
 structure IntegralLift (IntPoly Rq : Type*) where
   toRq : IntPoly → Rq
   mul : IntPoly → IntPoly → IntPoly
@@ -49,7 +50,7 @@ def vectorIntegralLift (q n : Nat) :
     IntegralLift (Poly ℤ n) (Poly (ZMod q) n) where
   toRq := PolyBackend.mapCoeffs (vectorBackend ℤ n) (vectorBackend (ZMod q) n) rfl
     (fun z => (z : ZMod q))
-  mul := schoolbookNegacyclicMul (vectorKernel ℤ n)
+  mul := negacyclicMulPure (vectorKernel ℤ n)
   const := constPoly n
 
 end LatticeCrypto

--- a/scripts/axiom_baseline.json
+++ b/scripts/axiom_baseline.json
@@ -19,8 +19,6 @@
   "Falcon.euf_cma_security",
   "Falcon.euf_cma_security_bytes40",
   "Falcon.keyGenFromSeed",
-  "Falcon.sign",
-  "Falcon.verify_sign_correct",
   "FiatShamirWithAbort.euf_cma_bound",
   "FiatShamirWithAbort.euf_cma_bound_perfectHVZK",
   "GPVHashAndSign.euf_cma_collision_bound",


### PR DESCRIPTION
Includes the original #640 (`falcon-sign-correctness`) commits and the packed-FFT correction.
Aligned with main at `b0e3a9c2` (Lean and Mathlib v4.34.0), preserving both PRs' author history.
The combined stack keeps the corrected FFT model together with its correctness corollaries.

## The bug

`Primitives.splitAngle`, the twiddle angle of `splitFFT`/`mergeFFT` at level `k`, was the natural-order `(2i+1)π/2^(k+2)`. Under that choice the packed-FFT recursion that `ffSampling` runs on is **not an evaluation map** once `n ≥ 8`: the merge tree of a product is not the pointwise product of the merge trees. In exact arithmetic on random ±5 coefficients, `max |tree(a·b) − tree(a)·tree(b)|`:

| n | natural-order angles (main) | bit-reversed angles (this PR) |
|---|---|---|
| 4 | 5e-35 | 5e-35 |
| 8 | 137.7 | 2e-34 |
| 16 | 209.7 | 8e-34 |

The consistent choice is Falcon's own bit-reversed order, `rootAngle k j = (4·bitrev_k j + 1)π/2^(k+1)` with `splitAngle i = rootAngle k i / 2`: the order of the reference twiddle table (`GM_TAB[m] = exp(π·bitrev₁₀(m)/1024 · I)`), and the fixed tree agrees with direct evaluation at those roots to 1e-34. Only `n ≤ 4` is unaffected, which is why the `n = 2` witness in #466 never saw it.

Consequence for #640: `LandsOnLattice`, and with it the `hz` hypothesis of `verify_sign_correct_concretePrimitives_of_landsOnLattice`, was **false** at Falcon-512 for any faithful FFT bundle: the rounded inverse transform of `z·B` misses the lattice point by ~8·10⁴. Those corollaries were vacuous for `n ≥ 8`. This PR fixes the model and then discharges the condition.

## What `concretePrimitives`' FFT fields were

They ran the 32.32 fixed-point `FXR.vect_FFT`/`vect_iFFT` inside ℝ. Two problems, neither of them precision:

- `FXR.fxr_mul`/`fxr_sqr` read the high halves with a logical shift (`(x >>> 32).toInt64`) where the C reference sign-extends: `fxr_mul (-1.0) 0.5 = 0x7fffffff80000000` against C's `0xffffffff80000000`. The fixed-point FFT of a real key is off by ~2·10⁹. Separate fix: #662.
- The reference signs in floating point (`sign_fpr.c`); FXR is key-generation arithmetic (`kgen_fxp.c`). Modelling the signing FFT with it was a shortcut.

For the record: with both bugs fixed, the fixed-point pipeline *would* land on the lattice on real Falcon-512 keys with pre-rounding deviation ≤ 3.3·10⁻⁵ (margin ~10⁴), so a fixed-point bridge is viable later; it is just not what the reference does.

## This PR

- `Primitives.lean`: `rootAngle` (recursive: level 0 is `π/2`; `2i ↦ θ/2`, `2i+1 ↦ θ/2 + π`), `splitAngle i := rootAngle k i / 2`, docstrings.
- `PackedFFT.lean` (new): `RealFFTPoly.ofCoeffs` / `toCoeffs` are the merge / split recursions on coefficient functions; `coord_ofCoeffs` says coordinate `j` at level `k` is the polynomial's value at `exp(rootAngle k j · I)`. From that: `ofCoeffs_negacyclic` (negacyclic product ↦ `mulFFT`, via `exp_rootAngle = −1` and the ring-homomorphism lemma `evalAngle_negacyclicConvCoeff`), `toCoeffs_ofCoeffs` (split inverts merge), `Primitives.ffSampling_support_ofCoeffs` (every sampler output is the packed FFT of an integer pair). Exact fields `Primitives.exactFftTarget` / `exactFftInt` / `exactIfftRound`; predicate `Primitives.ExactFFT`.
- `Coset.lean`: `landsOnLattice_of_exactFFT`, `hpreimage_of_exactFFT`.
- `Extern/Falcon/Instance.lean`: the three FFT fields of `concretePrimitives` are the exact ones; the FXR helpers are gone.
- `Extern/Falcon/SignCorrectness.lean`: **`verify_sign_correct_concretePrimitives_of_validKeyPair`**. Hypotheses: `p.n = 2^logn`, `1 ≤ logn`, `validKeyPair pk sk = true`, `∃ u, f·u = 1` in `R_q`, and the signature is in the signer's support.

`./scripts/validate.sh --lint --test --ffi --axioms` passes on the aligned stack,
including 210/210 Falcon native tests, all proof and test libraries, exact source and
environment lint checks, and the axiom sweep. The stack removes the two existing
`Falcon.sign` / `Falcon.verify_sign_correct` sorry entries; 33 existing tainted
declarations remain and no non-standard axiom or new sorry taint is introduced.
The merged verifier-kernel proofs and fixed-point arithmetic fixes remain intact.

A separate deterministic comparison against main's previous codec passed 20,317
compression/decompression comparisons: boundary coefficients, capacity limits,
bit-flipped encodings, malformed bytes, and wrong lengths. This supplements the
codec round-trip proof and native regression suite.

## Still open

- The executable signing path (`Extern/Falcon/Sign.lean`, the `FloatLike` FFT) against the exact packed FFT: the bridge obligation #514's per-operation float bounds exist for.
- `1 ≤ logn` and `∃ u, f·u = 1` are key-generation facts; `keyGenFromSeed` is still the sorry.

