### PR TITLE
perf: reduce byte-proof and unary-planner elaboration costs

### DIFF
--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -77,7 +77,7 @@ private theorem bitOf_lt_two_fin (b : UInt8) (j : Fin 8) : bitOf b j.val < 2 :=
 
 private theorem packByte_bitOf_fin :
     ∀ n : Fin (2 ^ 8), packByte (fun j => bitOf n.val.toUInt8 j.val) = n.val.toUInt8 := by
-  intro n; fin_cases n <;> rfl
+  decide +kernel
 
 private theorem packByte_bitOf_byte (b : UInt8) :
     packByte (fun j => bitOf b j.val) = b := by

--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
@@ -1383,7 +1383,7 @@ def probEqActionPlans : List (List ProbEqAction) :=
   ]
 
 private def probEqPlannerActionPlans : List (List ProbEqAction) :=
-  probEqRewritePlans 4 ++ probEqCongrPlans 3 ++
+  List.append (List.append (probEqRewritePlans 4) (probEqCongrPlans 3))
     [ [.congr]
     , [.congrNoSupport]
     , [.congr, .swap]
@@ -1424,7 +1424,7 @@ private def probEqBindDepth? (target : Expr) : Option Nat := do
 private def probEqPlannerActionPlansForDepth (bindDepth : Nat) : List (List ProbEqAction) :=
   let maxRewriteDepth := Nat.min 4 (bindDepth - 2)
   let maxCongrDepth := Nat.min 3 bindDepth
-  probEqRewritePlans maxRewriteDepth ++ probEqCongrPlans maxCongrDepth ++
+  List.append (List.append (probEqRewritePlans maxRewriteDepth) (probEqCongrPlans maxCongrDepth))
     [ [.congr]
     , [.congrNoSupport]
     , [.congr, .swap]


### PR DESCRIPTION
## Summary

- Replace the enumerated `packByte_bitOf_fin` proof with `decide +kernel`. This avoids constructing/elaborating 256 case proofs, without native evaluation or new axioms.
- Use concrete, left-associated `List.append` in two unary probability planners. Early element-type information avoids expensive speculative dotted-constructor diagnostics (`reverseFieldLookup` scans the environment).
- Keep executable definitions, theorem statements, list association, and instance priorities unchanged. This PR changes only two Lean files.

## Evidence

Five paired, uninstrumented file replays after warmup on macOS arm64, Lean/Mathlib 4.33.1, baseline `ffd0ca198fe6e640c0dd7f0f9c599943caacbf64`:

| Module | Original median | Candidate median | Reduction |
| --- | ---: | ---: | ---: |
| MLKEM.Concrete.Encoding | 3.829s | 2.267s | 40.8% |
| ProgramLogic.Tactics.Unary.Internals | 3.685s | 3.325s | 9.8% |

These are local-file results, **not whole-build speedup claims**. Scoped traces, complete-command prefix controls, and a dotted-constructor reproducer support the causal explanations. Reports and reproduction tooling are in a separate stacked draft.

## Validation

- Seven non-test libraries and `VCVioTest`, `LatticeCryptoTest`, `HashSigTest` built under the pinned toolchain in repository-local validation worktrees.
- Smoke, axiom-sweep fixtures, `axiomsweep --check`, warning budget, PMF boundary, Extern/Interop isolation, PolyFun boundary, and complexity-backend isolation passed.
- Existing public declaration names/types preserved; no axiom/sorry baseline changes or disabled linters.
- Native submodules were absent in the validation worktrees; native differential executables were not run.

Validation and measurements were performed against the stated baseline before newer main commits. Keeping this draft pending review/current-base CI; whole-build acceptance is a separate, unfinished experiment.
