### PR TITLE
refactor(PRFTagReader): narrow proof-module import dependencies

### DIFF
--- a/Examples/PRFTagReader/BadEvent.lean
+++ b/Examples/PRFTagReader/BadEvent.lean
@@ -6,7 +6,7 @@ Authors: Oleksandr Vovkotrub
 
 module
 
-public import Examples.PRFTagReader.Collision
+public import Examples.PRFTagReader.Defs
 
 /-!
 # PRF Tag/Reader Protocol — Bad-Event Bound

--- a/Examples/PRFTagReader/Collision.lean
+++ b/Examples/PRFTagReader/Collision.lean
@@ -7,6 +7,7 @@ Authors: Oleksandr Vovkotrub
 module
 
 public import Examples.PRFTagReader.Collision.ForgeStep
+public import Examples.PRFTagReader.Auth
 
 /-!
 # PRF Tag/Reader Protocol — Collision Bound

--- a/Examples/PRFTagReader/Collision/ForgeStep.lean
+++ b/Examples/PRFTagReader/Collision/ForgeStep.lean
@@ -6,7 +6,7 @@ Authors: Oleksandr Vovkotrub
 
 module
 
-public import Examples.PRFTagReader.Auth
+public import Examples.PRFTagReader.Defs
 
 /-!
 # PRF Tag/Reader Protocol — Collision Bound, Per-Step Forge Infrastructure

--- a/Examples/PRFTagReader/MultipleBadCollision.lean
+++ b/Examples/PRFTagReader/MultipleBadCollision.lean
@@ -7,6 +7,7 @@ Authors: Oleksandr Vovkotrub
 module
 
 public import Examples.PRFTagReader.DirectCoupling.Compose
+public import Examples.PRFTagReader.BadEvent
 public import Examples.PRFTagReader.MultipleToHybrid.EagerSetup
 
 /-!

--- a/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
+++ b/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
@@ -7,6 +7,7 @@ Authors: Oleksandr Vovkotrub
 module
 
 public import Examples.PRFTagReader.MultipleToHybrid.Setup
+public import Examples.PRFTagReader.Table
 
 /-!
 # PRF Tag/Reader Protocol — Multiple-to-hybrid eager coupling, shared setup

--- a/Examples/PRFTagReader/MultipleToHybrid/Setup.lean
+++ b/Examples/PRFTagReader/MultipleToHybrid/Setup.lean
@@ -6,7 +6,8 @@ Authors: Oleksandr Vovkotrub
 
 module
 
-public import Examples.PRFTagReader.Table
+public import Examples.PRFTagReader.PRFReductions.IdealHandlers
+import VCVio.ProgramLogic.Relational.SimulateQ
 
 /-!
 # PRF Tag/Reader Protocol — Instrumented multiple-session handler

--- a/Examples/PRFTagReader/PRFReductions/Reductions.lean
+++ b/Examples/PRFTagReader/PRFReductions/Reductions.lean
@@ -6,9 +6,7 @@ Authors: Oleksandr Vovkotrub
 
 module
 
-public import Examples.PRFTagReader
-public import VCVio.OracleComp.QueryTracking.RandomOracle.EagerTable
-public import VCVio.ProgramLogic.Relational.SimulateQ
+public import Examples.PRFTagReader.Defs
 
 /-!
 # PRF Tag/Reader Protocol — Reductions and Bridge Lemmas

--- a/Examples/PRFTagReader/Table.lean
+++ b/Examples/PRFTagReader/Table.lean
@@ -6,7 +6,8 @@ Authors: Oleksandr Vovkotrub
 
 module
 
-public import Examples.PRFTagReader.PRFReductions
+public import Examples.PRFTagReader.PRFReductions.IdealHandlers
+public import VCVio.OracleComp.QueryTracking.RandomOracle.EagerTable
 
 /-!
 # PRF Tag/Reader Protocol — Composed-Handler Eager-Table Equivalence


### PR DESCRIPTION
## Summary

Independent, import-only draft from the compile-performance investigation. This is repository import cleanup, not an upstream Lake change, and does not depend on #668.

- Replace PRFTagReader umbrellas and unnecessary proof dependencies with `Defs` or `IdealHandlers` at eight files.
- Add explicit `Auth`, `Table`, `BadEvent`, and relational imports at consumers that actually need them.
- Leave proof bodies and public top-level umbrellas unchanged. Internal submodule transitive import surfaces intentionally narrow; downstream clients may need explicit imports.

`lake shake --keep-public --explain Examples.PRFTagReader` was used for read-only review. Its additional suggestions for two implied imports in `Defs` are not included in this patch. No global `lake shake --fix` sweep is being proposed.

## Why draft

The original 41-module duration-weighted critical path serialized PRFTagReader authentication, collision, bad-event, reduction, table, and hybrid proofs. Removing these edges shortens that branch in a fixed-weight graph model, but another branch becomes critical. That is **not a measured speedup**.

The first import-only clean-build pair was **129.33s baseline versus 145.21s candidate** (12.3% slower). This is insufficient to establish a stable regression or benefit, and does not meet the performance acceptance gate. A later combined screening run was terminated by SIGTERM; another project's Lean build was observed on the machine. Failed runs are excluded from timing comparisons.

Keep draft pending review and idle, counterbalanced whole-build measurements. No project-wide speedup is claimed.

## Validation

- This exact eight-file patch compiled with all seven non-test libraries and the three test libraries in the repository-local 4.33.1 validation checkout.
- Existing public declaration names/types were preserved in the combined-candidate API snapshot.
- Import-isolation and PMF-boundary checks pass; proof bodies, axioms, linter settings, and instance priorities are unchanged.
- Validation used baseline `ffd0ca198fe6e640c0dd7f0f9c599943caacbf64`, before newer main commits. Native submodules were absent, so native differential executables were not run.

The separate profiling/prototype draft retains the measurements, patch hashes, reports, and reproduction protocol.
