### PR TITLE
feat(perf): add profiling tools and opt-in goal indexing

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -51,6 +51,7 @@ public import ToMathlib.MeasureTheory.Measure.Option
 public import ToMathlib.MeasureTheory.Measure.Subprobability
 public import ToMathlib.MeasureTheory.Measure.TotalVariation
 public import ToMathlib.OrderEnrichedCategory
+public import ToMathlib.Perf
 public import ToMathlib.Probability.Divergence.Renyi
 public import ToMathlib.Probability.Divergence.RenyiDiscrete
 public import ToMathlib.Probability.Divergence.TotalVariation

--- a/ToMathlib/Perf.lean
+++ b/ToMathlib/Perf.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public meta import Lean.Elab.InfoTree.Types
+public import Std.Data.HashSet.Lemmas
+
+/-!
+# Performance Prototypes for Metaprograms
+
+Explicit, side-effect-free alternatives for measuring shared metaprogram operations.
+Importing this module does not install callbacks or change any linter, tactic, or instance.
+The goal-difference operation preserves input order and multiplicity while indexing the
+comparison list once. Its reference equation supports differential performance tests.
+-/
+
+public meta section
+
+namespace ToMathlib.Perf
+
+/-- Goals from `left` whose names do not occur in `right`, preserving order and duplicates. -/
+def goalDifference (left right : List Lean.MVarId) : List Lean.MVarId :=
+  let names := Std.HashSet.ofList (right.map (·.name))
+  left.filter fun goal => !names.contains goal.name
+
+/-- The indexed implementation agrees with a list-membership filter. -/
+theorem goalDifference_eq (left right : List Lean.MVarId) :
+    goalDifference left right =
+      left.filter (fun goal => !(right.map (·.name)).contains goal.name) := by
+  simp only [goalDifference, Std.HashSet.contains_ofList]
+
+/-- Goals removed by a tactic, according to its before/after goal identifiers. -/
+def goalsTargetedBy (info : Lean.Elab.TacticInfo) : List Lean.MVarId :=
+  goalDifference info.goalsBefore info.goalsAfter
+
+/-- Goals created by a tactic, according to its before/after goal identifiers. -/
+def goalsCreatedBy (info : Lean.Elab.TacticInfo) : List Lean.MVarId :=
+  goalDifference info.goalsAfter info.goalsBefore
+
+end ToMathlib.Perf

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -24,6 +24,7 @@ public import VCVioTest.MonadProbability
 public import VCVioTest.OracleComp.PreservesInv
 public import VCVioTest.OracleComp.SecurityFamily
 public import VCVioTest.PFunctorFacade
+public import VCVioTest.Perf
 public import VCVioTest.PerfectMerkleTree
 public import VCVioTest.ProbabilityTactics
 public import VCVioTest.ProgramLogic.GCongr

--- a/VCVioTest/Perf.lean
+++ b/VCVioTest/Perf.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public meta import ToMathlib.Perf
+
+/-! # Regression Tests for Indexed Goal Differences -/
+
+public meta section
+
+open ToMathlib.Perf
+
+private def goal (n : Nat) : Lean.MVarId := ⟨Lean.Name.num `goal n⟩
+
+example : goalDifference [] [goal 1] = [] := by
+  rw [goalDifference_eq]; simp [goal]
+
+example : goalDifference [goal 1, goal 2] [] = [goal 1, goal 2] := by
+  rw [goalDifference_eq]; simp [goal]
+
+example : goalDifference [goal 1, goal 2] [goal 2, goal 1] = [] := by
+  rw [goalDifference_eq]; simp [goal]
+
+example : goalDifference [goal 3, goal 1, goal 3, goal 2] [goal 1, goal 1] =
+    [goal 3, goal 3, goal 2] := by
+  rw [goalDifference_eq]; simp [goal]
+
+example : goalDifference [goal 1, goal 2] [goal 3, goal 4] = [goal 1, goal 2] := by
+  rw [goalDifference_eq]; simp [goal]

--- a/docs/reading/compile-performance-investigation.md
+++ b/docs/reading/compile-performance-investigation.md
@@ -1,0 +1,306 @@
+# Compile-performance investigation
+
+## Outcome
+
+Investigated ten CI-slow modules and deeply profiled the five slowest in isolated
+local replays. Three causal mechanisms have actionable experimental fixes:
+computation-lift instance backtracking, a large enumerated byte proof, and
+speculative dotted-constructor elaboration that scans the entire environment.
+Two protocol modules were localized to expensive handler/state simplifications;
+their restricted-simp experiments do not justify large proof rewrites yet.
+
+This report records the original local-file investigation. The Encoding and Unary
+fixes have since been applied to the working tree; see the
+[remediation report](compile-performance-remediation.md) for the implementation,
+whole-build experiments, and current acceptance decisions. Candidate patches,
+a small elaboration reproducer, individual measurements, and the replay runner
+are in [scripts/compile_performance](../../scripts/compile_performance/README.md).
+The Add instance change remains diagnostic.
+
+## Scope and measurement
+
+Baseline: `ffd0ca198fe6e640c0dd7f0f9c599943caacbf64`, Lean/Mathlib `v4.33.1`,
+macOS arm64. CI reference: [successful baseline run](https://github.com/Verified-zkEVM/VCVio/actions/runs/33853954985),
+Build Project job `100962918918`. The timed libraries are `ToMathlib`, `VCVio`,
+`LatticeCrypto`, `Extern`, `HashSig`, `Examples`, and `VCVioWidgets`; test libraries
+and dormant Interop are not in that timing population.
+
+The existing local artifacts used Lean 4.33.0, so they were not reused as valid
+4.33.1 measurements. A detached checkout under
+`/private/tmp/vcvio-compile-perf.GpdqNw/repo` was populated with copy-on-write caches,
+refreshed with `lake exe cache get`, and successfully built under the pinned
+toolchain. Subsequent work moved into repository-local worktrees under
+`.lake/compile-performance/worktrees/`; the original path above identifies the
+historical measurements only. Native submodules are absent in these experiments,
+so Extern uses its intended stubs.
+
+The runner replays each actual Lake invocation, including module setup, options,
+plugins, and Lean/C output generation, but redirects outputs away from dependencies.
+It measures Lean compilation, not a no-op Lake cache hit, dependency builds, or a
+native C compiler invocation. First-pass ranking uses one warmup plus five serial
+uninstrumented runs with the original asynchronous elaboration setting.
+
+| Module (abbreviated) | CI seconds | Local median seconds | Local range |
+| --- | ---: | ---: | ---: |
+| OracleComp.Coercions.Add | 26 | 4.598 | 4.590–4.634 |
+| FiatShamir.Sigma.Stateful.Chain | 26 | 4.195 | 4.184–4.207 |
+| MLKEM.Concrete.Encoding | 19 | 3.451 | 3.424–3.456 |
+| FiatShamir.Sigma.Stateful.Compatibility | 20 | 3.251 | 3.245–3.297 |
+| ProgramLogic.Tactics.Unary.Internals | 17 | 3.215 | 3.205–3.236 |
+| ProgramLogic.Tactics.Relational.Internals | 17 | 3.037 | 3.029–3.053 |
+| Examples.ProgramLogic.RelationalStep | 15 | 2.829 | 2.823–2.849 |
+| FiatShamir.Sigma.Fork | 18 | 2.817 | 2.801–2.826 |
+| ProgramLogic.Relational.SimulateQ | 20 | 2.724 | 2.707–2.743 |
+| Fischlin.KnowledgeSoundness | 17 | 2.707 | 2.689–2.713 |
+
+These are ten CI-selected slow files, not an exhaustive isolated timing of every
+module. CI numbers include a different machine and concurrent build pressure;
+they are not directly comparable to local seconds. The local top five determine
+the deep-dive set, rather than assuming CI's order is intrinsic.
+
+Each deep dive used `--profile`, a nested Firefox trace, and complete-command
+prefix controls. Focused type-class/rewrite traces and macOS native sampling were
+added where useful. Imports-only controls retained each original import header:
+Add 1.041s, Chain 1.190s, Encoding 1.033s, Compatibility 1.144s, Unary 1.333s
+(single diagnostic runs). These are approximate floors, not subtractable constants.
+
+For candidate comparisons, round zero warmed both variants, then five rounds ran
+original followed by candidate, serially and without profiling. This limits drift
+but does not randomize order. Later original times drifted above the first-pass
+baseline; all improvement percentages below use the paired batch, not mixed batches.
+
+| Candidate | Original median (range), s | Candidate median (range), s | Median reduction |
+| --- | --- | --- | ---: |
+| Add: local guarded query-lift shortcut | 5.131 (5.001–5.231) | 2.763 (2.709–2.860) | 46.2% |
+| Encoding: `decide +kernel` | 3.829 (3.717–4.075) | 2.267 (2.227–2.467) | 40.8% |
+| Unary: concrete `List.append` | 3.685 (3.595–3.747) | 3.325 (3.273–3.440) | 9.8% |
+| Chain: one restricted `simpa only` | 4.463 (4.352–4.526) | 4.346 (4.269–4.400) | 2.6% |
+| Compatibility: restricted simplification | 3.598 (3.480–4.020) | 3.538 (3.491–3.770) | 1.7% |
+
+Percentages describe these local file replays, not total build acceleration or
+formal confidence intervals. Summed CPU medians changed 6.202→3.799s (Add),
+8.930→6.965s (Encoding), 6.579→6.236s (Unary), 16.288→14.871s (Chain), and
+8.007→7.532s (Compatibility). Concurrent task CPU and cumulative profiler totals
+can exceed wall time; they must not be read as percentages of elapsed time.
+
+## 1. Add: search through the wrong intermediate monads
+
+Location: `VCVio/OracleComp/Coercions/Add.lean`, especially examples at 341–371.
+The first 283 lines compile in about 1.35s; prefixes through 339 and 363 take
+2.14s and 3.35s. The costly work is concentrated in the coercion examples, not
+merely the definitions or import count. The full-file profile reports 2.92s
+cumulative instance synthesis. Four-oracle reassociations with an internal
+subspec coercion cost roughly 0.20–0.28s each in that profile.
+
+A scoped `trace.Meta.synthInstance` on the example at 365 records **669 new
+goals**, 182 applications of `instMonadLiftT`, 181 of
+`instMonadLiftTOfMonadLift`, and 181 of `SubSpec.toMonadLift`. Search enters the
+query-to-free-monad lifting route, then tries to produce an impossible lift from
+the source computation back into a target query. Transitivity leaves an unknown
+intermediate monad, and coproduct left/right alternatives multiply failed paths.
+The trace includes repeated irrelevant inhabitation/uniform-instance searches.
+
+This is consistent with the generic transitive `MonadLiftT` instance and the
+deliberately low-priority computation lift documented in `Coercions/SubSpec.lean`
+at 372–395. The issue is not simply “many type classes”: it is the ordering and
+shape of search through an underconstrained intermediate monad. Lean's
+[instance-synthesis reference](https://lean-lang.org/doc/reference/latest/Type-Classes/Instance-Synthesis/)
+explains candidate priorities and treatment of metavariables.
+
+The diagnostic shortcut synthesizes `MonadLiftT` between the two **query
+signatures**, then constructs `OracleComp.liftComp` directly. A priority-900
+shortcut was too late; requiring only `MonadLift` missed chained query embeddings.
+Priority 1100 with the transitive query premise produced the large improvement.
+
+Crucial negative result: that shortcut alone **breaks reflexive lift `rfl`**.
+An additional priority-1200 local identity instance restores the tested normal
+form; the candidate includes this canary and passes the existing Add examples.
+It is not evidence that exporting these instances is safe for every downstream
+definitional equality or universe combination. No global instance change is
+recommended for immediate landing. An informed fix should constrain the bad
+search route or use explicit lifts at the hot call sites, with a dedicated
+coercion-coherence and normal-form regression suite before changing priorities.
+
+## 2. Encoding: proof construction, not byte computation itself
+
+Location: `LatticeCrypto/MLKEM/Concrete/Encoding.lean:78`, private theorem
+`packByte_bitOf_fin`. Its original `fin_cases n <;> rfl` enumerates all 256 inputs.
+The profile attributes about 838ms to metavariable instantiation, 259ms to the
+case tactic's interpretation, and 180ms to kernel checking at that declaration.
+Synchronous before/after prefixes take 1.083s and 2.812s. The costly generated
+proof and its elaboration are the target, rather than changing the executable
+encoding algorithm.
+
+Ordinary `decide` hit the default recursion-depth limit and was rejected; that
+failed compilation is not counted as a speedup. `decide +kernel` succeeds without
+raising limits and leaves a compact decision-proof construction for the kernel.
+Its diagnostic kernel time was about 260ms, while the large metavariable
+instantiation hotspot disappeared. The complete file and its subsequent lemmas
+check successfully.
+
+This is kernel reduction, **not native evaluation** and not an expansion of the
+trusted computing base. The distinction is explicit in pinned
+[Lean's Decide implementation](https://github.com/leanprover/lean4/blob/v4.33.1/src/Lean/Elab/Tactic/Decide.lean),
+where the kernel branch builds/checks an auxiliary decision proof separately from
+the native branch. The one-line candidate preserves the theorem statement,
+visibility, and executable definitions.
+
+## 3. Unary planner: eager diagnostic suggestions during speculative elaboration
+
+Locations: `VCVio/ProgramLogic/Tactics/Unary/Internals.lean:1385` and `:1424`,
+`probEqPlannerActionPlans` and `probEqPlannerActionPlansForDepth`. These tiny
+definitions concatenate planner lists and a literal of `.congr`,
+`.congrNoSupport`, and `.swap` constructors.
+
+The whole-file profile initially exposed about 126ms and 123ms of elaboration
+at these unexpectedly small definitions. A threshold-zero scoped trace shows
+roughly 298ms combined exclusive time in six dotted-identifier elaborations with
+expected types still `?m.28` or `?m.55`. A sample of the actual Lean process
+contains `Lean.Elab.Term.reverseFieldLookup` on active stacks.
+
+The mechanism is visible in pinned
+[Lean.Elab.App](https://github.com/leanprover/lean4/blob/v4.33.1/src/Lean/Elab/App.lean#L1510):
+`reverseFieldLookup` folds over **all environment constants** to collect names.
+`resolveDottedIdentFn` calls it eagerly to build suggestions when the expected
+type cannot be determined. Overloaded `HAppend` leaves the literal's element
+type unsettled during speculative elaboration; error construction is expensive
+even though a later elaboration attempt succeeds.
+
+Replacing the two overloaded append expressions with concrete `List.append`
+applications supplies the element type earlier. The retained version preserves
+the original left association. A small reproducer with the same imports and a
+three-constructor enum reproduces roughly 166ms in `.congr`/`.congrNoSupport`/
+`.swap` under the overloaded expression; the explicit expression does not show
+that hotspot. Its equality is checked by `rfl`.
+
+The local fix is narrow and keeps the planner's action order unchanged. An
+upstream fix worth investigating would avoid environment-wide suggestion scans
+for discarded speculative errors, or index reverse field lookup. That is a
+proposed upstream direction, not an implemented/compiler-benchmarked fix.
+
+## 4. Chain: tuple-existential simplification and repeated inhabitation work
+
+Location: `VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean:761`,
+`forkLoggedImpl_sign_support`, plus other hot simplifications around 383, 470,
+1372 and 2011. Whole-file cumulative `simp` time is 6.33s, instance synthesis
+2.24s, and kernel checking 271ms. Work is distributed across asynchronous proofs;
+there is no single 6.33-second serial tactic.
+
+The selected proof expands `extendState`, `flattenStateT`, `mapStateTBase`, nested
+simulations and support maps to expose a six-component existential witness.
+Synchronous prefixes before/after this lemma take 4.333s and 4.907s. The selected
+`simpa` is about 457ms in the original profile.
+
+Its rewrite trace contains 57 `not_isEmpty_of_nonempty`, 21 `nonempty_prod`, and
+10 `isEmpty_prod` rewrites, alongside five `Prod.exists` rewrites and handler
+unfolding. This establishes repeated product inhabitation/emptiness normalization
+while simplifying the witness type, rather than attributing everything vaguely to
+the size of the ambient simp set. Rewrite counts alone do not measure their CPU cost.
+
+`simpa?` produced a 21-lemma `simpa only` list that still checks. Whole-file wall
+gain is only 2.6%, although summed CPU decreases. The stronger next experiment is
+a reusable support/state-transformer equation with an explicit witness shape,
+so callers avoid re-expanding handlers and re-normalizing tuple existentials.
+That would require an API/proof refactor and coverage of the other hot lemmas;
+this investigation does not establish that it improves the total build.
+
+## 5. Compatibility: repeated normalization across state and simulator layers
+
+Location: `VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean:445`,
+`cmaRealLoggedProdImpl_lift_query_eq_cmaRealAppendProdImpl`. It splits uniform,
+random-oracle cache hit/miss, and signing cases. The profile reports 2.91s
+cumulative simplification for the file and about 270ms for the selected signing
+simplification. Synchronous before/after prefixes take 2.939s and 3.503s.
+
+The focused trace records 27 `bind_pure_comp`, 21 `map_eq_bind_pure_comp`,
+20 `StateT.run_mk`, and 13 `Function.comp_apply` rewrites. Handler expansion repeats
+across four branches. Nested `mapStateTBase`/`flattenStateT`, pure/bind and function
+composition normal forms account for concrete repeated work. No rewrite loop has
+been demonstrated; the trace is finite, and repeated names alone do not prove one.
+
+Restricting to `simp?` suggestions did not initially close the signing branch.
+Additional `bind_assoc`, `Function.comp_apply`, `pure_bind`, and a final `rfl` were
+needed. The resulting patch checks but has only a 1.7% median wall improvement
+with overlapping ranges. It is retained as a negative/weak experiment, not a
+recommended verbose replacement. A shared handler-composition equality is a
+better-informed next hypothesis; its benefit remains unmeasured.
+
+## Controls, limitations, and interpretation
+
+- Source bisection preserved imports and complete commands, with synchronous
+  before/after controls where async work could cross the boundary. It localized
+  declarations without replacing proofs with `sorry`.
+- One Add prefix cut after a doc-comment failed to parse and was discarded.
+  An initial import control containing only `module` was also discarded: setup
+  `importArts` is not the optional `imports?` override. Corrected controls retained
+  the actual imports, as required by pinned `Lean/Setup.lean`.
+- Profiling and detailed tracing are separate from timing comparisons. Initial
+  profile runs combined stdout/stderr and could interleave JSON messages; the
+  runner now separates them. Focused follow-up traces use separate streams.
+- The first native sample failed OS permissions; the approved retry succeeded.
+  Sleeping worker-thread samples are not interpreted as compiler CPU cost.
+- Git history was inspected, but no validated fast historical endpoint with a
+  compatible toolchain was established. No historical `git bisect` regression
+  claim is made. Source-prefix bisection supplies the localization here; a future
+  historical bisect needs a repeatable threshold and passing endpoint builds.
+- No linters, visibility safeguards, heartbeat limits, or trust checks were
+  disabled. Development trace-option warnings are confined to scratch probes.
+- PMF/SPMF-bearing production files were not edited. The two selected candidate
+  files do not introduce that retiring surface. Add's identity failure is
+  explicitly retained as evidence against blindly changing global priorities.
+
+## Validation and artifacts
+
+Both selected candidates were applied together only in the detached checkout.
+The seven-library build passed before and after (3960 jobs). For each controlled
+build, the project's `.lake/build` directory was moved aside intact; dependency
+artifacts remained cached. Baseline wall/CPU were 135.27s / 1380.43s; candidate
+wall/CPU were 138.56s / 1375.99s. This single pair demonstrates **no overall
+wall-time improvement** (candidate 2.4% slower), despite the isolated file gains.
+It is not enough to establish a build-level regression either. The earlier
+131.34s setup build included cache/toolchain refresh effects and is excluded
+from this comparison.
+
+Downstream validation passed:
+
+- `lake build VCVioTest LatticeCryptoTest`: 3769 jobs, 15.51s wall.
+- `lake env lean VCVioTest/Smoke.lean`: 1.99s; subsequent seven-library warm
+  rebuild: 1.34s (cache-hit timing, not a compile-time comparison).
+- `./scripts/test-axiomsweep.sh`: executable fixture matrix passed.
+- `lake exe axiomsweep --check`: 17,878 declarations across 553 modules;
+  40 existing sorry-tainted declarations, **zero non-standard-axiom taint**,
+  no new axiom/sorry taint. The baseline was not modified.
+- Extern isolation, Interop isolation, and PMF/SPMF boundary checks.
+
+These are library compilation and smoke checks, not execution of every native
+cryptographic differential test; the native backends were absent. The Add local
+instance experiment passed its file's examples and explicit identity canary, but
+was deliberately excluded from downstream candidate validation.
+
+The runner passed Python syntax checking, actual successful replays, invalid-run
+count rejection, duplicate-label rejection, stale-toolchain rejection, and a
+forced timeout test that recorded the killed child and a nonzero exit status.
+The Python syntax check needed OS approval for the system bytecode-cache path;
+it did not change production source. No historical bisect or hardware-counter
+profiling was claimed.
+
+The persistent small artifacts are the report, runner, measurements, five
+candidate patches and dotted-constructor reproducer. Full local logs, profiles,
+prefix probes and the native sample are archived at
+`.lake/compile-performance/investigation.tar.gz`; they are intentionally not
+committed because they include large machine-specific traces. The detached
+checkout and saved build trees remain available under the temporary directory
+above. Individual run records include commands, source/setup hashes, exit status,
+CPU, RSS and output paths.
+
+## Performance guidance used
+
+The workflow follows Lean's [core performance guide](https://github.com/leanprover/lean4/blob/master/doc/perf.md)
+and [profiler guide](https://github.com/leanprover/lean4/blob/master/script/PROFILER_README.md):
+identify expensive declarations, narrow instrumentation, distinguish elaboration,
+kernel and compiler work, and measure an uninstrumented candidate. The
+[EPFL profiling wiki](https://vca.epfl.ch/wiki/lean-profiling/) supplies practical
+profiling context. Options/defaults were checked against the installed 4.33.1
+sources rather than assuming older wiki examples still match. Claims about the
+three concrete mechanisms above are supported by local traces and pinned source,
+not inferred solely from general optimization advice.

--- a/docs/reading/compile-performance-remediation.md
+++ b/docs/reading/compile-performance-remediation.md
@@ -1,0 +1,194 @@
+# Compile-performance remediation
+
+## Implemented source changes
+
+The two small, independently validated local fixes are in
+[draft PR #668](https://github.com/Verified-zkEVM/VCVio/pull/668). The profiling and
+prototype branch is stacked on that branch so these reports and experiments can
+be reviewed separately:
+
+- `LatticeCrypto/MLKEM/Concrete/Encoding.lean`: use `decide +kernel` for
+  `packByte_bitOf_fin`, avoiding the 256-case elaborated proof. The earlier paired
+  file replay measured a 40.8% median reduction. This uses kernel checking, not
+  native trust.
+- `VCVio/ProgramLogic/Tactics/Unary/Internals.lean`: use concrete, left-associated
+  `List.append` in the two probability planners. The earlier paired replay
+  measured a 9.8% median reduction. Supplying the element type early avoids
+  speculative dotted-constructor diagnostics that scan the whole environment.
+
+Those percentages are **file-level**, not whole-build improvements. See the
+[original investigation](compile-performance-investigation.md) for traces,
+complete-command bisection, failed controls, and causal evidence.
+
+`ToMathlib/Perf.lean` supplies an opt-in indexed goal-difference implementation,
+its general equivalence theorem, and two `TacticInfo` adapters. It does not
+register a linter or change existing tactics. `VCVioTest/Perf.lean` covers empty,
+disjoint, reordered, and duplicate goal lists. Generated umbrellas include these
+modules. The measurement tooling supports whole-build timelines and explicit
+native-plugin experiments, without changing Lake or Lean defaults.
+
+No instance priorities, thread defaults, linter settings, public theorem
+statements, or executable encoding definitions were changed.
+
+## Whole-build evidence: a separate optimization axis
+
+Baseline is `ffd0ca198fe6e640c0dd7f0f9c599943caacbf64`, Lean/Mathlib `v4.33.1`,
+macOS arm64, 14 logical CPUs. Measurements build all seven non-test libraries;
+dependency caches are warm but each clean run rebuilds the project. Native
+submodules are absent, so Extern uses its documented stub archives. These numbers
+do not predict Ubuntu CI with native backends present.
+
+One fresh diagnostic profile covered **553 modules** in 167.94s. Compiler children
+used 1680.91 CPU-seconds, with 53.88 CPU-seconds outside those recorded module
+processes. The five highest-CPU modules account for only **3.67%** of module CPU.
+Optimizing only those files therefore leaves most compilation work untouched.
+
+The profiler reports substantial cumulative import loading (1152.99s) and
+interpretation (846.06s), alongside instance synthesis (126.65s), simplification
+(114.88s), tactics (73.25s), and elaboration (53.70s). **These categories overlap,
+can include waiting, and are not exclusive CPU shares.** They motivate shared
+frontend/metaprogram experiments, but do not prove that a particular linter or
+import routine is the largest source of avoidable CPU work. The remaining
+attribution task needs native stack sampling with an exclusive cost breakdown.
+
+The duration-weighted import path had 41 modules and cost 127.17s. It crossed
+`PRFTagReader.Auth → Collision → BadEvent → PRFTagReader` before returning through
+the reduction/table/hybrid files. These dependencies serialize proofs that do
+not all need each other's results. Removing selected edges in the fixed-weight
+model shortens the PRF path from 125.80s to 100.22s, but the overall modeled path
+only drops to 123.07s because the bottleneck switches to another branch.
+**This graph calculation is not a measured build speedup.**
+
+| Experiment | Baseline median | Candidate median | Decision |
+| --- | ---: | ---: | --- |
+| Earlier consolidation, three clean pairs | 134.48s | 132.02s | 1.83%; below the 3% gate; not applied |
+| Eight-file import cleanup, one clean pair | 129.33s | 145.21s | 12.3% slower in this pair; inconclusive, not accepted |
+| Import cleanup + local fixes + unary split + Perf | — | — | First screen run terminated by SIGTERM; no valid comparison |
+
+An unrelated project's full Lean build was also observed during the attempted
+combined screen. Its processes were not stopped. The SIGTERM's cause was not
+established, and a terminated build is not counted as a fast build. The final
+correctness build succeeded after recovery. No whole-build speedup is claimed;
+the three-pair screen and five-pair confirmation remain unfinished.
+
+## Independent import-cleanup patch
+
+[`import-cleanup.patch`](../../scripts/compile_performance/candidates/import-cleanup.patch)
+contains eight import-only edits, with no proof changes. It replaces unnecessary
+PRF umbrellas and proof dependencies with `Defs` or `IdealHandlers`, and adds
+explicit `Auth`, `Table`, `BadEvent`, and relational imports where actually needed.
+Public top-level umbrellas remain intact. Internal submodule transitive surfaces
+are intentionally narrower; downstream clients may need explicit imports.
+
+The patch compiled with all seven libraries and the three test libraries, and
+preserved existing public declaration names/types. It is kept **separate from the
+working-tree fixes**, pending a reliable import-only timing comparison. It is
+published separately as [draft PR #669](https://github.com/Verified-zkEVM/VCVio/pull/669).
+
+`lake shake --keep-public --explain Examples.PRFTagReader` was run read-only on
+the built candidate. It additionally suggested removing two implied public
+imports in `PRFTagReader.Defs` (`StateT.PreservesInv` and `QueryBound`). These were
+not blindly applied or included in the measured eight-file candidate. Review
+each proposed edge change, preserve intentional façades, and rebuild all targets
+after selecting changes. The command exits nonzero when it has suggestions;
+that is not a Lean compilation failure. The pinned
+[Lake help](https://github.com/leanprover/lean4/blob/v4.33.1/src/lake/Lake/CLI/Help.lean)
+documents its analysis, preservation options, and `--fix` behavior.
+
+## Other implemented experiments
+
+### Unary core/dispatcher split
+
+[`unary-split.patch`](../../scripts/compile_performance/candidates/unary-split.patch)
+moves unary strategies into `Unary.Core` and retains the original `Internals`
+module as the dispatcher. Only its relational branch needs the relational tactic
+implementation. Same-package `import all` shares private helpers without exporting
+them. Original names, statements and declaration bodies are preserved, apart
+from the two concrete-append fixes included in this patch.
+
+The split passes the complete library/test build and public API comparison.
+It exposes more parallelism, but adds another module's import/serialization cost.
+It is not in the working tree because its whole-build timing gate is unresolved.
+Do not combine this patch with `unary-expected-type.patch`, which it includes.
+
+### Reusable state-handler support law
+
+[`handler-support-reuse.patch`](../../scripts/compile_performance/candidates/handler-support-reuse.patch)
+contains a checked generic law that peels an `extendState` support membership
+into a base-handler witness, reused at three invariant-proof branches in Chain.
+It adds no simplifier registration. The diagnostic version keeps the law private;
+if a beneficial version emerges, its natural owner is `StateT.StateProjection`.
+
+Applying the law to the main signing-support proof retained extra intermediate
+existential variables and broke the existing witness decomposition. This exposes
+a real design issue: a useful normalization API needs to compose the base
+handler and auxiliary-state transformation **before** expanding all product
+witnesses. Merely extracting the outer support equation is insufficient.
+
+The successful three-branch candidate had a 4.301s median versus 4.210s original,
+winning only one of five measured pairs after a warmup pair (counterbalanced
+order). The machine was not exclusively idle, so this is diagnostic evidence,
+not a precise regression estimate. It provides no reason to land the change.
+The earlier Chain/Compatibility restricted-simp patches also remain experiments.
+
+### Shared metaprograms and upstream work
+
+The `ToMathlib.Perf` microbenchmark used 200 interpreted `#eval` iterations per
+size. At 256 goals, list membership took 1.071s versus 0.117s indexed; at 64,
+0.069s versus 0.028s. At 1–16 goals indexing was slower. The implementation
+preserves order and multiplicity, but actual linter goal-size distributions have
+not been measured. Do not install it globally or pick a crossover threshold from
+this single synthetic run.
+
+Narrow native linter plugins reduced CPU in three isolated module probes by
+roughly 3–7%, with byte-identical diagnostics. Wall results were mixed: General
+improved, Chain was essentially unchanged, and Unary was slightly slower.
+Loading the broader `Mathlib.Init` plugin crashed with SIGSEGV. Loading Header
+alone also failed because DirectoryDependency must be loaded first; the ordered
+plugin replay succeeded. These are opt-in probes, not a recommendation to enable
+package-wide precompilation. Lake's
+[build documentation](https://lean-lang.org/doc/reference/latest/Build-Tools-and-Distribution/Lake/)
+describes the additional native build work involved.
+
+The strongest upstream Lean candidate remains lazy construction of dotted-name
+suggestions in `Lean.Elab.App`: preserve the eventual error text while avoiding
+`reverseFieldLookup` for discarded speculative errors. The retained
+`DottedConstructor.lean.txt` reproducer checks the local workaround by `rfl`.
+No upstream compiler patch or PR was published. For Mathlib, measure realistic
+goal-list sizes and native/interpreted stacks before considering an adaptive
+goal-difference implementation. Header already caches library-root lookup; a
+second cache is not an informed fix.
+
+## Validation and reproduction
+
+Worktrees, raw logs, traces, API snapshots and recoverably moved build trees are
+under `.lake/compile-performance/`. The final validation checkout mirrors every
+tracked/non-ignored Lean source in the working tree; it has the valid 4.33.1
+dependency cache, unlike the original stale 4.33.0 artifacts.
+
+- Seven non-test libraries plus `VCVioTest`, `LatticeCryptoTest`, `HashSigTest` build.
+- Direct smoke check, axiom-sweep fixtures and `axiomsweep --check` pass; no new
+  axiom/sorry taint, no nonstandard axioms.
+- Existing 20,169 public declaration names/types are preserved; four opt-in Perf
+  declarations are added. This comparison erases binder macro scopes and metadata,
+  not named arguments or global constants. It is not a comparison of proof bodies.
+- Warning budget, PMF boundary, Extern/Interop isolation, PolyFun boundary and
+  complexity-backend isolation pass. No baselines or suppressions were changed.
+- Generated umbrellas are checked; nine measurement-tool regression tests pass.
+
+The native executable test programs were not run with real backends. Representative
+real-edit rebuild measurements, an exclusive full-build CPU breakdown, and idle
+screening/confirmation pairs are still outstanding. Keep these limits distinct
+from the successful compilation and API checks.
+
+Individual compact results and patch hashes are retained in
+[`remediation-measurements.json`](../../scripts/compile_performance/remediation-measurements.json).
+The [runner instructions](../../scripts/compile_performance/README.md) and
+[whole-build protocol](../../scripts/compile_performance/whole-build-method.md)
+describe how to resume: compare import-only and layout-only arms separately,
+then their combination; freeze a qualifying candidate before confirmation.
+Do not mix widely separated timing batches or accept profiler timings as clean
+wall-time improvements. Lean's
+[performance guide](https://github.com/leanprover/lean4/blob/master/doc/perf.md)
+and the [profiling wiki](https://vca.epfl.ch/wiki/lean-profiling/) provide the
+tracing and native-sampling background for the remaining attribution work.

--- a/scripts/analyze_build_profile.py
+++ b/scripts/analyze_build_profile.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Analyze profile_build.py child records and Lean's direct-import metadata."""
+
+import argparse
+from collections import Counter
+from functools import lru_cache
+import json
+from pathlib import Path
+
+
+def analyze(run, build):
+    result = json.loads((run / 'result.json').read_text())
+    if result['exit_code'] != 0:
+        raise ValueError('failed builds are diagnostics, not comparable build profiles')
+    records = [json.loads(p.read_text()) for p in (run / 'processes').glob('*.json')
+               if not p.name.endswith('.start.json')]
+    modules = {r['module']: r for r in records if r['kind'] == 'lean' and r['module']}
+    if len(modules) != sum(r['kind'] == 'lean' and bool(r['module']) for r in records):
+        raise ValueError('duplicate module compilations require separate runs')
+    if not modules:
+        raise ValueError('no compiler modules recorded; a cache hit is not a compile profile')
+    if any(r['exit_code'] != 0 for r in records):
+        raise ValueError('failed compiler processes are not comparable build profiles')
+    graph = {}
+    for name, record in modules.items():
+        path = build / 'lib/lean' / Path(*name.split('.')).with_suffix('.ilean')
+        if not path.exists():
+            raise ValueError(f'missing import metadata for {name}: {path}')
+        data = json.loads(path.read_text())
+        if not all(isinstance(i, list) and len(i) == 4 and isinstance(i[0], str)
+                   for i in data['directImports']):
+            raise ValueError(f'unsupported directImports schema for {name}')
+        graph[name] = [i[0] for i in data['directImports'] if i[0] in modules]
+        record['imports'] = data['directImports']
+        record['ready'] = max((modules[i]['end'] for i in graph[name]), default=result['start'])
+        record['launch_gap_seconds'] = record['start'] - record['ready']
+        if record['launch_gap_seconds'] < -0.1:
+            raise ValueError(f'inconsistent timestamps or imports for {name}')
+
+    @lru_cache(None)
+    def weighted(name):
+        previous = max((weighted(i) for i in graph[name]), default=(0, []), key=lambda p: p[0])
+        return previous[0] + modules[name]['wall_seconds'], previous[1] + [name]
+
+    @lru_cache(None)
+    def ancestors(name):
+        return frozenset(graph[name]) | frozenset(a for i in graph[name] for a in ancestors(i))
+
+    last = max(modules, key=lambda n: modules[n]['end'])
+    observed = [last]
+    while graph[observed[-1]]:
+        observed.append(max(graph[observed[-1]], key=lambda n: modules[n]['end']))
+    observed.reverse()
+    longest = max((weighted(n) for n in modules), key=lambda p: p[0])
+    events = sorted([(r['start'], 1) for r in modules.values()] +
+                    [(r['end'], -1) for r in modules.values()])
+    active = peak = 0
+    occupancy = Counter()
+    previous = result['start']
+    for t, delta in events:
+        occupancy[active] += t-previous
+        active += delta
+        peak = max(peak, active)
+        previous = t
+    occupancy[active] += result['end']-previous
+    module_cpu = sum(r['user_seconds'] + r['system_seconds'] for r in modules.values())
+    total_cpu = result['user_seconds'] + result['system_seconds']
+    ranked = lambda key: sorted(modules, key=lambda n: key(modules[n]), reverse=True)
+    rows = [{**r, 'descendants': sum(n in ancestors(m) for m in modules)} for n, r in modules.items()]
+    return dict(result=result, module_count=len(modules), module_cpu_seconds=module_cpu,
+                residual_cpu_seconds=total_cpu-module_cpu, peak_compilers=peak,
+                compiler_occupancy_seconds=dict(occupancy), weighted_path=longest,
+                observed_terminal_path=observed,
+                rankings=dict(cpu=ranked(lambda r: r['user_seconds']+r['system_seconds']),
+                              duration=ranked(lambda r: r['wall_seconds']),
+                              launch_gap=ranked(lambda r: r['launch_gap_seconds'])),
+                modules=rows)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('run', type=Path)
+    p.add_argument('--build-dir', type=Path, required=True)
+    p.add_argument('--output', type=Path, required=True)
+    args = p.parse_args()
+    if args.output.exists():
+        p.error('output already exists')
+    data = analyze(args.run, args.build_dir)
+    args.output.write_text(json.dumps(data, indent=2) + '\n')
+    print(json.dumps({k: data[k] for k in ['module_count', 'module_cpu_seconds',
+                     'residual_cpu_seconds', 'peak_compilers', 'weighted_path',
+                     'observed_terminal_path']}, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/compile_performance/DottedConstructor.lean.txt
+++ b/scripts/compile_performance/DottedConstructor.lean.txt
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public meta import VCVio.ProgramLogic.Tactics.Common
+public import VCVio.ProgramLogic.Relational.Basic
+public meta import VCVio.ProgramLogic.Tactics.Relational.Internals
+public import Loom.Triple.SpecLemmas
+
+/-! # Dotted-constructor elaboration performance probe -/
+
+public meta section
+
+namespace CompilePerformance
+
+inductive Action where
+  | congr | congrNoSupport | swap
+
+def plans (n : Nat) : List (List Action) := List.replicate n [.congr]
+
+set_option trace.profiler true in
+def overloaded : List (List Action) :=
+  plans 4 ++ plans 3 ++
+    [[.congr], [.congrNoSupport], [.congr, .swap], [.congrNoSupport, .swap], [.swap]]
+
+set_option trace.profiler true in
+def explicitAppend : List (List Action) :=
+  List.append (List.append (plans 4) (plans 3))
+    [[.congr], [.congrNoSupport], [.congr, .swap], [.congrNoSupport, .swap], [.swap]]
+
+example : overloaded = explicitAppend := rfl
+
+end CompilePerformance

--- a/scripts/compile_performance/GoalDifference.lean.txt
+++ b/scripts/compile_performance/GoalDifference.lean.txt
@@ -1,0 +1,27 @@
+import ToMathlib.Perf
+
+meta section
+
+open Lean ToMathlib.Perf
+
+def reference (left right : List MVarId) : List MVarId :=
+  left.filter fun goal => !(right.map (·.name)).contains goal.name
+
+def benchmark (label : String) (f : List MVarId → List MVarId → List MVarId)
+    (n rounds : Nat) : IO Unit := do
+  let left := (List.range n).map fun i => MVarId.mk (Name.num `goal i)
+  let right := (List.range n).map fun i => MVarId.mk (Name.num `goal (i * 2))
+  let start ← IO.monoNanosNow
+  let mut checksum := 0
+  for i in [:rounds] do
+    let input := if i % 2 == 0 then left else left.reverse
+    checksum := checksum + (f input right).length
+  let elapsed := (← IO.monoNanosNow) - start
+  unless checksum == rounds * (n / 2) do
+    throw <| IO.userError "incorrect benchmark result"
+  IO.println s!"{label} n={n} rounds={rounds} ns={elapsed} checksum={checksum}"
+
+#eval do
+  for n in [0, 1, 4, 16, 64, 256] do
+    benchmark "list" reference n 200
+    benchmark "indexed" goalDifference n 200

--- a/scripts/compile_performance/README.md
+++ b/scripts/compile_performance/README.md
@@ -1,0 +1,98 @@
+# Compile-performance experiments
+
+See [the investigation report](../../docs/reading/compile-performance-investigation.md)
+for the original local-file findings and limitations. `measurements.json` contains individual uninstrumented
+measurements, including source/setup hashes, not profiler-derived estimates.
+
+See [the remediation report](../../docs/reading/compile-performance-remediation.md)
+for current source changes, independent patch status, shared-tooling probes and
+whole-build limitations. `remediation-measurements.json` retains the new compact
+results, including unsuccessful experiments; raw artifacts stay under `.lake/`.
+
+## Replay a module
+
+Use Python 3.9+ on macOS or Linux. First build the target under the pinned toolchain.
+The runner consumes Lake's recorded invocation and `.setup.json`, including plugins,
+module visibility and project options. It rejects stale toolchains/checkouts and
+keeps all generated artifacts outside Lake's build tree.
+
+```sh
+python3 scripts/profile_compile.py VCVio.OracleComp.Coercions.Add \
+  --output .lake/compile-performance/files --label baseline
+python3 scripts/profile_compile.py VCVio.OracleComp.Coercions.Add \
+  --output .lake/compile-performance/files --label profile --runs 1 --warmup 0 --profile
+python3 scripts/profile_compile.py VCVio.OracleComp.Coercions.Add \
+  --output .lake/compile-performance/files --label trace --runs 1 --warmup 0 --trace
+```
+
+Choose a new label for each experiment. Use `--root /absolute/checkout` for an
+isolated worktree; dependencies must already be built there. `--source` substitutes
+a scratch source while retaining the original module setup and output facets.
+Preserve its import header: `importArts` in the setup does **not** itself replace
+the source imports (`imports?` is a distinct, optional field).
+
+`--option Elab.async=false` supports synchronous prefix bisection. Cut only at
+complete command boundaries and append `#exit`; an unfinished doc-comment or
+declaration is not a valid timing control. Retain dependencies needed by the slice.
+Do not count failing compilations as faster successes.
+
+Scope `set_option trace.Meta.synthInstance true in` or
+`set_option trace.Meta.Tactic.simp.rewrite true in` to a suspect declaration in a
+scratch copy. For detailed scoped Firefox profiles use `set_option trace.profiler
+true in`, then pass `--option trace.profiler.threshold=0`,
+`--option trace.profiler.output.pp=true` and
+`--option trace.profiler.output=/absolute/profile.json`. Open the resulting file in
+Firefox Profiler. Avoid tracing entire large files at threshold zero.
+
+On macOS, `--sample` samples the actual Lean child for two seconds; OS permissions
+may require approval. It is diagnostic only, and may miss work outside that window.
+Wall times exclude sampler shutdown; a failed sampler still makes the runner fail.
+Linux users can wrap the recorded command with their installed native profiler.
+
+Use uninstrumented serial runs for comparisons. Warm each variant, then alternate
+original/candidate invocations at least five times; keep async settings and output
+facets identical. CPU is summed across threads and may exceed wall time. Peak RSS
+is reported in bytes. The runner's timeout kills the direct Lean child; it is not a
+general process-tree sandbox. Full-build timings must be collected separately;
+see [the whole-build protocol](whole-build-method.md).
+
+### Native metaprogram probes
+
+`--plugin /absolute/library.dylib` (or `.so` on Linux) is repeatable and records
+each library's hash. Build plugins with the pinned toolchain and pass dependencies
+before their consumers. On this checkout, the Header linter plugin needs the
+DirectoryDependency plugin first. A missing dependency produces a loader error;
+it is not a completed measurement. The broader `Mathlib.Init` native probe crashed
+and is not recommended. No plugins are enabled by default.
+
+`GoalDifference.lean.txt` benchmarks the opt-in `ToMathlib.Perf` implementation
+against list membership using `#eval`. Copy it into `.lake/compile-performance/`
+and run with `lake env lean` after building `ToMathlib.Perf`. It checks output
+lengths; the general equivalence theorem and `VCVioTest.Perf` check semantics.
+This microbenchmark is not an end-to-end linter benchmark. Hash-set construction
+cost can outweigh lookup savings on small goal lists.
+
+## Candidate status
+
+- `encoding-kernel.patch`: kernel-checked decision proof, not `native_decide`.
+- `unary-expected-type.patch`: concrete append operations, unchanged association.
+- `add-local-diagnostic.patch`: **diagnostic only**, local instances and a self-lift
+  canary. Not an approved change to the exported instance graph.
+- `chain-simp-only.patch` and `compatibility-simp-only.patch`: negative/weak
+  experiments retained for reproducibility, not recommended production changes.
+- `handler-support-reuse.patch`: checked three-branch Chain experiment; no measured
+  benefit. Its private generic support law is not added to the production API.
+
+Patches are in `candidates/`, relative to baseline
+`ffd0ca198fe6e640c0dd7f0f9c599943caacbf64`. `import-cleanup.patch` is an independent,
+import-only change set; it does not contain the local proof/planner edits.
+`unary-split.patch` contains the experimental core/dispatcher split **and** the
+two concrete-append fixes; do not combine it with `unary-expected-type.patch`.
+Apply only selected patches in a disposable checkout with `git apply --check`
+first; do not apply every experiment as a proposed fix. `DottedConstructor.lean.txt` is a
+small reproducer (stored outside the library sources). Copy it to a scratch
+`.lean` file and replay it with the Unary.Internals setup; its final `rfl` checks
+that the explicit-append version preserves the definition's value.
+
+Instrumentation can emit development-option lint warnings. These were retained,
+not suppressed; profiling options are absent from the two validated candidates.

--- a/scripts/compile_performance/candidates/add-local-diagnostic.patch
+++ b/scripts/compile_performance/candidates/add-local-diagnostic.patch
@@ -1,0 +1,27 @@
+--- a/VCVio/OracleComp/Coercions/Add.lean
++++ b/VCVio/OracleComp/Coercions/Add.lean
+@@ -281,6 +281,17 @@
+ 
+ end OracleQuery
+ 
++/-- Reflexive computation lifts retain the identity normal form. -/
++local instance (priority := 1200) fastLiftSelf {ι : Type _} {spec : OracleSpec ι} :
++    MonadLiftT (OracleComp spec) (OracleComp spec) where
++  monadLift mx := mx
++
++/-- Lift computations by synthesizing a chain between their query signatures. -/
++local instance (priority := 1100) fastLift {ι τ : Type _} {spec : OracleSpec ι}
++    {superSpec : OracleSpec τ} [MonadLiftT (OracleQuery spec) (OracleQuery superSpec)] :
++    MonadLiftT (OracleComp spec) (OracleComp superSpec) where
++  monadLift mx := OracleComp.liftComp mx superSpec
++
+ section tests
+ 
+ -- This set of examples serves as sort of a "unit test" for the coercions above
+@@ -398,4 +409,6 @@
+ example (px : ProbComp α) :
+     (px : OracleComp (unifSpec + spec₁) α) = OracleComp.liftComp px (unifSpec + spec₁) := rfl
+ 
++example (oa : OracleComp spec₁ α) : (liftM oa : OracleComp spec₁ α) = oa := rfl
++
+ end tests

--- a/scripts/compile_performance/candidates/chain-simp-only.patch
+++ b/scripts/compile_performance/candidates/chain-simp-only.patch
@@ -1,0 +1,15 @@
+--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
++++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+@@ -783,8 +783,10 @@
+           xLiveCache, xQueryLog),
+         signed ++ [m]) = z := by
+   have hz' := by
+-    simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
+-      QueryImpl.mapStateTBase] using hz
++    simpa only [add_apply_inr, forkLoggedImpl, QueryImpl.extendState, forkBaseImpl, QueryImpl.flattenStateT,
++        QueryImpl.mapStateTBase, simulatedNmaImpl, simulatedNmaBaseSim, QueryImpl.add_apply_inr, simulatedNmaSigSim,
++        StateT.run_bind, StateT.run_modifyGet, Prod.mk.eta, bind_pure_comp, simulateQ_map, StateT.run_mk, StateT.run_map,
++        Functor.map_map, cmaOracleSignLogAux, support_map, Set.mem_image, Prod.exists] using hz
+   rcases hz' with ⟨xCommit, xChal, xResp, xAdvCache, xLiveCache,
+     xQueryLog, hxmem, hout⟩
+   refine ⟨xCommit, xChal, xResp, xAdvCache, xLiveCache, xQueryLog, hxmem, ?_⟩

--- a/scripts/compile_performance/candidates/compatibility-simp-only.patch
+++ b/scripts/compile_performance/candidates/compatibility-simp-only.patch
@@ -1,0 +1,48 @@
+--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
++++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
+@@ -464,8 +464,12 @@
+     rw [simulateQ_spec_query]
+     ext st
+     rcases st with ⟨signed, st⟩
+-    simp [fs_simp, QueryImpl.extendStateLeft, QueryImpl.mapStateTBase, QueryImpl.flattenStateT,
+-      map_eq_bind_pure_comp]
++    simp only [cmaRealLoggedProdImpl, QueryImpl.flattenStateT, QueryImpl.mapStateTBase, cmaSignLogImpl,
++        StateT.run_monadLift, monadLift_self, bind_pure_comp, map_eq_bind_pure_comp, simulateQ_bind, simulateQ_query,
++        OracleQuery.input_query, OracleQuery.cont_query, cmaReal, cmaRealSourceFull, CompTriple.comp_eq, bind_pure,
++        Function.comp_apply, simulateQ_pure, StateT.run_mk, StateT.run_bind, StateT.run_pure, bind_assoc, pure_bind,
++        Prod.mk.eta, cmaRealAppendProdImpl, QueryImpl.extendStateLeft, add_apply_inl, cmaRealSourceFullSum,
++        cmaRealAppendAux]
+   · change simulateQ
+         (cmaRealLoggedProdImpl (σ := σ) (hr := hr) (M := M)
+           (Commit := Commit) (Chal := Chal) (Resp := Resp))
+@@ -476,8 +480,11 @@
+     ext st
+     rcases st with ⟨signed, st⟩
+     cases hcache : st.1.2.1 mc <;>
+-      simp [fs_simp, QueryImpl.extendStateLeft, QueryImpl.mapStateTBase,
+-        QueryImpl.flattenStateT, hcache]
++      simp only [cmaRealLoggedProdImpl, QueryImpl.flattenStateT, QueryImpl.mapStateTBase, cmaSignLogImpl,
++          StateT.run_monadLift, monadLift_self, bind_pure_comp, simulateQ_map, simulateQ_query, OracleQuery.input_query,
++          OracleQuery.cont_query, cmaReal, cmaRealSourceFull, Prod.mk.eta, id_map, StateT.run_mk, StateT.run_map,
++          Functor.map_map, hcache, map_pure, cmaRealAppendProdImpl, QueryImpl.extendStateLeft, add_apply_inl, add_apply_inr,
++          cmaRealSourceFullSum, cmaRealAppendAux]
+   · change simulateQ
+         (cmaRealLoggedProdImpl (σ := σ) (hr := hr) (M := M)
+           (Commit := Commit) (Chal := Chal) (Resp := Resp))
+@@ -487,8 +494,14 @@
+     rw [simulateQ_spec_query]
+     ext st
+     rcases st with ⟨signed, st⟩
+-    simp [fs_simp, QueryImpl.extendStateLeft, QueryImpl.mapStateTBase,
+-      QueryImpl.flattenStateT, StateT.run_bind, monad_norm]
++    simp only [cmaRealLoggedProdImpl, QueryImpl.flattenStateT, QueryImpl.mapStateTBase, cmaSignLogImpl,
++        bind_pure_comp, map_eq_bind_pure_comp, StateT.run_bind, StateT.run_get, StateT.run_monadLift, monadLift_self,
++        StateT.run_set, Function.comp_apply, StateT.run_pure, map_pure, map_bind, pure_bind, simulateQ_bind,
++        simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query, cmaReal, cmaRealSourceFull, Prod.mk.eta, id_map,
++        simulateQ_pure, StateT.run_mk, cmaRealAppendProdImpl, QueryImpl.extendStateLeft, add_apply_inr,
++        cmaRealSourceFullSum, cmaRealAppendAux]
++    simp only [bind_assoc, Function.comp_apply, pure_bind]
++    rfl
+ 
+ private lemma cmaRealLoggedProdImpl_liftAdv_run {α : Type}
+     (oa : SourceCmaComp (M := M) (Commit := Commit) (Chal := Chal)

--- a/scripts/compile_performance/candidates/encoding-kernel.patch
+++ b/scripts/compile_performance/candidates/encoding-kernel.patch
@@ -1,0 +1,11 @@
+--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
++++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+@@ -77,7 +77,7 @@
+ 
+ private theorem packByte_bitOf_fin :
+     ∀ n : Fin (2 ^ 8), packByte (fun j => bitOf n.val.toUInt8 j.val) = n.val.toUInt8 := by
+-  intro n; fin_cases n <;> rfl
++  decide +kernel
+ 
+ private theorem packByte_bitOf_byte (b : UInt8) :
+     packByte (fun j => bitOf b j.val) = b := by

--- a/scripts/compile_performance/candidates/handler-support-reuse.patch
+++ b/scripts/compile_performance/candidates/handler-support-reuse.patch
@@ -1,0 +1,56 @@
+diff --git a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+index c042f567..39b73114 100644
+--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
++++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+@@ -35,6 +35,23 @@ open ENNReal OracleSpec OracleComp ProbComp OracleComp.ProgramLogic.Relational
+ `PFunctor.Obj` presentation. Keep that reduction local to this proof module. -/
+ attribute [local implicit_reducible] PFunctor.Obj
+ 
++namespace QueryImpl
++
++/-- Membership in an auxiliary-state handler's support is witnessed by a base-handler result. -/
++private theorem mem_support_extendState_iff
++    {ι : Type u} {spec : OracleSpec ι} {σ Q : Type u} {m : Type u → Type u}
++    [Monad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
++    (so : QueryImpl spec (StateT σ m))
++    (aux : (t : spec.Domain) → σ → spec.Range t → σ → Q → Q)
++    (t : spec.Domain) (s : σ × Q) (z : spec.Range t × (σ × Q)) :
++    z ∈ support ((extendState so aux t).run s) ↔
++      ∃ y ∈ support ((so t).run s.1),
++        (y.1, (y.2, aux t s.1 y.1 y.2 s.2)) = z := by
++  rw [extendState_apply, mem_support_bind_iff]
++  simp only [support_pure, Set.mem_singleton_iff, eq_comm]
++
++end QueryImpl
++
+ namespace FiatShamir.Stateful
+ 
+ /-! Tag the CMA-to-NMA simulator handler family from `Sigma/CmaToNma.lean`
+@@ -807,13 +824,15 @@ private lemma forkLoggedImpl_preserves_inv_step
+   rcases hs with ⟨hfreshInv, hlogInv⟩
+   rcases t with ((n | mc) | m)
+   · have hz' := by
+-      simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
++      rw [forkLoggedImpl, QueryImpl.mem_support_extendState_iff] at hz
++      simpa [fs_simp, QueryImpl.flattenStateT,
+         QueryImpl.mapStateTBase] using hz
+     rcases hz' with ⟨w, hw, rfl⟩
+     exact And.intro hfreshInv hlogInv
+   · by_cases hadv : advCache (.inr mc) = none
+     · have hz' := by
+-        simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
++        rw [forkLoggedImpl, QueryImpl.mem_support_extendState_iff] at hz
++        simpa [fs_simp, QueryImpl.flattenStateT,
+           QueryImpl.mapStateTBase, hadv] using hz
+       rcases hz' with ⟨ch, liveCache', queryLog', hw, rfl⟩
+       by_cases hlive : liveCache mc = none
+@@ -910,7 +929,8 @@ private lemma forkLoggedImpl_preserves_inv_step
+     · rcases hadv' : advCache (.inr mc) with _ | advCh
+       · exact (hadv hadv').elim
+       · have hz' := by
+-          simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
++          rw [forkLoggedImpl, QueryImpl.mem_support_extendState_iff] at hz
++          simpa [fs_simp, QueryImpl.flattenStateT,
+             QueryImpl.mapStateTBase, hadv'] using hz
+         rcases hz' with ⟨w, hw, rfl⟩
+         constructor

--- a/scripts/compile_performance/candidates/import-cleanup.patch
+++ b/scripts/compile_performance/candidates/import-cleanup.patch
@@ -1,0 +1,105 @@
+diff --git a/Examples/PRFTagReader/BadEvent.lean b/Examples/PRFTagReader/BadEvent.lean
+index 91d2325a..f1929138 100644
+--- a/Examples/PRFTagReader/BadEvent.lean
++++ b/Examples/PRFTagReader/BadEvent.lean
+@@ -6,7 +6,7 @@ Authors: Oleksandr Vovkotrub
+ 
+ module
+ 
+-public import Examples.PRFTagReader.Collision
++public import Examples.PRFTagReader.Defs
+ 
+ /-!
+ # PRF Tag/Reader Protocol — Bad-Event Bound
+diff --git a/Examples/PRFTagReader/Collision.lean b/Examples/PRFTagReader/Collision.lean
+index 0b2456fc..c175ad2c 100644
+--- a/Examples/PRFTagReader/Collision.lean
++++ b/Examples/PRFTagReader/Collision.lean
+@@ -7,6 +7,7 @@ Authors: Oleksandr Vovkotrub
+ module
+ 
+ public import Examples.PRFTagReader.Collision.ForgeStep
++public import Examples.PRFTagReader.Auth
+ 
+ /-!
+ # PRF Tag/Reader Protocol — Collision Bound
+diff --git a/Examples/PRFTagReader/Collision/ForgeStep.lean b/Examples/PRFTagReader/Collision/ForgeStep.lean
+index f920e00d..4b685958 100644
+--- a/Examples/PRFTagReader/Collision/ForgeStep.lean
++++ b/Examples/PRFTagReader/Collision/ForgeStep.lean
+@@ -6,7 +6,7 @@ Authors: Oleksandr Vovkotrub
+ 
+ module
+ 
+-public import Examples.PRFTagReader.Auth
++public import Examples.PRFTagReader.Defs
+ 
+ /-!
+ # PRF Tag/Reader Protocol — Collision Bound, Per-Step Forge Infrastructure
+diff --git a/Examples/PRFTagReader/MultipleBadCollision.lean b/Examples/PRFTagReader/MultipleBadCollision.lean
+index 34b8a4fb..da0c157a 100644
+--- a/Examples/PRFTagReader/MultipleBadCollision.lean
++++ b/Examples/PRFTagReader/MultipleBadCollision.lean
+@@ -7,6 +7,7 @@ Authors: Oleksandr Vovkotrub
+ module
+ 
+ public import Examples.PRFTagReader.DirectCoupling.Compose
++public import Examples.PRFTagReader.BadEvent
+ public import Examples.PRFTagReader.MultipleToHybrid.EagerSetup
+ 
+ /-!
+diff --git a/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean b/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
+index 3f19dd0e..85c2e3d2 100644
+--- a/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
++++ b/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
+@@ -7,6 +7,7 @@ Authors: Oleksandr Vovkotrub
+ module
+ 
+ public import Examples.PRFTagReader.MultipleToHybrid.Setup
++public import Examples.PRFTagReader.Table
+ 
+ /-!
+ # PRF Tag/Reader Protocol — Multiple-to-hybrid eager coupling, shared setup
+diff --git a/Examples/PRFTagReader/MultipleToHybrid/Setup.lean b/Examples/PRFTagReader/MultipleToHybrid/Setup.lean
+index 2b965894..1f0f20f8 100644
+--- a/Examples/PRFTagReader/MultipleToHybrid/Setup.lean
++++ b/Examples/PRFTagReader/MultipleToHybrid/Setup.lean
+@@ -6,7 +6,8 @@ Authors: Oleksandr Vovkotrub
+ 
+ module
+ 
+-public import Examples.PRFTagReader.Table
++public import Examples.PRFTagReader.PRFReductions.IdealHandlers
++import VCVio.ProgramLogic.Relational.SimulateQ
+ 
+ /-!
+ # PRF Tag/Reader Protocol — Instrumented multiple-session handler
+diff --git a/Examples/PRFTagReader/PRFReductions/Reductions.lean b/Examples/PRFTagReader/PRFReductions/Reductions.lean
+index 206a173c..73cad5a7 100644
+--- a/Examples/PRFTagReader/PRFReductions/Reductions.lean
++++ b/Examples/PRFTagReader/PRFReductions/Reductions.lean
+@@ -6,9 +6,7 @@ Authors: Oleksandr Vovkotrub
+ 
+ module
+ 
+-public import Examples.PRFTagReader
+-public import VCVio.OracleComp.QueryTracking.RandomOracle.EagerTable
+-public import VCVio.ProgramLogic.Relational.SimulateQ
++public import Examples.PRFTagReader.Defs
+ 
+ /-!
+ # PRF Tag/Reader Protocol — Reductions and Bridge Lemmas
+diff --git a/Examples/PRFTagReader/Table.lean b/Examples/PRFTagReader/Table.lean
+index e44636e5..c9974366 100644
+--- a/Examples/PRFTagReader/Table.lean
++++ b/Examples/PRFTagReader/Table.lean
+@@ -6,7 +6,8 @@ Authors: Oleksandr Vovkotrub
+ 
+ module
+ 
+-public import Examples.PRFTagReader.PRFReductions
++public import Examples.PRFTagReader.PRFReductions.IdealHandlers
++public import VCVio.OracleComp.QueryTracking.RandomOracle.EagerTable
+ 
+ /-!
+ # PRF Tag/Reader Protocol — Composed-Handler Eager-Table Equivalence

--- a/scripts/compile_performance/candidates/unary-expected-type.patch
+++ b/scripts/compile_performance/candidates/unary-expected-type.patch
@@ -1,0 +1,20 @@
+--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
++++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+@@ -1383,7 +1383,7 @@
+   ]
+ 
+ private def probEqPlannerActionPlans : List (List ProbEqAction) :=
+-  probEqRewritePlans 4 ++ probEqCongrPlans 3 ++
++  List.append (List.append (probEqRewritePlans 4) (probEqCongrPlans 3))
+     [ [.congr]
+     , [.congrNoSupport]
+     , [.congr, .swap]
+@@ -1424,7 +1424,7 @@
+ private def probEqPlannerActionPlansForDepth (bindDepth : Nat) : List (List ProbEqAction) :=
+   let maxRewriteDepth := Nat.min 4 (bindDepth - 2)
+   let maxCongrDepth := Nat.min 3 bindDepth
+-  probEqRewritePlans maxRewriteDepth ++ probEqCongrPlans maxCongrDepth ++
++  List.append (List.append (probEqRewritePlans maxRewriteDepth) (probEqCongrPlans maxCongrDepth))
+     [ [.congr]
+     , [.congrNoSupport]
+     , [.congr, .swap]

--- a/scripts/compile_performance/candidates/unary-split.patch
+++ b/scripts/compile_performance/candidates/unary-split.patch
@@ -1,0 +1,3445 @@
+diff --git a/VCVio.lean b/VCVio.lean
+index b844c0fa..4e2d571d 100644
+--- a/VCVio.lean
++++ b/VCVio.lean
+@@ -271,6 +271,7 @@ public import VCVio.ProgramLogic.Tactics.Handler
+ public import VCVio.ProgramLogic.Tactics.Relational
+ public import VCVio.ProgramLogic.Tactics.Relational.Internals
+ public import VCVio.ProgramLogic.Tactics.Unary
++public import VCVio.ProgramLogic.Tactics.Unary.Core
+ public import VCVio.ProgramLogic.Tactics.Unary.Internals
+ public import VCVio.ProgramLogic.Unary.Examples
+ public import VCVio.ProgramLogic.Unary.HandlerSpecs
+diff --git a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+index 9429dde6..f45f186b 100644
+--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
++++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+@@ -6,15 +6,15 @@ Authors: Quang Dao
+ 
+ module
+ 
+-public meta import VCVio.ProgramLogic.Tactics.Common
+-public import VCVio.ProgramLogic.Relational.Basic
++public meta import VCVio.ProgramLogic.Tactics.Unary.Core
+ public meta import VCVio.ProgramLogic.Tactics.Relational.Internals
+-public import Loom.Triple.SpecLemmas
++import all VCVio.ProgramLogic.Tactics.Unary.Core
+ 
+ /-!
+-# Unary VCGen Internals
++# Unary VCGen Dispatch
+ 
+-Implementation details for the unary VCGen planner and close passes.
++Structural dispatch, plan selection, and multi-goal passes for unary VCGen.
++Relational goals are delegated to the relational engine.
+ -/
+ 
+ public meta section
+@@ -25,1688 +25,6 @@ namespace OracleComp.ProgramLogic
+ namespace TacticInternals
+ namespace Unary
+ 
+-universe u v
+-
+-/-- Cached raw-`wp` structural leaf for `pure`.
+-
+-The equality theorem `wp_pure` remains the canonical rewrite rule.
+-This lower-bound form lets raw `wp` goals use the cached `@[vcspec]`
+-backward-rule path before falling back to `@[wpStep]`. -/
+-theorem wp_pure_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {α : Type} (x : α)
+-    (post : α → ENNReal) :
+-    post x ≤ wp (pure x : OracleComp spec α) post := by
+-  rw [OracleComp.ProgramLogic.wp_pure]
+-
+-/-- Cached raw-`wp` structural leaf for functorial map. -/
+-theorem wp_map_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {α β : Type}
+-    (f : α → β) (oa : OracleComp spec α) (post : β → ENNReal) :
+-    wp oa (post ∘ f) ≤ wp (f <$> oa) post := by
+-  rw [OracleComp.ProgramLogic.wp_map]
+-
+-/-- Cached raw-`wp` structural leaf for conditionals. -/
+-theorem wp_ite_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {α : Type} (c : Prop) [Decidable c]
+-    (oa ob : OracleComp spec α) (post : α → ENNReal) :
+-    (if c then wp oa post else wp ob post) ≤ wp (if c then oa else ob) post := by
+-  rw [OracleComp.ProgramLogic.wp_ite]
+-
+-/-- Cached raw-`wp` structural leaf for dependent conditionals. -/
+-theorem wp_dite_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {α : Type} (c : Prop) [Decidable c]
+-    (oa : c → OracleComp spec α) (ob : ¬c → OracleComp spec α) (post : α → ENNReal) :
+-    (if h : c then wp (oa h) post else wp (ob h) post) ≤ wp (dite c oa ob) post := by
+-  rw [OracleComp.ProgramLogic.wp_dite]
+-
+-/-- Cached raw-`wp` structural leaf for `replicate (n + 1)`. -/
+-theorem wp_replicate_succ_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {α : Type}
+-    (oa : OracleComp spec α) (n : Nat) (post : List α → ENNReal) :
+-    wp oa (fun x => wp (oa.replicate n) (fun xs => post (x :: xs))) ≤
+-      wp (oa.replicate (n + 1)) post := by
+-  rw [OracleComp.ProgramLogic.wp_replicate_succ]
+-
+-/-- Cached raw-`wp` structural leaf for `List.mapM` on `x :: xs`. -/
+-theorem wp_list_mapM_cons_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {α β : Type}
+-    (x : α) (xs : List α) (f : α → OracleComp spec β) (post : List β → ENNReal) :
+-    wp (f x) (fun y => wp (xs.mapM f) (fun ys => post (y :: ys))) ≤
+-      wp ((x :: xs).mapM f) post := by
+-  rw [OracleComp.ProgramLogic.wp_list_mapM_cons]
+-
+-/-- Cached raw-`wp` structural leaf for `List.foldlM` on `x :: xs`. -/
+-theorem wp_list_foldlM_cons_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {α σ : Type}
+-    (x : α) (xs : List α) (f : σ → α → OracleComp spec σ)
+-    (init : σ) (post : σ → ENNReal) :
+-    wp (f init x) (fun s => wp (xs.foldlM f s) post) ≤
+-      wp ((x :: xs).foldlM f init) post := by
+-  rw [OracleComp.ProgramLogic.wp_list_foldlM_cons]
+-
+-/-- Cached raw-`wp` structural leaf for oracle queries. -/
+-theorem wp_query_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec]
+-    (t : spec.Domain) (post : spec.Range t → ENNReal) :
+-    (∑' u : spec.Range t, (1 / Fintype.card (spec.Range t) : ENNReal) * post u) ≤
+-      wp (query t : OracleComp spec (spec.Range t)) post := by
+-  simpa using le_of_eq (OracleComp.ProgramLogic.wp_HasQuery_query (spec := spec) t post).symm
+-
+-/-- Cached raw-`wp` structural leaf for `HasQuery.query`. -/
+-theorem wp_HasQuery_query_le_vcspec {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec]
+-    (t : spec.Domain) (post : spec.Range t → ENNReal) :
+-    (∑' u : spec.Range t, (1 / Fintype.card (spec.Range t) : ENNReal) * post u) ≤
+-      wp (spec := spec) (HasQuery.query t : OracleComp spec (spec.Range t)) post := by
+-  simpa using le_of_eq (OracleComp.ProgramLogic.wp_HasQuery_query (spec := spec) t post).symm
+-
+-/-- Cached raw-`wp` structural leaf for uniform sampling. -/
+-theorem wp_uniformSample_le_vcspec {α : Type} [SampleableType α] (post : α → ENNReal) :
+-    (∑' u : α, Pr[= u | ($ᵗ α : ProbComp α)] * post u) ≤
+-      wp ($ᵗ α : ProbComp α) post := by
+-  rw [OracleComp.ProgramLogic.wp_uniformSample]
+-
+-/-- Generic Loom triple bind step with the intermediate postcondition fixed to
+-the weakest precondition of the continuation. This is the `Std.Do'.Triple`
+-counterpart of `OracleComp.ProgramLogic.triple_bind_wp`, and lets unary
+-automation walk transformer-stack `do` blocks without guessing a user cut. -/
+-theorem stdDoTriple_bind_wp {m : Type u → Type v}
+-    {Pred EPred : Type u} {α β : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {pre : Pred} (x : m α) (f : α → m β) (post : β → Pred) (epost : EPred) :
+-    Std.Do'.Triple pre x (fun a => Std.Do'.wp (f a) post epost) epost →
+-      Std.Do'.Triple pre (x >>= f) post epost := by
+-  intro h
+-  exact Std.Do'.Triple.bind x f (fun a => Std.Do'.wp (f a) post epost) h
+-    (fun _ => Std.Do'.Triple.iff.mpr Lean.Order.PartialOrder.rel_refl)
+-
+-/-- Close a Loom triple from the corresponding WP entailment.
+-
+-This is just `Std.Do'.Triple.iff.mpr` packaged as a theorem so tactic code can expose
+-the weakest-precondition side condition and then run transformer-specific WP normalizers. -/
+-theorem stdDoTriple_of_wp_le {m : Type u → Type v}
+-    {Pred EPred : Type u} {α : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {pre : Pred} (x : m α) (post : α → Pred) (epost : EPred)
+-    (hpre : Lean.Order.PartialOrder.rel pre (Std.Do'.wp x post epost)) :
+-    Std.Do'.Triple pre x post epost :=
+-  Std.Do'.Triple.iff.mpr hpre
+-
+-theorem wp_StateT_get_layer {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ : Type u} (post : σ → σ → Pred) (epost : EPred) :
+-    Std.Do'.wp (MonadStateOf.get : StateT σ m σ) post epost =
+-      fun s => Std.Do'.wp (pure (s, s) : m (σ × σ))
+-        (fun p : σ × σ => post p.1 p.2) epost :=
+-  rfl
+-
+-theorem wp_StateT_get_layer' {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ : Type u} (post : σ → σ → Pred) (epost : EPred) :
+-    Std.Do'.wp (StateT.get : StateT σ m σ) post epost =
+-      fun s => Std.Do'.wp (pure (s, s) : m (σ × σ))
+-        (fun p : σ × σ => post p.1 p.2) epost :=
+-  rfl
+-
+-theorem stdDoTriple_StateT_get_of_rel {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ : Type u} (pre : σ → Pred) (post : σ → σ → Pred) (epost : EPred)
+-    (h : ∀ s, Lean.Order.PartialOrder.rel (pre s) (post s s)) :
+-    Std.Do'.Triple pre (StateT.get : StateT σ m σ) post epost := by
+-  refine Std.Do'.Triple.iff.mpr ?_
+-  intro s
+-  change Lean.Order.PartialOrder.rel (pre s)
+-    (Std.Do'.wp (pure (s, s) : m (σ × σ))
+-      (fun p : σ × σ => post p.1 p.2) epost)
+-  exact Lean.Order.PartialOrder.rel_trans (h s)
+-    (Std.Do'.WP.wp_pure (m := m) (x := (s, s))
+-      (post := fun p : σ × σ => post p.1 p.2) (epost := epost))
+-
+-theorem wp_StateT_set_layer {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ : Type u} (s' : σ) (post : PUnit → σ → Pred) (epost : EPred) :
+-    Std.Do'.wp (MonadStateOf.set s' : StateT σ m PUnit) post epost =
+-      fun _ => Std.Do'.wp (pure (PUnit.unit, s') : m (PUnit × σ))
+-        (fun p : PUnit × σ => post p.1 p.2) epost :=
+-  rfl
+-
+-theorem wp_StateT_run_get_layer {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ : Type u} (s : σ) (post : σ → σ → Pred) (epost : EPred) :
+-    Std.Do'.wp ((MonadStateOf.get : StateT σ m σ).run s)
+-        (fun p : σ × σ => post p.1 p.2) epost =
+-      Std.Do'.wp (pure (s, s) : m (σ × σ)) (fun p : σ × σ => post p.1 p.2) epost :=
+-  rfl
+-
+-theorem wp_StateT_run_get_layer' {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ : Type u} (s : σ) (post : σ → σ → Pred) (epost : EPred) :
+-    Std.Do'.wp ((StateT.get : StateT σ m σ).run s)
+-        (fun p : σ × σ => post p.1 p.2) epost =
+-      Std.Do'.wp (pure (s, s) : m (σ × σ)) (fun p : σ × σ => post p.1 p.2) epost :=
+-  rfl
+-
+-theorem wp_StateT_run_set_layer {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ : Type u} (s s' : σ) (post : PUnit → σ → Pred) (epost : EPred) :
+-    Std.Do'.wp ((MonadStateOf.set s' : StateT σ m PUnit).run s)
+-        (fun p : PUnit × σ => post p.1 p.2) epost =
+-      Std.Do'.wp (pure (PUnit.unit, s') : m (PUnit × σ))
+-        (fun p : PUnit × σ => post p.1 p.2) epost :=
+-  rfl
+-
+-theorem wp_StateT_run_set_layer' {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ : Type u} (s s' : σ) (post : PUnit → σ → Pred) (epost : EPred) :
+-    Std.Do'.wp ((StateT.set s' : StateT σ m PUnit).run s)
+-        (fun p : PUnit × σ => post p.1 p.2) epost =
+-      Std.Do'.wp (pure (PUnit.unit, s') : m (PUnit × σ))
+-        (fun p : PUnit × σ => post p.1 p.2) epost :=
+-  rfl
+-
+-theorem wp_StateT_map_layer {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {σ α β : Type u} (f : α → β) (x : StateT σ m α) (post : β → σ → Pred)
+-    (epost : EPred) :
+-    Std.Do'.wp (f <$> x) post epost =
+-      fun s => Std.Do'.wp ((f <$> x).run s)
+-        (fun p : β × σ => post p.1 p.2) epost :=
+-  rfl
+-
+-theorem wp_ReaderT_read_layer {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {ρ : Type u} (post : ρ → ρ → Pred) (epost : EPred) :
+-    Std.Do'.wp (MonadReaderOf.read : ReaderT ρ m ρ) post epost =
+-      fun r => Std.Do'.wp (pure r : m ρ) (fun a => post a r) epost :=
+-  rfl
+-
+-theorem wp_ReaderT_read_layer' {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {ρ : Type u} (post : ρ → ρ → Pred) (epost : EPred) :
+-    Std.Do'.wp (ReaderT.read : ReaderT ρ m ρ) post epost =
+-      fun r => Std.Do'.wp (pure r : m ρ) (fun a => post a r) epost :=
+-  rfl
+-
+-theorem stdDoTriple_ReaderT_read_of_rel {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {ρ : Type u} (pre : ρ → Pred) (post : ρ → ρ → Pred) (epost : EPred)
+-    (h : ∀ r, Lean.Order.PartialOrder.rel (pre r) (post r r)) :
+-    Std.Do'.Triple pre (MonadReaderOf.read : ReaderT ρ m ρ) post epost := by
+-  refine Std.Do'.Triple.iff.mpr ?_
+-  intro r
+-  change Lean.Order.PartialOrder.rel (pre r)
+-    (Std.Do'.wp (pure r : m ρ) (fun a : ρ => post a r) epost)
+-  exact Lean.Order.PartialOrder.rel_trans (h r)
+-    (Std.Do'.WP.wp_pure (m := m) (x := r)
+-      (post := fun a : ρ => post a r) (epost := epost))
+-
+-theorem wp_ReaderT_run_read_layer {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {ρ : Type u} (r : ρ) (post : ρ → ρ → Pred) (epost : EPred) :
+-    Std.Do'.wp ((MonadReaderOf.read : ReaderT ρ m ρ).run r) (fun a : ρ => post a r)
+-        epost =
+-      Std.Do'.wp (pure r : m ρ) (fun a : ρ => post a r) epost :=
+-  rfl
+-
+-theorem wp_ReaderT_run_read_layer' {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {ρ : Type u} (r : ρ) (post : ρ → ρ → Pred) (epost : EPred) :
+-    Std.Do'.wp ((ReaderT.read : ReaderT ρ m ρ).run r) (fun a : ρ => post a r)
+-        epost =
+-      Std.Do'.wp (pure r : m ρ) (fun a : ρ => post a r) epost :=
+-  rfl
+-
+-theorem mAlgOrdered_wp_OptionT_run_StateT_get {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {σ : Type} (s : σ)
+-    (post : σ → σ → ENNReal)
+-    (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
+-    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
+-      (((StateT.get : StateT σ (OptionT (OracleComp spec)) σ).run s).run)
+-      (epost.pushOption (fun p : σ × σ => post p.1 p.2)) = post s s := by
+-  change MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
+-      (pure (some (s, s)) : OracleComp spec (Option (σ × σ)))
+-      (epost.pushOption (fun p : σ × σ => post p.1 p.2)) = post s s
+-  rw [MAlgOrdered.wp_pure]
+-
+-theorem mAlgOrdered_wp_OptionT_run_StateT_set {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {σ : Type} (s s' : σ)
+-    (post : PUnit → σ → ENNReal) (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
+-    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
+-      (((StateT.set s' : StateT σ (OptionT (OracleComp spec)) PUnit).run s).run)
+-      (epost.pushOption (fun p : PUnit × σ => post p.1 p.2)) = post PUnit.unit s' := by
+-  change MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
+-      (pure (some (PUnit.unit, s')) : OracleComp spec (Option (PUnit × σ)))
+-      (epost.pushOption (fun p : PUnit × σ => post p.1 p.2)) = post PUnit.unit s'
+-  rw [MAlgOrdered.wp_pure]
+-
+-theorem mAlgOrdered_wp_OptionT_run_lift {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {α : Type}
+-    (oa : OracleComp spec α) (post : α → ENNReal)
+-    (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
+-    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) (OptionT.lift oa).run
+-      (epost.pushOption post) =
+-        MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa post := by
+-  change MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
+-      (oa >>= fun a => pure (some a) : OracleComp spec (Option α))
+-      (epost.pushOption post) =
+-    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa post
+-  rw [MAlgOrdered.wp_bind]
+-  refine congrArg (MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa) ?_
+-  funext a
+-  rw [MAlgOrdered.wp_pure]
+-
+-theorem mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift {ι : Type u}
+-    {spec : OracleSpec ι} [IsUniformSpec spec]
+-    {σ α : Type} (oa : OracleComp spec α) (s : σ) (post : α → σ → ENNReal)
+-    (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
+-    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
+-      (((MonadLift.monadLift (OptionT.lift oa) :
+-        StateT σ (OptionT (OracleComp spec)) α).run s).run)
+-      (epost.pushOption (fun p : α × σ => post p.1 p.2)) =
+-        MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa (fun a => post a s) := by
+-  simp [MonadLift.monadLift, OptionT.run_lift, MAlgOrdered.wp_map,
+-    Std.Do'.EPost.cons.pushOption]
+-
+-theorem wp_StateT_OptionT_monadLift_lift {ι : Type u} {spec : OracleSpec ι}
+-    [IsUniformSpec spec] {σ α : Type}
+-    (oa : OracleComp spec α) (post : α → σ → ENNReal)
+-    (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
+-    Std.Do'.wp
+-      (MonadLift.monadLift (OptionT.lift oa) : StateT σ (OptionT (OracleComp spec)) α)
+-      post epost =
+-        fun s => MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa
+-          (fun a => post a s) := by
+-  funext s
+-  change MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
+-      (((MonadLift.monadLift (OptionT.lift oa) :
+-        StateT σ (OptionT (OracleComp spec)) α).run s).run)
+-      (epost.pushOption (fun p : α × σ => post p.1 p.2)) =
+-        MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa (fun a => post a s)
+-  exact mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift (spec := spec) oa s post epost
+-
+-theorem mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift_map {ι : Type u}
+-    {spec : OracleSpec ι} [IsUniformSpec spec]
+-    {σ α β : Type} (oa : OracleComp spec α) (s : σ) (f : α × σ → β)
+-    (post : β → ENNReal) (nonePost : ENNReal) :
+-    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
+-      (((MonadLift.monadLift (OptionT.lift oa) :
+-        StateT σ (OptionT (OracleComp spec)) α).run s).run)
+-      (fun o => match Option.map f o with | some b => post b | none => nonePost) =
+-        MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa
+-          (fun a => post (f (a, s))) := by
+-  simp [MonadLift.monadLift, OptionT.run_lift, MAlgOrdered.wp_map]
+-
+-theorem wp_ReaderT_map_layer {m : Type u → Type v} {Pred EPred : Type u}
+-    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
+-    {ρ α β : Type u} (f : α → β) (x : ReaderT ρ m α) (post : β → ρ → Pred)
+-    (epost : EPred) :
+-    Std.Do'.wp (f <$> x) post epost =
+-      fun r => Std.Do'.wp ((f <$> x).run r) (fun b : β => post b r) epost :=
+-  rfl
+-
+-attribute [vcspec]
+-  OracleComp.ProgramLogic.triple_pure
+-  wp_pure_le_vcspec
+-  wp_map_le_vcspec
+-  wp_ite_le_vcspec
+-  wp_dite_le_vcspec
+-  wp_replicate_succ_le_vcspec
+-  wp_list_mapM_cons_le_vcspec
+-  wp_list_foldlM_cons_le_vcspec
+-  wp_query_le_vcspec
+-  wp_HasQuery_query_le_vcspec
+-  wp_uniformSample_le_vcspec
+-  -- StateT
+-  Std.Do'.Spec.get_StateT
+-  Std.Do'.Spec.set_StateT
+-  Std.Do'.Spec.modifyGet_StateT
+-  Std.Do'.Spec.monadLift_StateT
+-  -- ReaderT
+-  Std.Do'.Spec.read_ReaderT
+-  Std.Do'.Spec.monadLift_ReaderT
+-  Std.Do'.Spec.adapt_ReaderT
+-  Std.Do'.Spec.withReader_ReaderT
+-  -- WriterT
+-  Std.Do'.Spec.tell_WriterT
+-  Std.Do'.Spec.monadLift_WriterT
+-  Std.Do'.Spec.mk_WriterT
+-  Std.Do'.WriterT.wp_pure
+-  Std.Do'.WriterT.wp_bind
+-  Std.Do'.WriterT.wp_tell
+-  Std.Do'.WriterT.wp_monadLift
+-  Std.Do'.WriterT.wp_map
+-  -- OptionT
+-  Std.Do'.Spec.run_OptionT
+-  Std.Do'.Spec.throw_OptionT
+-  Std.Do'.Spec.tryCatch_OptionT
+-  Std.Do'.Spec.orElse_OptionT
+-  Std.Do'.Spec.monadLift_OptionT
+-  -- ExceptT
+-  Std.Do'.Spec.run_ExceptT
+-  Std.Do'.Spec.throw_ExceptT
+-  Std.Do'.Spec.tryCatch_ExceptT
+-  Std.Do'.Spec.orElse_ExceptT
+-  Std.Do'.Spec.adapt_ExceptT
+-  Std.Do'.Spec.monadLift_ExceptT
+-  -- Lifted MonadExceptOf
+-  Std.Do'.Spec.throw_MonadExcept
+-  Std.Do'.Spec.tryCatch_MonadExcept
+-  Std.Do'.Spec.throw_ReaderT
+-  Std.Do'.Spec.throw_StateT
+-  Std.Do'.Spec.throw_ExceptT_lift
+-  Std.Do'.Spec.throw_Option_lift
+-  Std.Do'.Spec.tryCatch_ReaderT
+-  Std.Do'.Spec.tryCatch_StateT
+-  Std.Do'.Spec.tryCatch_ExceptT_lift
+-  Std.Do'.Spec.tryCatch_OptionT_lift
+-  -- Generic monad-transformer hooks
+-  Std.Do'.Spec.monadMap_StateT
+-  Std.Do'.Spec.monadMap_ReaderT
+-  Std.Do'.Spec.monadMap_ExceptT
+-  Std.Do'.Spec.monadMap_OptionT
+-  Std.Do'.Spec.monadMap_refl
+-  Std.Do'.Spec.monadMap_trans
+-  Std.Do'.Spec.liftWith_StateT
+-  Std.Do'.Spec.liftWith_ReaderT
+-  Std.Do'.Spec.liftWith_ExceptT
+-  Std.Do'.Spec.liftWith_OptionT
+-  Std.Do'.Spec.liftWith_refl
+-  Std.Do'.Spec.liftWith_trans
+-  Std.Do'.Spec.restoreM_StateT
+-  Std.Do'.Spec.restoreM_ReaderT
+-  Std.Do'.Spec.restoreM_ExceptT
+-  Std.Do'.Spec.restoreM_OptionT
+-  Std.Do'.Spec.restoreM_refl
+-
+-/-! ## `vcspec_simp` normalization set
+-
+-Centralized registration of the transformer-`wp` peel lemmas, `*.run`
+-projections, monadic-algebra rewrites, and the `Loom.wp_eq_mAlgOrdered_wp`
+-bridges that the unary tactic uses to expose spec-applicable goal shapes.
+-The single simp set is consumed by `runVCSpecSimp`. New normalization rewrites
+-should be tagged here (or at definition) rather than inserted into a
+-tactic-local `simp only [...]` list. -/
+-
+-attribute [vcspec_simp]
+-  -- `Std.Do'` transformer apply_wp / `*.run` peeling
+-  Std.Do'.StateT.apply_wp
+-  Std.Do'.ReaderT.apply_wp
+-  Std.Do'.WriterT.apply_wp
+-  StateT.run_bind StateT.run_pure StateT.run_get StateT.run_set
+-  StateT.run_modifyGet StateT.run_monadLift StateT.run_map StateT.run_lift
+-  ReaderT.run_bind ReaderT.run_pure ReaderT.run_monadLift ReaderT.run_read
+-  ReaderT.run_map
+-  WriterT.run_bind WriterT.run_pure WriterT.run_tell WriterT.run_monadLift
+-  WriterT.run_liftM WriterT.run_map
+-  OptionT.run_bind OptionT.run_pure OptionT.run_lift OptionT.run_failure
+-  OptionT.run_map
+-  ExceptT.run_bind ExceptT.run_pure ExceptT.run_lift ExceptT.run_throw
+-  ExceptT.run_map
+-  -- VCVio Loom bridges and the underlying quantitative `MAlgOrdered.wp`
+-  OracleComp.ProgramLogic.Loom.wp_eq_mAlgOrdered_wp
+-  OracleComp.ProgramLogic.Loom.wp_eq_mAlgOrdered_wp_epost
+-  MAlgOrdered.wp_bind MAlgOrdered.wp_pure MAlgOrdered.wp_map
+-  -- VCVio per-transformer `Loom.wp_*` peeling lemmas
+-  OracleComp.ProgramLogic.Loom.wp_StateT_bind
+-  OracleComp.ProgramLogic.Loom.wp_StateT_bind'
+-  OracleComp.ProgramLogic.Loom.wp_StateT_pure
+-  OracleComp.ProgramLogic.Loom.wp_StateT_get
+-  OracleComp.ProgramLogic.Loom.wp_StateT_set
+-  OracleComp.ProgramLogic.Loom.wp_StateT_modifyGet
+-  OracleComp.ProgramLogic.Loom.wp_StateT_monadLift
+-  OracleComp.ProgramLogic.Loom.wp_OptionT_bind
+-  OracleComp.ProgramLogic.Loom.wp_OptionT_pure
+-  OracleComp.ProgramLogic.Loom.wp_OptionT_failure
+-  OracleComp.ProgramLogic.Loom.wp_OptionT_monadLift
+-  OracleComp.ProgramLogic.Loom.wp_OptionT_lift
+-  OracleComp.ProgramLogic.Loom.wp_OptionT_map
+-  OracleComp.ProgramLogic.Loom.wp_ExceptT_bind
+-  OracleComp.ProgramLogic.Loom.wp_ExceptT_pure
+-  OracleComp.ProgramLogic.Loom.wp_ExceptT_throw
+-  OracleComp.ProgramLogic.Loom.wp_ExceptT_monadLift
+-  OracleComp.ProgramLogic.Loom.wp_ReaderT_bind
+-  OracleComp.ProgramLogic.Loom.wp_ReaderT_pure
+-  OracleComp.ProgramLogic.Loom.wp_ReaderT_read
+-  OracleComp.ProgramLogic.Loom.wp_ReaderT_monadLift
+-  OracleComp.ProgramLogic.Loom.WriterT.wp_bind
+-  OracleComp.ProgramLogic.Loom.WriterT.wp_pure
+-  OracleComp.ProgramLogic.Loom.WriterT.wp_tell
+-  OracleComp.ProgramLogic.Loom.WriterT.wp_monadLift
+-  OracleComp.ProgramLogic.Loom.WriterT.wp_map
+-  -- VCVio transformer-internal layer lemmas (defined above in this file)
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_get_layer
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_get_layer'
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_run_get_layer
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_run_get_layer'
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_set_layer
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_run_set_layer
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_run_set_layer'
+-  OracleComp.ProgramLogic.TacticInternals.Unary.mAlgOrdered_wp_OptionT_run_StateT_get
+-  OracleComp.ProgramLogic.TacticInternals.Unary.mAlgOrdered_wp_OptionT_run_StateT_set
+-  OracleComp.ProgramLogic.TacticInternals.Unary.mAlgOrdered_wp_OptionT_run_lift
+-  mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift
+-  mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift_map
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_OptionT_monadLift_lift
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_map_layer
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_read_layer
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_read_layer'
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_run_read_layer
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_run_read_layer'
+-  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_map_layer
+-  -- Algebraic monad/`EPost`/scalar rewrites used by both peel and close passes
+-  Std.Do'.EPost.cons.pushOption
+-  Std.Do'.EPost.cons.pushExcept
+-  Option.elimM
+-  pure_bind
+-  bind_pure_comp
+-  bind_map_left
+-  map_bind
+-  bind_assoc
+-  map_pure
+-  Functor.map_map
+-  MonadLift.monadLift
+-  monadLift_self
+-  monadLift_eq_self
+-  one_mul
+-  mul_one
+-  mul_assoc
+-
+-private def mkVCGenPlannedStep (label replayText : String) (run : TacticM Bool) : PlannedStep :=
+-  { label, replayText, run }
+-
+-private def hasProbGoal (target : Expr) : Bool :=
+-  (findAppWithHead? ``probEvent target).isSome || (findAppWithHead? ``probOutput target).isSome
+-
+-def throwWpStepError : TacticM Unit := withMainContext do
+-  let target ← instantiateMVars (← getMainTarget)
+-  match wpGoalComp? target with
+-  | none =>
+-      throwError "vcstep: expected a goal containing `wp`; got:{indentExpr target}"
+-  | some comp =>
+-      let comp ← instantiateMVars comp
+-      throwError
+-        "vcstep: found a `wp` goal, but none of the current single-step rules apply to:\n\
+-        {indentExpr comp}\n\
+-        Current rules handle bind, pure, `replicate`, `List.mapM`, `List.foldlM`, query, `if`, \
+-        uniform sampling, `map`, `simulateQ`, `simulateQ ... run'`, and `liftComp`."
+-
+-def runHoareStepRuleUsing (cut : TSyntax `term) : TacticM Bool := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  match tripleGoalComp? target with
+-  | some comp =>
+-      let comp ← instantiateMVars comp
+-      if isBindExpr comp then
+-        tryEvalTacticSyntax (← `(tactic|
+-          apply OracleComp.ProgramLogic.triple_bind (cut := $cut)))
+-      else
+-        return false
+-  | none => return false
+-
+-/-- Check whether an expression (possibly under `∀` quantifiers and `mdata`) contains
+- a unary triple application as its head. -/
+-private def hasTripleHead (e : Expr) : Bool :=
+-  let rec go : Expr → Bool
+-    | .forallE _ _ body _ => go body
+-    | .mdata _ e => go e
+-    | e => (tripleGoalComp? e).isSome
+-  go e
+-
+-/-- Extract the head function of the computation argument from a unary triple
+-application, after stripping `∀` quantifiers and `mdata`. -/
+-private def tripleCompFn? (e : Expr) : Option Expr :=
+-  let rec go : Expr → Option Expr
+-    | .forallE _ _ body _ => go body
+-    | .mdata _ e => go e
+-    | e => do
+-        let comp ← tripleGoalComp? e
+-        some comp.consumeMData.getAppFn
+-  go e
+-
+-/-- Try to close a `Triple` goal by targeted application of local hypotheses
+-whose type (possibly under `∀` quantifiers) has `Triple` as head and whose
+-computation argument structurally matches the goal's computation.
+-Much faster than `assumption` + `solve_by_elim` when the goal has unresolved metavariables,
+-because it skips expensive `isDefEq` checks against non-matching hypotheses. -/
+-private def tryApplyTripleHyp : TacticM Bool := withMainContext do
+-  let target ← instantiateMVars (← getMainTarget)
+-  let some goalCompFn := tripleCompFn? target | return false
+-  for ldecl in ← getLCtx do
+-    if ldecl.isImplementationDetail then continue
+-    let hypType ← instantiateMVars ldecl.type
+-    unless hasTripleHead hypType do continue
+-    let some hypCompFn := tripleCompFn? hypType | continue
+-    unless goalCompFn == hypCompFn do continue
+-    if ← tryEvalTacticSyntax (← `(tactic| exact $(mkIdent ldecl.userName))) then
+-      return true
+-    if hypType.isForall then
+-      let saved ← saveState
+-      if ← tryEvalTacticSyntax
+-          (← `(tactic| apply $(mkIdent ldecl.userName) <;> assumption)) then
+-        return true
+-      saved.restore
+-  return false
+-
+-/-- Peel known transformer `wp` layers in the current goal via the cached
+-`vcspec_simp` simp set. Always succeeds (errors and unchanged-goal results are
+-swallowed), since callers always `discard` the outcome and rely on later
+-structural dispatch to decide whether the goal can close. -/
+-private def peelKnownTransformerWPInGoal : TacticM Unit :=
+-  runVCSpecSimp
+-
+-/-- Class-method unfolds used by the close passes to expose `apply_wp` /
+-`*.run` projections through overloaded `Monad{State,Reader,Writer}Of` /
+-`StateT.{get,set,lift}` calls, plus the `Lean.Order.PartialOrder.rel` head
+-needed for the final `le_refl` step. Kept inline (rather than in
+-`vcspec_simp`) to avoid eager class-projection unfolding outside of close
+-contexts. -/
+-private def runVCSpecCloseUnfolds : TacticM Unit := do
+-  discard <| tryEvalTacticSyntax (← `(tactic|
+-    simp only [Lean.Order.PartialOrder.rel,
+-      MonadStateOf.get, MonadStateOf.set, MonadReaderOf.read, MonadWriter.tell,
+-      StateT.get, StateT.set, StateT.lift, ReaderT.read, WriterT.tell]))
+-
+-private def tryCloseNormalizedTransformerWP : TacticM Bool := do
+-  let saved ← saveState
+-  let target ← instantiateMVars (← getMainTarget)
+-  unless (tripleGoalComp? target).isSome do
+-    return false
+-  -- Overloaded operations such as `MonadStateOf.get` may not expose their
+-  -- concrete transformer type until the triple theorem has been applied.
+-  -- Speculate cheaply, then restore if the layer peeler cannot close.
+-  if ← tryEvalTacticSyntax (← `(tactic| refine Std.Do'.Triple.iff.mpr ?_)) then
+-    discard <| tryEvalTacticSyntax (← `(tactic| repeat intro _))
+-    runVCSpecCloseUnfolds
+-    runVCSpecSimp
+-    if (← getGoals).isEmpty then
+-      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic| exact le_refl _)) then
+-      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
+-      return true
+-    runVCSpecCloseUnfolds
+-    runVCSpecSimp
+-    discard <| tryEvalTacticSyntax (← `(tactic| repeat intro _))
+-    if (← getGoals).isEmpty then
+-      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic| exact le_refl _)) then
+-      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
+-      return true
+-  saved.restore
+-  return false
+-
+-private def tryApplySpecThenPeel (stx : TSyntax `tactic) : TacticM Bool := do
+-  let saved ← saveState
+-  if ← tryEvalTacticSyntax stx then
+-    discard <| tryEvalTacticSyntax (← `(tactic| repeat intro _))
+-    peelKnownTransformerWPInGoal
+-    discard <| tryEvalTacticSyntax (← `(tactic| repeat intro _))
+-    runVCSpecCloseUnfolds
+-    runVCSpecSimp
+-    if (← getGoals).isEmpty then
+-      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic| exact le_refl _)) then
+-      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
+-      return true
+-  saved.restore
+-  return false
+-
+-/-- Try to close the current goal using only immediate local information.
+-This is intentionally cheap: it is used while speculating on `triple_bind`, so it must not
+-launch expensive proof search on goals with unresolved cut metavariables. -/
+-def tryCloseSpecGoalImmediate : TacticM Bool := do
+-  tryApplyTripleHyp <||>
+-  tryCloseNormalizedTransformerWP <||>
+-  tryApplySpecThenPeel (← `(tactic| apply
+-    OracleComp.ProgramLogic.TacticInternals.Unary.stdDoTriple_StateT_get_of_rel)) <||>
+-  tryApplySpecThenPeel (← `(tactic| apply
+-    OracleComp.ProgramLogic.TacticInternals.Unary.stdDoTriple_ReaderT_read_of_rel)) <||>
+-  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.get_StateT)) <||>
+-  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.set_StateT)) <||>
+-  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.modifyGet_StateT)) <||>
+-  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.monadLift_StateT)) <||>
+-  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.read_ReaderT)) <||>
+-  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.monadLift_ReaderT)) <||>
+-  tryEvalTacticSyntax (← `(tactic| assumption)) <||>
+-  tryEvalTacticSyntax (← `(tactic| solve_by_elim (maxDepth := 2))) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_pure _ _)) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_zero _ _)) <||>
+-  tryEvalTacticSyntax (← `(tactic| exact le_refl _)) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_ofLE le_rfl))
+-
+-/-- Try bounded local proof search on a closed goal.
+-We only invoke `solve_by_elim` once the target has no unresolved expression metavariables; this
+-avoids pathological search on speculative intermediate cuts introduced by `triple_bind`. -/
+-def tryCloseSpecGoalSearch : TacticM Bool := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  if target.hasExprMVar then
+-    return false
+-  tryEvalTacticSyntax (← `(tactic| (
+-    repeat intro
+-    simp only [OracleComp.ProgramLogic.triple_iff_le_wp] at *
+-    solve_by_elim (maxDepth := 6) [OracleComp.ProgramLogic.wp_mono, le_trans]
+-  )))
+-
+-private def closeTheoremStepGoals : TacticM Unit := do
+-  let goals ← getGoals
+-  let mut remaining : List MVarId := []
+-  for goal in goals do
+-    if ← goal.isAssigned then continue
+-    setGoals [goal]
+-    unless ← tryCloseSpecGoalImmediate do
+-      remaining := remaining ++ [goal]
+-  setGoals remaining
+-  unless remaining.isEmpty do
+-    discard <| tryEvalTacticSyntax (← `(tactic|
+-      all_goals first
+-        | assumption
+-        | simp [Lean.Order.PartialOrder.rel]
+-        | (repeat intro; split_ifs <;> simp_all [Lean.Order.PartialOrder.rel])
+-        | (
+-            repeat intro
+-            simp only [OracleComp.ProgramLogic.triple_iff_le_wp] at *
+-            solve_by_elim (maxDepth := 4) [OracleComp.ProgramLogic.wp_mono, le_trans]
+-          )))
+-
+-private def runVCGenStepWithTheoremDirect
+-    (thm : TSyntax `term) (requireClosed : Bool := false) : TacticM Bool := do
+-  let saved ← saveState
+-  let ok ←
+-    match ← observing? do
+-      evalTactic (← `(tactic| apply $thm))
+-      closeTheoremStepGoals
+-    with
+-    | some _ => pure true
+-    | none => pure false
+-  if ok && (!(requireClosed) || (← getGoals).isEmpty) then
+-    return true
+-  saved.restore
+-  return false
+-
+-private def runVCGenStepWithTheoremConseq
+-    (thm : TSyntax `term) (requireClosed : Bool := false) : TacticM Bool := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  unless (tripleGoalComp? target).isSome do
+-    return false
+-  let saved ← saveState
+-  let ok ←
+-    match ← observing? do
+-      evalTactic (← `(tactic| refine OracleComp.ProgramLogic.triple_conseq le_rfl ?_ $thm))
+-      closeTheoremStepGoals
+-    with
+-    | some _ => pure true
+-    | none => pure false
+-  if ok && (!(requireClosed) || (← getGoals).isEmpty) then
+-    return true
+-  saved.restore
+-  return false
+-
+-/-- Apply a `@[vcspec]` unary rule to the current goal.
+-Default `vcstep` first tries the cached rule directly. For folded unary
+-`Triple` goals, a global declaration can also be applied under `triple_conseq`,
+-which lets a registered concrete postcondition theorem feed a weaker goal
+-postcondition. -/
+-private def runUnaryVCSpecRule
+-    (entry : VCSpecEntry) (requireClosed : Bool := false) : TacticM Bool := do
+-  if entry.kind == .unaryWP then
+-    let saved ← saveState
+-    let ok ←
+-      match ← observing? do
+-        unless ← runVCSpecEntryRawUnaryConsequence entry do
+-          throwError "vcstep: raw unary `@[vcspec]` consequence did not apply"
+-        closeTheoremStepGoals
+-      with
+-      | some _ => pure true
+-      | none => pure false
+-    if ok && (!(requireClosed) || (← getGoals).isEmpty) then
+-      return true
+-    saved.restore
+-  let saved ← saveState
+-  let ok ←
+-    match ← observing? do
+-      unless ← runVCSpecEntryCachedBackward entry do
+-        throwError "vcstep: registered `@[vcspec]` rule did not apply"
+-      closeTheoremStepGoals
+-    with
+-    | some _ => pure true
+-    | none => pure false
+-  if ok && (!(requireClosed) || (← getGoals).isEmpty) then
+-    return true
+-  saved.restore
+-  return false
+-
+-/-- Apply an explicit unary theorem/assumption step and try to close any easy side goals.
+-When `requireClosed` is true, the step only succeeds if no goals remain afterwards. -/
+-def runVCGenStepWithTheorem (thm : TSyntax `term) (requireClosed : Bool := false) :
+-    TacticM Bool := do
+-  if ← runVCGenStepWithTheoremDirect thm requireClosed then
+-    return true
+-  runVCGenStepWithTheoremConseq thm requireClosed
+-
+-/-- Try to close the current goal (typically a `Triple` subgoal) using direct hypotheses,
+-canonical leaf rules, or bounded local consequence search. -/
+-def tryCloseSpecGoal : TacticM Bool := do
+-  tryCloseSpecGoalImmediate <||> tryCloseSpecGoalSearch
+-
+-/-- Normalize Loom's unary triple head to VCVio's quantitative `Triple` abbrev.
+-
+-The two goals are definitionally equal for `OracleComp` with the no-exception
+-postcondition, but proof terms produced directly against the `Std.Do'.Triple`
+-head can trip Lean's kernel on anonymous proofs. Normalizing before structural
+-steps keeps the Loom notation surface while making the unary tactic operate on
+-its historical canonical head. -/
+-private def normalizeStdDoTripleGoal : TacticM Bool := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  unless (findAppWithHead? ``Std.Do'.Triple target).isSome do
+-    return false
+-  tryEvalTacticSyntax (← `(tactic| change OracleComp.ProgramLogic.Triple _ _ _))
+-
+-/-- Finish-only closure step: includes the support-sensitive leaf rules that are too expensive
+-for the default `vcstep` hot path. -/
+-def tryCloseSpecGoalFinal : TacticM Bool := do
+-  tryApplyTripleHyp <||>
+-  tryCloseNormalizedTransformerWP <||>
+-  tryEvalTacticSyntax (← `(tactic| assumption)) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_pure _ _)) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_zero _ _)) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    classical
+-    exact OracleComp.ProgramLogic.triple_support _)) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_propInd_of_support _ _ (by assumption))) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_probEvent_eq_one _ _ (by assumption))) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_probOutput_eq_one _ _ (by assumption))) <||>
+-  tryEvalTacticSyntax (← `(tactic| exact le_refl _)) <||>
+-  tryEvalTacticSyntax (← `(tactic|
+-    exact OracleComp.ProgramLogic.triple_ofLE le_rfl)) <||>
+-  tryCloseSpecGoalSearch
+-
+-/-- Run one bounded finish/closure pass across all current goals. -/
+-def runVCGenClosePass : TacticM Bool := do
+-  let goals ← getGoals
+-  if goals.isEmpty then
+-    return false
+-  let mut progress := false
+-  let mut newGoals : List MVarId := []
+-  for goal in goals do
+-    setGoals [goal]
+-    if ← withVCGenCloseTiming tryCloseSpecGoalFinal then
+-      progress := true
+-      newGoals := newGoals ++ (← getGoals)
+-    else
+-      newGoals := newGoals ++ [goal]
+-  setGoals newGoals
+-  return progress
+-
+-/-- Try to decompose a `match` expression in the computation by case-splitting
+-on its discriminant(s). Only fires when the computation is a compiled matcher
+-(detected via `matchMatcherApp?`). Delegates to `split` which handles the actual
+-case analysis. -/
+-def tryMatchDecomp (comp : Expr) : TacticM Bool := do
+-  let some _ ← Lean.Meta.matchMatcherApp? comp | return false
+-  tryEvalTacticSyntax (← `(tactic| split))
+-
+-/-- Check if an expression is a lambda whose body does not use the bound variable
+-(i.e. a constant function `fun _ => c`). -/
+-def isConstantLambda (e : Expr) : Bool :=
+-  match e.consumeMData with
+-  | .lam _ _ body _ => !body.hasLooseBVar 0
+-  | _ => false
+-
+-/-- Try the strongest automatic bind step: `triple_bind` plus immediate closure of the
+-spec side-goal. -/
+-def tryBindImmediate (comp : Expr) : TacticM Bool := do
+-  if !isBindExpr comp then
+-    return false
+-  match ← observing? do
+-    evalTactic (← `(tactic|
+-      first
+-        | apply OracleComp.ProgramLogic.triple_bind
+-        | apply Std.Do'.Triple.bind))
+-    unless ← tryCloseSpecGoalImmediate do throwError "" with
+-  | some _ => return true
+-  | none => return false
+-
+-/-- Try only the automatic loop-invariant rules, without the structural fallback rules. -/
+-def tryLoopInvariantRuleAuto (comp : Expr) : TacticM Bool := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  let some (_pre, _comp, post) := tripleGoalParts? target | return false
+-  if isReplicateHead comp then
+-    if isConstantLambda post then
+-      match ← observing? do
+-        evalTactic (← `(tactic| apply OracleComp.ProgramLogic.triple_replicate_inv))
+-        unless ← tryCloseSpecGoalImmediate do throwError "" with
+-      | some _ => return true
+-      | none => pure ()
+-  if isListFoldlMHead comp then
+-    match ← observing? do
+-      evalTactic (← `(tactic| apply OracleComp.ProgramLogic.triple_list_foldlM_inv))
+-      unless ← tryCloseSpecGoalImmediate do throwError "" with
+-    | some _ => return true
+-    | none => pure ()
+-  if isListMapMHead comp then
+-    if isConstantLambda post then
+-      match ← observing? do
+-        evalTactic (← `(tactic| apply OracleComp.ProgramLogic.triple_list_mapM_inv))
+-        unless ← tryCloseSpecGoalImmediate do throwError "" with
+-      | some _ => return true
+-      | none => pure ()
+-  return false
+-
+-/-- Try only the structural loop fallback rules (`succ` / `cons`) after invariant search. -/
+-def tryLoopFallback (comp : Expr) : TacticM Bool := do
+-  if isReplicateHead comp then
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        apply OracleComp.ProgramLogic.triple_replicate_succ)) then
+-      return true
+-  if isListFoldlMHead comp then
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        apply OracleComp.ProgramLogic.triple_list_foldlM_cons)) then
+-      return true
+-  if isListMapMHead comp then
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        apply OracleComp.ProgramLogic.triple_list_mapM_cons)) then
+-      return true
+-  return false
+-
+-/-- Apply a loop invariant rule with an explicitly provided invariant. -/
+-def runLoopInvExplicit (inv : TSyntax `term) : TacticM Bool := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  match tripleGoalComp? target with
+-  | none => return false
+-  | some comp =>
+-    let comp ← whnfReducible (← instantiateMVars comp)
+-    if isReplicateHead comp then
+-      tryEvalTacticSyntax (← `(tactic|
+-        refine OracleComp.ProgramLogic.triple_replicate (I := $inv) ?_ ?_ ?_))
+-    else if isListFoldlMHead comp then
+-      tryEvalTacticSyntax (← `(tactic|
+-        refine OracleComp.ProgramLogic.triple_list_foldlM (I := $inv) ?_ ?_ ?_))
+-    else if isListMapMHead comp then
+-      tryEvalTacticSyntax (← `(tactic|
+-        refine OracleComp.ProgramLogic.triple_list_mapM (I := $inv) ?_ ?_ ?_))
+-    else
+-      return false
+-
+-/-- Find the local hypotheses that work as explicit bind cuts. -/
+-def findHoareCutHintCandidates : TacticM (Array Name) :=
+-  withVCGenLocalHintTiming <| withMainContext do
+-    let target ← instantiateMVars (← getMainTarget)
+-    let some comp := tripleGoalComp? target | return #[]
+-    let comp ← whnfReducible (← instantiateMVars comp)
+-    unless isBindExpr comp do return #[]
+-    let mut found : Array Name := #[]
+-    for localDecl in ← getLCtx do
+-      unless localDecl.isImplementationDetail do
+-        let name := localDecl.userName
+-        if isUsableBinderName name then
+-          let type ← instantiateMVars localDecl.type
+-          unless type.isSort do
+-            let saved ← saveState
+-            let ok ← runHoareStepRuleUsing (mkIdent name)
+-            saved.restore
+-            if ok then
+-              found := found.push name
+-    return found
+-
+-/-- Find the unique local hypothesis that works as an explicit bind cut.
+-Returns `none` if there are 0 or ≥ 2 viable candidates. -/
+-def findUniqueHoareCutHint? : TacticM (Option Name) := do
+-  let found ← findHoareCutHintCandidates
+-  return found.toList.head? >>= fun first =>
+-    if found.size = 1 then some first else none
+-
+-/-- Find the local hypotheses that work as explicit loop invariants. -/
+-def findLoopInvHintCandidates : TacticM (Array Name) :=
+-  withVCGenLocalHintTiming <| withMainContext do
+-    let target ← instantiateMVars (← getMainTarget)
+-    let some comp := tripleGoalComp? target | return #[]
+-    let comp ← whnfReducible (← instantiateMVars comp)
+-    unless isReplicateHead comp || isListFoldlMHead comp || isListMapMHead comp do
+-      return #[]
+-    let mut found : Array Name := #[]
+-    for localDecl in ← getLCtx do
+-      unless localDecl.isImplementationDetail do
+-        let name := localDecl.userName
+-        if isUsableBinderName name then
+-          let type ← instantiateMVars localDecl.type
+-          unless type.isSort do
+-            let saved ← saveState
+-            let ok ← runLoopInvExplicit (mkIdent name)
+-            saved.restore
+-            if ok then
+-              found := found.push name
+-    return found
+-
+-/-- Find the unique local hypothesis that works as an explicit loop invariant.
+-Returns `none` if there are 0 or ≥ 2 viable candidates. -/
+-def findUniqueLoopInvHint? : TacticM (Option Name) := do
+-  let found ← findLoopInvHintCandidates
+-  return found.toList.head? >>= fun first =>
+-    if found.size = 1 then some first else none
+-
+-private def potentialLocalHintNames : TacticM (Array Name) := withMainContext do
+-  let mut names : Array Name := #[]
+-  for localDecl in ← getLCtx do
+-    unless localDecl.isImplementationDetail do
+-      let name := localDecl.userName
+-      if isUsableBinderName name then
+-        let type ← instantiateMVars localDecl.type
+-        unless type.isSort do
+-          names := names.push name
+-  return names
+-
+-private def unaryGoalKindAndComp? (target : Expr) : Option (VCSpecKind × Expr) :=
+-  match tripleGoalComp? target with
+-  | some comp => some (.unaryTriple, comp)
+-  | none =>
+-      match wpGoalComp? target with
+-      | some comp => some (.unaryWP, comp)
+-      | none => none
+-
+-private def takeCandidatePrefix (entries : Array VCSpecEntry) : Array VCSpecEntry :=
+-  (entries.toList.take 8).toArray
+-
+-private def registeredVCGenRuleCandidateTiers : TacticM (Array (Array VCSpecEntry)) := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  let some (kind, comp) := unaryGoalKindAndComp? target | return #[]
+-  let goalPattern := classifyUnaryCompPattern comp
+-  let direct :=
+-    (← getRegisteredUnaryVCSpecEntries comp).filter (·.kind == kind)
+-  let fallbackAll :=
+-    (← getVCSpecEntriesOfKind kind).filter fun entry =>
+-      !(direct.any fun directEntry => directEntry.theoremName! == entry.theoremName!)
+-  let fallbackPreferred := fallbackAll.filter (·.spec.compPattern == goalPattern)
+-  let fallbackFallback := fallbackAll.filter (·.spec.compPattern != goalPattern)
+-  let mut tiers : Array (Array VCSpecEntry) := #[]
+-  for tier in #[direct, fallbackPreferred, fallbackFallback] do
+-    let tier := takeCandidatePrefix tier
+-    unless tier.isEmpty do
+-      tiers := tiers.push tier
+-  return tiers
+-
+-/-- Find the registered unary `@[vcspec]` entries whose bounded application
+-makes progress on the current goal. Prefers direct discrimination-tree hits on
+-the goal's `comp`, falling back to kind-matched entries filtered by structural
+-compatibility. -/
+-def findRegisteredVCGenRuleCandidates : TacticM (Array VCSpecEntry) := do
+-  withVCGenRegisteredTiming do
+-    for tier in ← registeredVCGenRuleCandidateTiers do
+-      let mut found : Array VCSpecEntry := #[]
+-      for entry in tier do
+-        let saved ← saveState
+-        let ok ← runUnaryVCSpecRule entry
+-        saved.restore
+-        if ok then
+-          found := found.push entry
+-      unless found.isEmpty do
+-        return found
+-    return #[]
+-
+-/-- Find the first registered unary `@[vcspec]` entry whose bounded
+-application makes progress. -/
+-def findRegisteredVCGenRule? : TacticM (Option VCSpecEntry) := do
+-  withVCGenRegisteredTiming do
+-    for tier in ← registeredVCGenRuleCandidateTiers do
+-      for entry in tier do
+-        let saved ← saveState
+-        let ok ← runUnaryVCSpecRule entry
+-        saved.restore
+-        if ok then
+-          return some entry
+-    return none
+-
+-/-- Try registered `@[vcspec]` rules against a raw `wp` goal.
+-
+-This is intentionally direct-hit only: raw `wp` stepping is on the hot path, so
+-we use the discrimination tree and avoid same-kind fallback scans. -/
+-private def runRawWpVCSpecBackward : TacticM Bool := do
+-  withVCGenRegisteredTiming do
+-    let target ← instantiateMVars (← getMainTarget)
+-    let comp? :=
+-      match rawWPGoalParts? target with
+-      | some (_, comp, _) => some comp
+-      | none => wpGoalComp? target
+-    let some comp := comp? | return false
+-    let comp ← instantiateMVars comp
+-    let goalPattern := classifyUnaryCompPattern comp
+-    let entries ← getRegisteredUnaryVCSpecEntriesNoWhnf comp
+-    let entries :=
+-      takeCandidatePrefix <|
+-        entries.filter (fun entry =>
+-          entry.kind == .unaryWP && entry.spec.compPattern == goalPattern) ++
+-          entries.filter (fun entry => entry.kind == .unaryTriple &&
+-            entry.spec.compPattern == goalPattern)
+-    for entry in entries do
+-      if ← runUnaryVCSpecRule entry then
+-        return true
+-    return false
+-
+-def throwVCGenStepError : TacticM Unit := withMainContext do
+-  let target ← instantiateMVars (← getMainTarget)
+-  match tripleGoalComp? target with
+-  | none =>
+-      if hasProbGoal target then
+-        if isProbEqGoal target then
+-          throwError
+-            "vcstep: found a `Pr[ ...] = Pr[ ...]` goal but no swap or congruence rule applied.\n\
+-            Goal:{indentExpr target}\n\
+-            Try `vcstep rw`, `vcstep rw under 1`, `vcstep rw congr`, \
+-            `vcstep rw congr'`, `vcstep?`, or manual rewriting with \
+-            `probEvent_bind_bind_swap`."
+-        else
+-          throwError
+-            "vcstep: found a probability goal but could not lower it to a supported\n\
+-            `Triple` or raw `wp` shape.\n\
+-            Goal:{indentExpr target}\n\
+-            Supported direct lowerings include `Pr[ ...] = 1`, `Pr[ ...] = Pr[ ...]`,\n\
+-            and lower bounds such as `r ≤ Pr[ ...]` / `Pr[ ...] ≥ r`.\n\
+-            Try `rw [probEvent_eq_wp_propInd]`, `vcstep?`, or manual rewriting."
+-      else if let some comp := wpGoalComp? target then
+-        let comp ← whnfReducible (← instantiateMVars comp)
+-        let theoremMsg ← do
+-          let tiers ← registeredVCGenRuleCandidateTiers
+-          let thms := tiers.foldl (init := #[]) fun acc tier =>
+-            acc ++ tier.map (·.theoremName!)
+-          pure <| if thms.isEmpty then "" else
+-            s!"\nRegistered `@[vcspec]` candidates: {formatCandidateNames thms}"
+-        throwError
+-          "vcstep: currently in raw `wp` continuation mode, but no matching rule applied to:\n\
+-          {indentExpr comp}\n\
+-          Try `vcstep?`, `vcstep`, or manual rewriting.{theoremMsg}"
+-      else
+-        throwError
+-          "vcstep: expected a `Triple`, raw `wp`, or probability goal; got:{indentExpr target}"
+-  | some comp =>
+-      let comp ← whnfReducible (← instantiateMVars comp)
+-      let cutMsg ←
+-        if isBindExpr comp then
+-          let cuts ← potentialLocalHintNames
+-          pure <| if cuts.isEmpty then "" else
+-            s!"\nPotential local cut candidates: {formatCandidateNames cuts}"
+-        else
+-          pure ""
+-      let invMsg ←
+-        if isReplicateHead comp || isListFoldlMHead comp || isListMapMHead comp then
+-          let invs ← potentialLocalHintNames
+-          pure <| if invs.isEmpty then "" else
+-            s!"\nPotential local invariant candidates: {formatCandidateNames invs}"
+-        else
+-          pure ""
+-      let theoremMsg ← do
+-        let tiers ← registeredVCGenRuleCandidateTiers
+-        let thms := tiers.foldl (init := #[]) fun acc tier =>
+-          acc ++ tier.map (·.theoremName!)
+-        pure <| if thms.isEmpty then "" else
+-          s!"\nRegistered `@[vcspec]` candidates: {formatCandidateNames thms}"
+-      throwError
+-        "vcstep: found a `Triple` goal, but no matching rule applied to:{indentExpr comp}\n\
+-        Try `vcstep`, or manually unfolding the remaining arithmetic side conditions.\
+-        {cutMsg}{invMsg}{theoremMsg}"
+-
+-/-- Try to close or rewrite a `Pr[ ...] = Pr[ ...]` goal by swapping adjacent independent binds.
+-Handles 0–2 layers of tsum peeling. -/
+-inductive ProbEqAction where
+-  | swap
+-  | congr
+-  | congrNoSupport
+-  | rewrite
+-  | rewriteUnder (depth : Nat)
+-
+-private def normalizeProbEqGoal : TacticM Unit := do
+-  discard <| tryEvalTacticSyntax (← `(tactic|
+-    simp only [map_eq_bind_pure_comp, bind_assoc]))
+-
+-def runProbEqSwap : TacticM Bool := do
+-  normalizeProbEqGoal
+-  tryEvalTacticSyntax (← `(tactic| (
+-    try simp only [bind_assoc]
+-    first
+-      | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
+-         exact probEvent_bind_bind_swap _ _ _ _)
+-      | (rw [show Pr[ _ | _ >>= fun a => _ >>= fun b => _] =
+-              Pr[ _ | _ >>= fun b => _ >>= fun a => _] from
+-            probEvent_bind_bind_swap _ _ _ _])
+-      | (conv in (Pr[ _ | _]) =>
+-          rw [show Pr[ _ | _ >>= fun a => _ >>= fun b => _] =
+-                Pr[ _ | _ >>= fun b => _ >>= fun a => _] from
+-              probEvent_bind_bind_swap _ _ _ _])
+-      | (rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
+-         refine tsum_congr fun _ => ?_
+-         congr 1
+-         try simp only [monad_norm]
+-         first
+-           | exact probEvent_bind_bind_swap _ _ _ _
+-           | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
+-              exact probEvent_bind_bind_swap _ _ _ _))
+-      | (rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
+-         refine tsum_congr fun _ => ?_
+-         congr 1
+-         rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
+-         refine tsum_congr fun _ => ?_
+-         congr 1
+-         try simp only [monad_norm]
+-         first
+-           | exact probEvent_bind_bind_swap _ _ _ _
+-           | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
+-              exact probEvent_bind_bind_swap _ _ _ _)))))
+-
+-def runProbEqCongrNoSupportWithNames (names : Array Name) : TacticM Bool := do
+-  normalizeProbEqGoal
+-  if ← tryEvalTacticSyntax (← `(tactic| apply probOutput_bind_congr')) then
+-    discard <| introMainGoalNames names
+-    return true
+-  if ← tryEvalTacticSyntax (← `(tactic| apply probEvent_bind_congr')) then
+-    discard <| introMainGoalNames names
+-    return true
+-  return false
+-
+-def runProbEqCongrNoSupport : TacticM Bool := do
+-  let names ← getProbCongrNames false
+-  runProbEqCongrNoSupportWithNames names
+-
+-/-- Try to decompose a `Pr[ ... | mx >>= f₁] = Pr[ ... | mx >>= f₂]` goal by congruence,
+-then auto-intro the bound variable and support hypothesis. -/
+-def runProbEqCongrWithNames (names : Array Name) : TacticM Bool := do
+-  normalizeProbEqGoal
+-  if ← tryEvalTacticSyntax (← `(tactic| apply probOutput_bind_congr)) then
+-    discard <| introMainGoalNames names
+-    return true
+-  if ← tryEvalTacticSyntax (← `(tactic| apply probEvent_bind_congr)) then
+-    discard <| introMainGoalNames names
+-    return true
+-  return false
+-
+-def runProbEqCongr : TacticM Bool := do
+-  let names ← getProbCongrNames true
+-  if ← runProbEqCongrWithNames names then
+-    return true
+-  runProbEqCongrNoSupport
+-
+-private def chunkNameArray
+-    (names : Array Name) (width : Nat) : Option (Array (Array Name)) := Id.run do
+-  if width = 0 || names.isEmpty then
+-    return none
+-  if names.size % width != 0 then
+-    return none
+-  let mut chunks : Array (Array Name) := #[]
+-  let mut i := 0
+-  while i < names.size do
+-    chunks := chunks.push (names.extract i (i + width))
+-    i := i + width
+-  return some chunks
+-
+-def runProbEqCongrChainWithNames
+-    (supportSensitive : Bool) (names : Array Name) : TacticM Bool := do
+-  let width := if supportSensitive then 2 else 1
+-  let some chunks := chunkNameArray names width | return false
+-  let saved ← saveState
+-  for chunk in chunks do
+-    let ok ←
+-      if supportSensitive then
+-        runProbEqCongrWithNames chunk
+-      else
+-        runProbEqCongrNoSupportWithNames chunk
+-    if !ok then
+-      saved.restore
+-      return false
+-  return true
+-
+-/-- Build a theorem that swaps adjacent binds under `depth` shared prefixes. -/
+-partial def mkProbSwapUnderProof (depth : Nat) : TacticM (TSyntax `term) := do
+-  match depth with
+-  | 0 => `(term| probEvent_bind_bind_swap _ _ _ _)
+-  | depth + 1 =>
+-      let inner ← mkProbSwapUnderProof depth
+-      `(term| probEvent_bind_congr fun _ _ => $inner)
+-
+-/-- Try to rewrite one top-level bind-swap without closing the goal. -/
+-def runProbEqRewrite : TacticM Bool := do
+-  normalizeProbEqGoal
+-  tryEvalTacticSyntax (← `(tactic| (
+-    first
+-      | (simp only [← probEvent_eq_eq_probOutput]
+-         rw [probEvent_bind_bind_swap]
+-         try simp only [probEvent_eq_eq_probOutput])
+-      | rw [probEvent_bind_bind_swap])))
+-
+-/-- Try to rewrite one bind-swap under `depth` shared prefixes on either side. -/
+-def runProbEqRewriteUnder (depth : Nat) : TacticM Bool := do
+-  normalizeProbEqGoal
+-  let proof ← mkProbSwapUnderProof depth
+-  tryEvalTacticSyntax (← `(tactic| (
+-    first
+-      | (simp only [← probEvent_eq_eq_probOutput]
+-         first
+-           | (conv_lhs => rw [show _ from $proof])
+-           | (conv_rhs => rw [show _ from $proof])
+-         try simp only [probEvent_eq_eq_probOutput])
+-      | first
+-          | (conv_lhs => rw [show _ from $proof])
+-          | (conv_rhs => rw [show _ from $proof]))))
+-
+-def runProbEqAction : ProbEqAction → TacticM Bool
+-  | .swap => runProbEqSwap
+-  | .congr => runProbEqCongr
+-  | .congrNoSupport => runProbEqCongrNoSupport
+-  | .rewrite => runProbEqRewrite
+-  | .rewriteUnder depth =>
+-      if depth = 0 then
+-        runProbEqRewrite
+-      else
+-        runProbEqRewriteUnder depth
+-
+-private def renderProbEqAction : ProbEqAction → TacticM String
+-  | .swap => pure "vcstep"
+-  | .congr => do
+-      let names ← getProbCongrNames true
+-      pure s!"vcstep rw congr{renderAsClause names}"
+-  | .congrNoSupport => do
+-      let names ← getProbCongrNames false
+-      pure s!"vcstep rw congr'{renderAsClause names}"
+-  | .rewrite => pure "vcstep rw"
+-  | .rewriteUnder depth => pure s!"vcstep rw under {depth}"
+-
+-private def renderProbEqPlan (actions : List ProbEqAction) : TacticM String := do
+-  let parts ← actions.mapM renderProbEqAction
+-  match parts with
+-  | [] => pure "vcstep"
+-  | [part] => pure part
+-  | _ => pure s!"({String.intercalate "; " parts})"
+-
+-/-- Try a small backtracking-free sequence of probability-equality steps. -/
+-def tryProbEqActions (steps : List ProbEqAction) : TacticM Bool := do
+-  let saved ← saveState
+-  for step in steps do
+-    if (← getGoals).isEmpty then
+-      return true
+-    if !(← runProbEqAction step) then
+-      saved.restore
+-      return false
+-  return true
+-
+-private def chooseBestProbEqPlan? (plans : List (List ProbEqAction)) :
+-    TacticM (Option (List ProbEqAction × PreviewResult)) := do
+-  withVCGenProbPlannerTiming do
+-    let mut best? : Option (List ProbEqAction × PreviewResult) := none
+-    for plan in plans do
+-      let preview ← previewActionWithGoals (tryProbEqActions plan)
+-      if preview.ok then
+-        if preview.goalCount = 0 then
+-          return some (plan, preview)
+-        match best? with
+-        | none => best? := some (plan, preview)
+-        | some (_, bestPreview) =>
+-            if preview.goalCount < bestPreview.goalCount then
+-              best? := some (plan, preview)
+-    return best?
+-
+-private def mkRewriteChain (depth : Nat) : List ProbEqAction :=
+-  ((List.range depth).reverse.map fun idx => ProbEqAction.rewriteUnder (idx + 1)) ++
+-    [ProbEqAction.rewrite]
+-
+-private def probEqCongrPlans (maxDepth : Nat) : List (List ProbEqAction) :=
+-  let layers := (List.range maxDepth).map fun idx =>
+-    let depth := idx + 1
+-    [List.replicate depth ProbEqAction.congr,
+-      List.replicate depth ProbEqAction.congrNoSupport]
+-  layers.foldr List.append []
+-
+-private def probEqRewritePlans (maxDepth : Nat) : List (List ProbEqAction) :=
+-  let layers := ((List.range (maxDepth + 1)).reverse.map fun depth =>
+-    let chain := mkRewriteChain depth
+-    [chain ++ [ProbEqAction.congr], chain ++ [ProbEqAction.congrNoSupport], chain])
+-  layers.foldr List.append []
+-
+-def probEqActionPlans : List (List ProbEqAction) :=
+-  [ [.swap]
+-  , [.congr]
+-  , [.congrNoSupport]
+-  , [.rewrite, .congr]
+-  , [.rewrite, .congrNoSupport]
+-  , [.congr, .swap]
+-  , [.congrNoSupport, .swap]
+-  , [.rewriteUnder 1, .rewrite, .congr]
+-  , [.rewriteUnder 1, .rewrite, .congrNoSupport]
+-  , [.rewriteUnder 1, .rewrite]
+-  , [.rewriteUnder 2, .rewriteUnder 1, .rewrite, .congr]
+-  , [.rewriteUnder 2, .rewriteUnder 1, .rewrite, .congrNoSupport]
+-  , [.rewriteUnder 2, .rewriteUnder 1, .rewrite]
+-  ]
+-
+-private def probEqPlannerActionPlans : List (List ProbEqAction) :=
+-  probEqRewritePlans 4 ++ probEqCongrPlans 3 ++
+-    [ [.congr]
+-    , [.congrNoSupport]
+-    , [.congr, .swap]
+-    , [.congrNoSupport, .swap]
+-    , [.swap]
+-    ]
+-
+-private def probExprComp? (expr : Expr) : Option Expr := do
+-  let app ←
+-    match findAppWithHead? ``probOutput expr with
+-    | some app => some app
+-    | none => findAppWithHead? ``probEvent expr
+-  let args ← trailingArgs? app 2
+-  let #[comp, _] := args | none
+-  some comp
+-
+-private partial def topBindDepth (expr : Expr) : Nat :=
+-  let expr := expr.consumeMData
+-  if isBindExpr expr then
+-    let args := expr.getAppArgs
+-    if h : 0 < args.size then
+-      let k := args[args.size - 1]
+-      match k.consumeMData with
+-      | .lam _ _ body _ => topBindDepth body + 1
+-      | _ => 1
+-    else
+-      1
+-  else
+-    0
+-
+-private def probEqBindDepth? (target : Expr) : Option Nat := do
+-  let target := target.consumeMData
+-  guard <| target.isAppOfArity ``Eq 3
+-  let lhsComp ← probExprComp? (target.getArg! 1)
+-  let rhsComp ← probExprComp? (target.getArg! 2)
+-  some (Nat.min (topBindDepth lhsComp) (topBindDepth rhsComp))
+-
+-private def probEqPlannerActionPlansForDepth (bindDepth : Nat) : List (List ProbEqAction) :=
+-  let maxRewriteDepth := Nat.min 4 (bindDepth - 2)
+-  let maxCongrDepth := Nat.min 3 bindDepth
+-  probEqRewritePlans maxRewriteDepth ++ probEqCongrPlans maxCongrDepth ++
+-    [ [.congr]
+-    , [.congrNoSupport]
+-    , [.congr, .swap]
+-    , [.congrNoSupport, .swap]
+-    , [.swap]
+-    ]
+-
+-private def probEqPlannerActionPlansForGoal : TacticM (List (List ProbEqAction)) := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  match probEqBindDepth? target with
+-  | some depth => return probEqPlannerActionPlansForDepth depth
+-  | none => return probEqPlannerActionPlans
+-
+-def tryProbEqPlans (plans : List (List ProbEqAction)) : TacticM Bool := do
+-  match ← chooseBestProbEqPlan? plans with
+-  | none => return false
+-  | some (plan, _) => tryProbEqActions plan
+-
+-/-- Explicit probability-equality normalization.
+-
+-This runs the deeper planner-backed bind-rewrite/congruence search used by `vcstep?`, but only
+-when the user asks for it. Plain `vcstep` keeps the smaller default plan set. -/
+-def runProbEqNormalize : TacticM Bool := do
+-  for plan in ← probEqPlannerActionPlansForGoal do
+-    let preview ← previewActionWithGoals (tryProbEqActions plan)
+-    if preview.ok && preview.goalCount = 0 then
+-      return (← tryProbEqActions plan)
+-  return false
+-
+-/-- Try to handle a `Pr[ ...] = Pr[ ...]` equality goal by swap, congr, or swap+congr.
+-Also tries a fallback bridge from exact `probOutput` equalities into relational VCGen. -/
+-def runProbOutputEqRelBridge : TacticM Bool := do
+-  let saved ← saveState
+-  let tryBridge (symmFirst : Bool) : TacticM Bool := do
+-    match ← observing? do
+-      if symmFirst then
+-        evalTactic (← `(tactic| symm))
+-      evalTactic (← `(tactic|
+-        apply OracleComp.ProgramLogic.Relational.probOutput_eq_of_relTriple_eqRel))
+-    with
+-    | some _ => return true
+-    | none => return false
+-  if ← tryBridge false then
+-    return true
+-  saved.restore
+-  if ← tryBridge true then
+-    return true
+-  saved.restore
+-  return false
+-
+-/-- Try to handle a `Pr[ ...] = Pr[ ...]` equality goal by swap, congr, or swap+congr. -/
+-def tryProbEqGoal : TacticM Bool := do
+-  if ← tryProbEqPlans probEqActionPlans then
+-    return true
+-  runProbOutputEqRelBridge
+-
+-def throwVCGenStepRwError (depth : Nat) : TacticM Unit := withMainContext do
+-  let target ← instantiateMVars (← getMainTarget)
+-  if depth = 0 then
+-    throwError
+-      "vcstep rw: expected a `Pr[ ...] = Pr[ ...]` goal where one top-level\n\
+-      bind-swap rewrite applies.\n\
+-      Goal:{indentExpr target}"
+-  else
+-    throwError
+-      "vcstep rw under {depth}: expected a `Pr[ ...] = Pr[ ...]` goal where one\n\
+-      bind-swap rewrite applies under {depth} shared bind prefix(es).\n\
+-      Goal:{indentExpr target}"
+-
+-def throwVCGenStepRwCongrError (supportSensitive : Bool) : TacticM Unit := withMainContext do
+-  let target ← instantiateMVars (← getMainTarget)
+-  if supportSensitive then
+-    throwError
+-      "vcstep rw congr: expected a `Pr[ ...] = Pr[ ...]` goal with a shared outer\n\
+-      bind, leaving the bound variable and a support hypothesis.\n\
+-      Goal:{indentExpr target}"
+-  else
+-    throwError
+-      "vcstep rw congr': expected a `Pr[ ...] = Pr[ ...]` goal with a shared outer\n\
+-      bind, leaving only the bound variable.\n\
+-      Goal:{indentExpr target}"
+-
+-def throwVCGenStepRwNormalizeError : TacticM Unit := withMainContext do
+-  let target ← instantiateMVars (← getMainTarget)
+-  throwError
+-    "vcstep rw normalize: expected a `Pr[ ...] = Pr[ ...]` goal where the bounded\n\
+-    probability-equality planner can close the goal by bind-swap and congruence steps.\n\
+-    Goal:{indentExpr target}"
+-
+-/-- Try to lower a probability goal into a `Triple`, `wp`, or probability-equality goal. -/
+-def tryLowerProbGoal : TacticM Bool := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  let isProbEventGoal := (findAppWithHead? ``probEvent target).isSome
+-  let isProbOutputGoal := (findAppWithHead? ``probOutput target).isSome
+-  unless isProbEventGoal || isProbOutputGoal do return false
+-  if isProbEqGoal target then
+-    if ← tryProbEqGoal then return true
+-  if isProbEventGoal then
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [← OracleComp.ProgramLogic.triple_propInd_iff_probEvent_eq_one];
+-        simp only [OracleComp.ProgramLogic.propInd_true])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [eq_comm (a := 1),
+-            ← OracleComp.ProgramLogic.triple_propInd_iff_probEvent_eq_one];
+-        simp only [OracleComp.ProgramLogic.propInd_true])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [← OracleComp.ProgramLogic.triple_propInd_iff_le_probEvent])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [ge_iff_le, ← OracleComp.ProgramLogic.triple_propInd_iff_le_probEvent])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [OracleComp.ProgramLogic.probEvent_eq_wp_propInd])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        simp only [OracleComp.ProgramLogic.probEvent_eq_wp_propInd])) then
+-      return true
+-  if isProbOutputGoal then
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [OracleComp.ProgramLogic.probOutput_eq_one_iff_triple])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [eq_comm, OracleComp.ProgramLogic.probOutput_eq_one_iff_triple])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [OracleComp.ProgramLogic.le_probOutput_iff_triple_indicator])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [ge_iff_le, OracleComp.ProgramLogic.le_probOutput_iff_triple_indicator])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        rw [OracleComp.ProgramLogic.probOutput_eq_wp_indicator])) then
+-      return true
+-    if ← tryEvalTacticSyntax (← `(tactic|
+-        simp only [OracleComp.ProgramLogic.probOutput_eq_wp_indicator])) then
+-      return true
+-  return false
+-
+-/-- Continue structural stepping on a raw `wp` goal after probability lowering or explicit
+-`wp`-level work. This stays deliberately smaller than the `Triple` path. -/
+-def tryRawWpStructuralStep : TacticM Bool := do
+-  let target ← instantiateMVars (← getMainTarget)
+-  let comp? :=
+-    match rawWPGoalParts? target with
+-    | some (_, comp, _) => some comp
+-    | none => wpGoalComp? target
+-  let some comp := comp? | return false
+-  let comp ← instantiateMVars comp
+-  let isLowerBoundGoal := (rawWPGoalParts? target).isSome
+-  if isLowerBoundGoal then
+-    if ← runRawWpVCSpecBackward then
+-      return true
+-  if ← runWpStepRules then
+-    return true
+-  unless isLowerBoundGoal do
+-    if ← runRawWpVCSpecBackward then
+-      return true
+-  if ← tryMatchDecomp comp then
+-    return true
+-  return false
+-
+-/-- Try to synthesize a support-based intermediate postcondition for a bind step.
+-When the computation is `oa >>= f` and no explicit spec is available, tries applying
+-`triple_bind` with an inferred cut and closing the spec subgoal via `triple_support`,
+-which unifies the cut to `fun x => 𝟙⟦x ∈ support oa⟧`. -/
+-def trySupportCutBind (comp : Expr) : TacticM Bool := do
+-  if !isBindExpr comp then return false
+-  match ← observing? do
+-    evalTactic (← `(tactic| apply OracleComp.ProgramLogic.triple_bind))
+-    unless ← tryEvalTacticSyntax (← `(tactic|
+-      classical exact OracleComp.ProgramLogic.triple_support _)) do
+-      throwError "" with
+-  | some _ => return true
+-  | none => return false
+-
+-/-! ### Goal classification and per-kind dispatch
+-
+-Mirrors `Loom.Tactic.VCGen.GoalKind` and `classifyGoalKind`: the structural
+-core picks one strategy per goal kind instead of falling through a procedural
+-cascade. New monad transformers / combinators become a new
+-`UnaryGoalKind` constructor plus a registered `@[vcspec]` rule, not another
+-`tryEvalTacticSyntax` block.
+-
+-Probability lowering is run opportunistically *before* classification, since
+-`Pr[…]` may appear inside `wp …` goals that should ultimately dispatch via
+-raw `wp` or `Triple` rules; only goals where lowering actually fires bypass
+-the rest of the pipeline. -/
+-
+-/-- High-level classification of a unary VCGen target.
+-
+-Kept intentionally coarse: structural details (the bind continuation,
+-ite condition, matcher app, …) live in the `comp` payload, not in the
+-constructor, so per-kind handlers can share `tryEvalTacticSyntax`-style logic
+-with the existing helpers. -/
+-inductive UnaryGoalKind where
+-  /-- A relational `RelTriple` / `RelWP` goal; defer to the relational planner. -/
+-  | relational
+-  /-- A unary `Triple` whose computation is a `>>=` application. -/
+-  | tripleBind (comp : Expr)
+-  /-- A unary `Triple` whose computation is `ite c a b` (non-dependent). -/
+-  | tripleIte
+-  /-- A unary `Triple` whose computation is `dite c a b` (dependent). -/
+-  | tripleDite
+-  /-- A unary `Triple` whose computation is a compiled `match` matcher. -/
+-  | tripleMatch (comp : Expr)
+-  /-- A unary `Triple` whose computation is a `replicate` / `List.mapM` /
+-  `List.foldlM` head. -/
+-  | tripleLoop (comp : Expr)
+-  /-- A unary `Triple` whose computation does not match the cases above; the
+-  dispatcher unfolds to raw `wp` and lets `@[wpStep]` rewrite. -/
+-  | tripleOther
+-  /-- A raw `wp` / `≤ wp` goal. -/
+-  | rawWp
+-  /-- Unrecognized goal shape. -/
+-  | unknown
+-  deriving Inhabited
+-
+-/-- Classify the current goal target as a `UnaryGoalKind`.
+-
+-Probability lowering is intentionally not a kind here: it runs opportunistically
+-in `runVCGenStructuralCore` before classification, so a `wp … = ∑' u, Pr[…] * …`
+-goal still classifies as `rawWp` / `tripleOther` rather than getting stuck in a
+-non-lowerable prob branch. -/
+-def classifyUnaryGoalKind (target : Expr) : MetaM UnaryGoalKind := do
+-  if (relTripleGoalParts? target).isSome then return .relational
+-  match tripleGoalComp? target with
+-  | some comp =>
+-      let comp ← whnfReducible (← instantiateMVars comp)
+-      if isBindExpr comp then return .tripleBind comp
+-      if isIfExpr comp then
+-        return if comp.consumeMData.getAppFn.isConstOf ``dite then
+-          .tripleDite else .tripleIte
+-      if (← Lean.Meta.matchMatcherApp? comp).isSome then return .tripleMatch comp
+-      if isReplicateHead comp || isListFoldlMHead comp || isListMapMHead comp then
+-        return .tripleLoop comp
+-      return .tripleOther
+-  | none =>
+-      if (wpGoalComp? target).isSome then return .rawWp
+-      else return .unknown
+-
+-/-- Lower the current probability goal and, when the residual goal is a raw
+-`wp`, follow up with one structural raw-`wp` step. Returns `true` whenever
+-lowering actually fired (matching the original cascade's behaviour). -/
+-private def runProbStep : TacticM Bool := do
+-  unless ← tryLowerProbGoal do return false
+-  if (← getGoals).isEmpty then
+-    return true
+-  let target ← instantiateMVars (← getMainTarget)
+-  if (tripleGoalComp? target).isNone && (relTripleGoalParts? target).isNone
+-      && (wpGoalComp? target).isSome then
+-    discard <| tryRawWpStructuralStep
+-  return true
+-
+-/-- Bind dispatch family: try `triple_bind` immediately, then a support-based
+-cut, then the explicit `triple_bind_wp` / `stdDoTriple_bind_wp` closers. -/
+-private def runTripleBindStep (comp : Expr) : TacticM Bool := do
+-  if ← tryBindImmediate comp then return true
+-  if ← trySupportCutBind comp then return true
+-  if ← tryEvalTacticSyntax (← `(tactic|
+-      apply OracleComp.ProgramLogic.triple_bind_wp)) then
+-    closeTheoremStepGoals
+-    return true
+-  if ← tryEvalTacticSyntax (← `(tactic|
+-      apply OracleComp.ProgramLogic.TacticInternals.Unary.stdDoTriple_bind_wp)) then
+-    closeTheoremStepGoals
+-    return true
+-  return false
+-
+-/-- Last-ditch triple step: unfold to a raw `wp` goal and dispatch via
+-`@[wpStep]`. Used when the specialized triple dispatchers do not match. -/
+-private def runTripleFallback : TacticM Bool := do
+-  match ← observing? do
+-      evalTactic (← `(tactic| unfold OracleComp.ProgramLogic.Triple))
+-      evalTactic (← `(tactic| change _ ≤ OracleComp.ProgramLogic.wp _ _))
+-      unless ← runWpStepRules do
+-        throwError "vcstep: no matching wp rule after unfolding `Triple`"
+-    with
+-  | some _ => return true
+-  | none => return false
+-
+ /-- Structural/default unary VCGen step, excluding explicit cut/invariant/theorem-driven
+ fallbacks and the final close/search phase.
+ 
+diff --git a/VCVio/ProgramLogic/Tactics/Unary/Core.lean b/VCVio/ProgramLogic/Tactics/Unary/Core.lean
+new file mode 100644
+--- /dev/null
++++ b/VCVio/ProgramLogic/Tactics/Unary/Core.lean
+@@ -0,0 +1,1714 @@
++/-
++Copyright (c) 2026 Quang Dao. All rights reserved.
++Released under Apache 2.0 license as described in the file LICENSE.
++Authors: Quang Dao
++-/
++
++module
++
++public meta import VCVio.ProgramLogic.Tactics.Common
++public import VCVio.ProgramLogic.Relational.Basic
++public import VCVio.ProgramLogic.Relational.Loom.Quantitative
++public import Loom.Triple.SpecLemmas
++
++/-!
++# Unary VCGen Core
++
++Unary proof rules, probability normalization, and planning primitives used by the
++VCGen dispatcher. This layer supplies the unary strategies independently of the
++relational tactic implementation.
++-/
++
++public meta section
++
++open Lean Elab Tactic Meta
++
++namespace OracleComp.ProgramLogic
++namespace TacticInternals
++namespace Unary
++
++universe u v
++
++/-- Cached raw-`wp` structural leaf for `pure`.
++
++The equality theorem `wp_pure` remains the canonical rewrite rule.
++This lower-bound form lets raw `wp` goals use the cached `@[vcspec]`
++backward-rule path before falling back to `@[wpStep]`. -/
++theorem wp_pure_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {α : Type} (x : α)
++    (post : α → ENNReal) :
++    post x ≤ wp (pure x : OracleComp spec α) post := by
++  rw [OracleComp.ProgramLogic.wp_pure]
++
++/-- Cached raw-`wp` structural leaf for functorial map. -/
++theorem wp_map_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {α β : Type}
++    (f : α → β) (oa : OracleComp spec α) (post : β → ENNReal) :
++    wp oa (post ∘ f) ≤ wp (f <$> oa) post := by
++  rw [OracleComp.ProgramLogic.wp_map]
++
++/-- Cached raw-`wp` structural leaf for conditionals. -/
++theorem wp_ite_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {α : Type} (c : Prop) [Decidable c]
++    (oa ob : OracleComp spec α) (post : α → ENNReal) :
++    (if c then wp oa post else wp ob post) ≤ wp (if c then oa else ob) post := by
++  rw [OracleComp.ProgramLogic.wp_ite]
++
++/-- Cached raw-`wp` structural leaf for dependent conditionals. -/
++theorem wp_dite_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {α : Type} (c : Prop) [Decidable c]
++    (oa : c → OracleComp spec α) (ob : ¬c → OracleComp spec α) (post : α → ENNReal) :
++    (if h : c then wp (oa h) post else wp (ob h) post) ≤ wp (dite c oa ob) post := by
++  rw [OracleComp.ProgramLogic.wp_dite]
++
++/-- Cached raw-`wp` structural leaf for `replicate (n + 1)`. -/
++theorem wp_replicate_succ_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {α : Type}
++    (oa : OracleComp spec α) (n : Nat) (post : List α → ENNReal) :
++    wp oa (fun x => wp (oa.replicate n) (fun xs => post (x :: xs))) ≤
++      wp (oa.replicate (n + 1)) post := by
++  rw [OracleComp.ProgramLogic.wp_replicate_succ]
++
++/-- Cached raw-`wp` structural leaf for `List.mapM` on `x :: xs`. -/
++theorem wp_list_mapM_cons_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {α β : Type}
++    (x : α) (xs : List α) (f : α → OracleComp spec β) (post : List β → ENNReal) :
++    wp (f x) (fun y => wp (xs.mapM f) (fun ys => post (y :: ys))) ≤
++      wp ((x :: xs).mapM f) post := by
++  rw [OracleComp.ProgramLogic.wp_list_mapM_cons]
++
++/-- Cached raw-`wp` structural leaf for `List.foldlM` on `x :: xs`. -/
++theorem wp_list_foldlM_cons_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {α σ : Type}
++    (x : α) (xs : List α) (f : σ → α → OracleComp spec σ)
++    (init : σ) (post : σ → ENNReal) :
++    wp (f init x) (fun s => wp (xs.foldlM f s) post) ≤
++      wp ((x :: xs).foldlM f init) post := by
++  rw [OracleComp.ProgramLogic.wp_list_foldlM_cons]
++
++/-- Cached raw-`wp` structural leaf for oracle queries. -/
++theorem wp_query_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec]
++    (t : spec.Domain) (post : spec.Range t → ENNReal) :
++    (∑' u : spec.Range t, (1 / Fintype.card (spec.Range t) : ENNReal) * post u) ≤
++      wp (query t : OracleComp spec (spec.Range t)) post := by
++  simpa using le_of_eq (OracleComp.ProgramLogic.wp_HasQuery_query (spec := spec) t post).symm
++
++/-- Cached raw-`wp` structural leaf for `HasQuery.query`. -/
++theorem wp_HasQuery_query_le_vcspec {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec]
++    (t : spec.Domain) (post : spec.Range t → ENNReal) :
++    (∑' u : spec.Range t, (1 / Fintype.card (spec.Range t) : ENNReal) * post u) ≤
++      wp (spec := spec) (HasQuery.query t : OracleComp spec (spec.Range t)) post := by
++  simpa using le_of_eq (OracleComp.ProgramLogic.wp_HasQuery_query (spec := spec) t post).symm
++
++/-- Cached raw-`wp` structural leaf for uniform sampling. -/
++theorem wp_uniformSample_le_vcspec {α : Type} [SampleableType α] (post : α → ENNReal) :
++    (∑' u : α, Pr[= u | ($ᵗ α : ProbComp α)] * post u) ≤
++      wp ($ᵗ α : ProbComp α) post := by
++  rw [OracleComp.ProgramLogic.wp_uniformSample]
++
++/-- Generic Loom triple bind step with the intermediate postcondition fixed to
++the weakest precondition of the continuation. This is the `Std.Do'.Triple`
++counterpart of `OracleComp.ProgramLogic.triple_bind_wp`, and lets unary
++automation walk transformer-stack `do` blocks without guessing a user cut. -/
++theorem stdDoTriple_bind_wp {m : Type u → Type v}
++    {Pred EPred : Type u} {α β : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {pre : Pred} (x : m α) (f : α → m β) (post : β → Pred) (epost : EPred) :
++    Std.Do'.Triple pre x (fun a => Std.Do'.wp (f a) post epost) epost →
++      Std.Do'.Triple pre (x >>= f) post epost := by
++  intro h
++  exact Std.Do'.Triple.bind x f (fun a => Std.Do'.wp (f a) post epost) h
++    (fun _ => Std.Do'.Triple.iff.mpr Lean.Order.PartialOrder.rel_refl)
++
++/-- Close a Loom triple from the corresponding WP entailment.
++
++This is just `Std.Do'.Triple.iff.mpr` packaged as a theorem so tactic code can expose
++the weakest-precondition side condition and then run transformer-specific WP normalizers. -/
++theorem stdDoTriple_of_wp_le {m : Type u → Type v}
++    {Pred EPred : Type u} {α : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {pre : Pred} (x : m α) (post : α → Pred) (epost : EPred)
++    (hpre : Lean.Order.PartialOrder.rel pre (Std.Do'.wp x post epost)) :
++    Std.Do'.Triple pre x post epost :=
++  Std.Do'.Triple.iff.mpr hpre
++
++theorem wp_StateT_get_layer {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ : Type u} (post : σ → σ → Pred) (epost : EPred) :
++    Std.Do'.wp (MonadStateOf.get : StateT σ m σ) post epost =
++      fun s => Std.Do'.wp (pure (s, s) : m (σ × σ))
++        (fun p : σ × σ => post p.1 p.2) epost :=
++  rfl
++
++theorem wp_StateT_get_layer' {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ : Type u} (post : σ → σ → Pred) (epost : EPred) :
++    Std.Do'.wp (StateT.get : StateT σ m σ) post epost =
++      fun s => Std.Do'.wp (pure (s, s) : m (σ × σ))
++        (fun p : σ × σ => post p.1 p.2) epost :=
++  rfl
++
++theorem stdDoTriple_StateT_get_of_rel {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ : Type u} (pre : σ → Pred) (post : σ → σ → Pred) (epost : EPred)
++    (h : ∀ s, Lean.Order.PartialOrder.rel (pre s) (post s s)) :
++    Std.Do'.Triple pre (StateT.get : StateT σ m σ) post epost := by
++  refine Std.Do'.Triple.iff.mpr ?_
++  intro s
++  change Lean.Order.PartialOrder.rel (pre s)
++    (Std.Do'.wp (pure (s, s) : m (σ × σ))
++      (fun p : σ × σ => post p.1 p.2) epost)
++  exact Lean.Order.PartialOrder.rel_trans (h s)
++    (Std.Do'.WP.wp_pure (m := m) (x := (s, s))
++      (post := fun p : σ × σ => post p.1 p.2) (epost := epost))
++
++theorem wp_StateT_set_layer {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ : Type u} (s' : σ) (post : PUnit → σ → Pred) (epost : EPred) :
++    Std.Do'.wp (MonadStateOf.set s' : StateT σ m PUnit) post epost =
++      fun _ => Std.Do'.wp (pure (PUnit.unit, s') : m (PUnit × σ))
++        (fun p : PUnit × σ => post p.1 p.2) epost :=
++  rfl
++
++theorem wp_StateT_run_get_layer {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ : Type u} (s : σ) (post : σ → σ → Pred) (epost : EPred) :
++    Std.Do'.wp ((MonadStateOf.get : StateT σ m σ).run s)
++        (fun p : σ × σ => post p.1 p.2) epost =
++      Std.Do'.wp (pure (s, s) : m (σ × σ)) (fun p : σ × σ => post p.1 p.2) epost :=
++  rfl
++
++theorem wp_StateT_run_get_layer' {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ : Type u} (s : σ) (post : σ → σ → Pred) (epost : EPred) :
++    Std.Do'.wp ((StateT.get : StateT σ m σ).run s)
++        (fun p : σ × σ => post p.1 p.2) epost =
++      Std.Do'.wp (pure (s, s) : m (σ × σ)) (fun p : σ × σ => post p.1 p.2) epost :=
++  rfl
++
++theorem wp_StateT_run_set_layer {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ : Type u} (s s' : σ) (post : PUnit → σ → Pred) (epost : EPred) :
++    Std.Do'.wp ((MonadStateOf.set s' : StateT σ m PUnit).run s)
++        (fun p : PUnit × σ => post p.1 p.2) epost =
++      Std.Do'.wp (pure (PUnit.unit, s') : m (PUnit × σ))
++        (fun p : PUnit × σ => post p.1 p.2) epost :=
++  rfl
++
++theorem wp_StateT_run_set_layer' {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ : Type u} (s s' : σ) (post : PUnit → σ → Pred) (epost : EPred) :
++    Std.Do'.wp ((StateT.set s' : StateT σ m PUnit).run s)
++        (fun p : PUnit × σ => post p.1 p.2) epost =
++      Std.Do'.wp (pure (PUnit.unit, s') : m (PUnit × σ))
++        (fun p : PUnit × σ => post p.1 p.2) epost :=
++  rfl
++
++theorem wp_StateT_map_layer {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {σ α β : Type u} (f : α → β) (x : StateT σ m α) (post : β → σ → Pred)
++    (epost : EPred) :
++    Std.Do'.wp (f <$> x) post epost =
++      fun s => Std.Do'.wp ((f <$> x).run s)
++        (fun p : β × σ => post p.1 p.2) epost :=
++  rfl
++
++theorem wp_ReaderT_read_layer {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {ρ : Type u} (post : ρ → ρ → Pred) (epost : EPred) :
++    Std.Do'.wp (MonadReaderOf.read : ReaderT ρ m ρ) post epost =
++      fun r => Std.Do'.wp (pure r : m ρ) (fun a => post a r) epost :=
++  rfl
++
++theorem wp_ReaderT_read_layer' {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {ρ : Type u} (post : ρ → ρ → Pred) (epost : EPred) :
++    Std.Do'.wp (ReaderT.read : ReaderT ρ m ρ) post epost =
++      fun r => Std.Do'.wp (pure r : m ρ) (fun a => post a r) epost :=
++  rfl
++
++theorem stdDoTriple_ReaderT_read_of_rel {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {ρ : Type u} (pre : ρ → Pred) (post : ρ → ρ → Pred) (epost : EPred)
++    (h : ∀ r, Lean.Order.PartialOrder.rel (pre r) (post r r)) :
++    Std.Do'.Triple pre (MonadReaderOf.read : ReaderT ρ m ρ) post epost := by
++  refine Std.Do'.Triple.iff.mpr ?_
++  intro r
++  change Lean.Order.PartialOrder.rel (pre r)
++    (Std.Do'.wp (pure r : m ρ) (fun a : ρ => post a r) epost)
++  exact Lean.Order.PartialOrder.rel_trans (h r)
++    (Std.Do'.WP.wp_pure (m := m) (x := r)
++      (post := fun a : ρ => post a r) (epost := epost))
++
++theorem wp_ReaderT_run_read_layer {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {ρ : Type u} (r : ρ) (post : ρ → ρ → Pred) (epost : EPred) :
++    Std.Do'.wp ((MonadReaderOf.read : ReaderT ρ m ρ).run r) (fun a : ρ => post a r)
++        epost =
++      Std.Do'.wp (pure r : m ρ) (fun a : ρ => post a r) epost :=
++  rfl
++
++theorem wp_ReaderT_run_read_layer' {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {ρ : Type u} (r : ρ) (post : ρ → ρ → Pred) (epost : EPred) :
++    Std.Do'.wp ((ReaderT.read : ReaderT ρ m ρ).run r) (fun a : ρ => post a r)
++        epost =
++      Std.Do'.wp (pure r : m ρ) (fun a : ρ => post a r) epost :=
++  rfl
++
++theorem mAlgOrdered_wp_OptionT_run_StateT_get {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {σ : Type} (s : σ)
++    (post : σ → σ → ENNReal)
++    (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
++    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
++      (((StateT.get : StateT σ (OptionT (OracleComp spec)) σ).run s).run)
++      (epost.pushOption (fun p : σ × σ => post p.1 p.2)) = post s s := by
++  change MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
++      (pure (some (s, s)) : OracleComp spec (Option (σ × σ)))
++      (epost.pushOption (fun p : σ × σ => post p.1 p.2)) = post s s
++  rw [MAlgOrdered.wp_pure]
++
++theorem mAlgOrdered_wp_OptionT_run_StateT_set {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {σ : Type} (s s' : σ)
++    (post : PUnit → σ → ENNReal) (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
++    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
++      (((StateT.set s' : StateT σ (OptionT (OracleComp spec)) PUnit).run s).run)
++      (epost.pushOption (fun p : PUnit × σ => post p.1 p.2)) = post PUnit.unit s' := by
++  change MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
++      (pure (some (PUnit.unit, s')) : OracleComp spec (Option (PUnit × σ)))
++      (epost.pushOption (fun p : PUnit × σ => post p.1 p.2)) = post PUnit.unit s'
++  rw [MAlgOrdered.wp_pure]
++
++theorem mAlgOrdered_wp_OptionT_run_lift {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {α : Type}
++    (oa : OracleComp spec α) (post : α → ENNReal)
++    (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
++    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) (OptionT.lift oa).run
++      (epost.pushOption post) =
++        MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa post := by
++  change MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
++      (oa >>= fun a => pure (some a) : OracleComp spec (Option α))
++      (epost.pushOption post) =
++    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa post
++  rw [MAlgOrdered.wp_bind]
++  refine congrArg (MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa) ?_
++  funext a
++  rw [MAlgOrdered.wp_pure]
++
++theorem mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift {ι : Type u}
++    {spec : OracleSpec ι} [IsUniformSpec spec]
++    {σ α : Type} (oa : OracleComp spec α) (s : σ) (post : α → σ → ENNReal)
++    (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
++    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
++      (((MonadLift.monadLift (OptionT.lift oa) :
++        StateT σ (OptionT (OracleComp spec)) α).run s).run)
++      (epost.pushOption (fun p : α × σ => post p.1 p.2)) =
++        MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa (fun a => post a s) := by
++  simp [MonadLift.monadLift, OptionT.run_lift, MAlgOrdered.wp_map,
++    Std.Do'.EPost.cons.pushOption]
++
++theorem wp_StateT_OptionT_monadLift_lift {ι : Type u} {spec : OracleSpec ι}
++    [IsUniformSpec spec] {σ α : Type}
++    (oa : OracleComp spec α) (post : α → σ → ENNReal)
++    (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
++    Std.Do'.wp
++      (MonadLift.monadLift (OptionT.lift oa) : StateT σ (OptionT (OracleComp spec)) α)
++      post epost =
++        fun s => MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa
++          (fun a => post a s) := by
++  funext s
++  change MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
++      (((MonadLift.monadLift (OptionT.lift oa) :
++        StateT σ (OptionT (OracleComp spec)) α).run s).run)
++      (epost.pushOption (fun p : α × σ => post p.1 p.2)) =
++        MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa (fun a => post a s)
++  exact mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift (spec := spec) oa s post epost
++
++theorem mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift_map {ι : Type u}
++    {spec : OracleSpec ι} [IsUniformSpec spec]
++    {σ α β : Type} (oa : OracleComp spec α) (s : σ) (f : α × σ → β)
++    (post : β → ENNReal) (nonePost : ENNReal) :
++    MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
++      (((MonadLift.monadLift (OptionT.lift oa) :
++        StateT σ (OptionT (OracleComp spec)) α).run s).run)
++      (fun o => match Option.map f o with | some b => post b | none => nonePost) =
++        MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) oa
++          (fun a => post (f (a, s))) := by
++  simp [MonadLift.monadLift, OptionT.run_lift, MAlgOrdered.wp_map]
++
++theorem wp_ReaderT_map_layer {m : Type u → Type v} {Pred EPred : Type u}
++    [Monad m] [Std.Do'.Assertion Pred] [Std.Do'.Assertion EPred] [Std.Do'.WP m Pred EPred]
++    {ρ α β : Type u} (f : α → β) (x : ReaderT ρ m α) (post : β → ρ → Pred)
++    (epost : EPred) :
++    Std.Do'.wp (f <$> x) post epost =
++      fun r => Std.Do'.wp ((f <$> x).run r) (fun b : β => post b r) epost :=
++  rfl
++
++attribute [vcspec]
++  OracleComp.ProgramLogic.triple_pure
++  wp_pure_le_vcspec
++  wp_map_le_vcspec
++  wp_ite_le_vcspec
++  wp_dite_le_vcspec
++  wp_replicate_succ_le_vcspec
++  wp_list_mapM_cons_le_vcspec
++  wp_list_foldlM_cons_le_vcspec
++  wp_query_le_vcspec
++  wp_HasQuery_query_le_vcspec
++  wp_uniformSample_le_vcspec
++  -- StateT
++  Std.Do'.Spec.get_StateT
++  Std.Do'.Spec.set_StateT
++  Std.Do'.Spec.modifyGet_StateT
++  Std.Do'.Spec.monadLift_StateT
++  -- ReaderT
++  Std.Do'.Spec.read_ReaderT
++  Std.Do'.Spec.monadLift_ReaderT
++  Std.Do'.Spec.adapt_ReaderT
++  Std.Do'.Spec.withReader_ReaderT
++  -- WriterT
++  Std.Do'.Spec.tell_WriterT
++  Std.Do'.Spec.monadLift_WriterT
++  Std.Do'.Spec.mk_WriterT
++  Std.Do'.WriterT.wp_pure
++  Std.Do'.WriterT.wp_bind
++  Std.Do'.WriterT.wp_tell
++  Std.Do'.WriterT.wp_monadLift
++  Std.Do'.WriterT.wp_map
++  -- OptionT
++  Std.Do'.Spec.run_OptionT
++  Std.Do'.Spec.throw_OptionT
++  Std.Do'.Spec.tryCatch_OptionT
++  Std.Do'.Spec.orElse_OptionT
++  Std.Do'.Spec.monadLift_OptionT
++  -- ExceptT
++  Std.Do'.Spec.run_ExceptT
++  Std.Do'.Spec.throw_ExceptT
++  Std.Do'.Spec.tryCatch_ExceptT
++  Std.Do'.Spec.orElse_ExceptT
++  Std.Do'.Spec.adapt_ExceptT
++  Std.Do'.Spec.monadLift_ExceptT
++  -- Lifted MonadExceptOf
++  Std.Do'.Spec.throw_MonadExcept
++  Std.Do'.Spec.tryCatch_MonadExcept
++  Std.Do'.Spec.throw_ReaderT
++  Std.Do'.Spec.throw_StateT
++  Std.Do'.Spec.throw_ExceptT_lift
++  Std.Do'.Spec.throw_Option_lift
++  Std.Do'.Spec.tryCatch_ReaderT
++  Std.Do'.Spec.tryCatch_StateT
++  Std.Do'.Spec.tryCatch_ExceptT_lift
++  Std.Do'.Spec.tryCatch_OptionT_lift
++  -- Generic monad-transformer hooks
++  Std.Do'.Spec.monadMap_StateT
++  Std.Do'.Spec.monadMap_ReaderT
++  Std.Do'.Spec.monadMap_ExceptT
++  Std.Do'.Spec.monadMap_OptionT
++  Std.Do'.Spec.monadMap_refl
++  Std.Do'.Spec.monadMap_trans
++  Std.Do'.Spec.liftWith_StateT
++  Std.Do'.Spec.liftWith_ReaderT
++  Std.Do'.Spec.liftWith_ExceptT
++  Std.Do'.Spec.liftWith_OptionT
++  Std.Do'.Spec.liftWith_refl
++  Std.Do'.Spec.liftWith_trans
++  Std.Do'.Spec.restoreM_StateT
++  Std.Do'.Spec.restoreM_ReaderT
++  Std.Do'.Spec.restoreM_ExceptT
++  Std.Do'.Spec.restoreM_OptionT
++  Std.Do'.Spec.restoreM_refl
++
++/-! ## `vcspec_simp` normalization set
++
++Centralized registration of the transformer-`wp` peel lemmas, `*.run`
++projections, monadic-algebra rewrites, and the `Loom.wp_eq_mAlgOrdered_wp`
++bridges that the unary tactic uses to expose spec-applicable goal shapes.
++The single simp set is consumed by `runVCSpecSimp`. New normalization rewrites
++should be tagged here (or at definition) rather than inserted into a
++tactic-local `simp only [...]` list. -/
++
++attribute [vcspec_simp]
++  -- `Std.Do'` transformer apply_wp / `*.run` peeling
++  Std.Do'.StateT.apply_wp
++  Std.Do'.ReaderT.apply_wp
++  Std.Do'.WriterT.apply_wp
++  StateT.run_bind StateT.run_pure StateT.run_get StateT.run_set
++  StateT.run_modifyGet StateT.run_monadLift StateT.run_map StateT.run_lift
++  ReaderT.run_bind ReaderT.run_pure ReaderT.run_monadLift ReaderT.run_read
++  ReaderT.run_map
++  WriterT.run_bind WriterT.run_pure WriterT.run_tell WriterT.run_monadLift
++  WriterT.run_liftM WriterT.run_map
++  OptionT.run_bind OptionT.run_pure OptionT.run_lift OptionT.run_failure
++  OptionT.run_map
++  ExceptT.run_bind ExceptT.run_pure ExceptT.run_lift ExceptT.run_throw
++  ExceptT.run_map
++  -- VCVio Loom bridges and the underlying quantitative `MAlgOrdered.wp`
++  OracleComp.ProgramLogic.Loom.wp_eq_mAlgOrdered_wp
++  OracleComp.ProgramLogic.Loom.wp_eq_mAlgOrdered_wp_epost
++  MAlgOrdered.wp_bind MAlgOrdered.wp_pure MAlgOrdered.wp_map
++  -- VCVio per-transformer `Loom.wp_*` peeling lemmas
++  OracleComp.ProgramLogic.Loom.wp_StateT_bind
++  OracleComp.ProgramLogic.Loom.wp_StateT_bind'
++  OracleComp.ProgramLogic.Loom.wp_StateT_pure
++  OracleComp.ProgramLogic.Loom.wp_StateT_get
++  OracleComp.ProgramLogic.Loom.wp_StateT_set
++  OracleComp.ProgramLogic.Loom.wp_StateT_modifyGet
++  OracleComp.ProgramLogic.Loom.wp_StateT_monadLift
++  OracleComp.ProgramLogic.Loom.wp_OptionT_bind
++  OracleComp.ProgramLogic.Loom.wp_OptionT_pure
++  OracleComp.ProgramLogic.Loom.wp_OptionT_failure
++  OracleComp.ProgramLogic.Loom.wp_OptionT_monadLift
++  OracleComp.ProgramLogic.Loom.wp_OptionT_lift
++  OracleComp.ProgramLogic.Loom.wp_OptionT_map
++  OracleComp.ProgramLogic.Loom.wp_ExceptT_bind
++  OracleComp.ProgramLogic.Loom.wp_ExceptT_pure
++  OracleComp.ProgramLogic.Loom.wp_ExceptT_throw
++  OracleComp.ProgramLogic.Loom.wp_ExceptT_monadLift
++  OracleComp.ProgramLogic.Loom.wp_ReaderT_bind
++  OracleComp.ProgramLogic.Loom.wp_ReaderT_pure
++  OracleComp.ProgramLogic.Loom.wp_ReaderT_read
++  OracleComp.ProgramLogic.Loom.wp_ReaderT_monadLift
++  OracleComp.ProgramLogic.Loom.WriterT.wp_bind
++  OracleComp.ProgramLogic.Loom.WriterT.wp_pure
++  OracleComp.ProgramLogic.Loom.WriterT.wp_tell
++  OracleComp.ProgramLogic.Loom.WriterT.wp_monadLift
++  OracleComp.ProgramLogic.Loom.WriterT.wp_map
++  -- VCVio transformer-internal layer lemmas (defined above in this file)
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_get_layer
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_get_layer'
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_run_get_layer
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_run_get_layer'
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_set_layer
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_run_set_layer
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_run_set_layer'
++  OracleComp.ProgramLogic.TacticInternals.Unary.mAlgOrdered_wp_OptionT_run_StateT_get
++  OracleComp.ProgramLogic.TacticInternals.Unary.mAlgOrdered_wp_OptionT_run_StateT_set
++  OracleComp.ProgramLogic.TacticInternals.Unary.mAlgOrdered_wp_OptionT_run_lift
++  mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift
++  mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift_map
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_OptionT_monadLift_lift
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_StateT_map_layer
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_read_layer
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_read_layer'
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_run_read_layer
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_run_read_layer'
++  OracleComp.ProgramLogic.TacticInternals.Unary.wp_ReaderT_map_layer
++  -- Algebraic monad/`EPost`/scalar rewrites used by both peel and close passes
++  Std.Do'.EPost.cons.pushOption
++  Std.Do'.EPost.cons.pushExcept
++  Option.elimM
++  pure_bind
++  bind_pure_comp
++  bind_map_left
++  map_bind
++  bind_assoc
++  map_pure
++  Functor.map_map
++  MonadLift.monadLift
++  monadLift_self
++  monadLift_eq_self
++  one_mul
++  mul_one
++  mul_assoc
++
++private def mkVCGenPlannedStep (label replayText : String) (run : TacticM Bool) : PlannedStep :=
++  { label, replayText, run }
++
++private def hasProbGoal (target : Expr) : Bool :=
++  (findAppWithHead? ``probEvent target).isSome || (findAppWithHead? ``probOutput target).isSome
++
++def throwWpStepError : TacticM Unit := withMainContext do
++  let target ← instantiateMVars (← getMainTarget)
++  match wpGoalComp? target with
++  | none =>
++      throwError "vcstep: expected a goal containing `wp`; got:{indentExpr target}"
++  | some comp =>
++      let comp ← instantiateMVars comp
++      throwError
++        "vcstep: found a `wp` goal, but none of the current single-step rules apply to:\n\
++        {indentExpr comp}\n\
++        Current rules handle bind, pure, `replicate`, `List.mapM`, `List.foldlM`, query, `if`, \
++        uniform sampling, `map`, `simulateQ`, `simulateQ ... run'`, and `liftComp`."
++
++def runHoareStepRuleUsing (cut : TSyntax `term) : TacticM Bool := do
++  let target ← instantiateMVars (← getMainTarget)
++  match tripleGoalComp? target with
++  | some comp =>
++      let comp ← instantiateMVars comp
++      if isBindExpr comp then
++        tryEvalTacticSyntax (← `(tactic|
++          apply OracleComp.ProgramLogic.triple_bind (cut := $cut)))
++      else
++        return false
++  | none => return false
++
++/-- Check whether an expression (possibly under `∀` quantifiers and `mdata`) contains
++ a unary triple application as its head. -/
++private def hasTripleHead (e : Expr) : Bool :=
++  let rec go : Expr → Bool
++    | .forallE _ _ body _ => go body
++    | .mdata _ e => go e
++    | e => (tripleGoalComp? e).isSome
++  go e
++
++/-- Extract the head function of the computation argument from a unary triple
++application, after stripping `∀` quantifiers and `mdata`. -/
++private def tripleCompFn? (e : Expr) : Option Expr :=
++  let rec go : Expr → Option Expr
++    | .forallE _ _ body _ => go body
++    | .mdata _ e => go e
++    | e => do
++        let comp ← tripleGoalComp? e
++        some comp.consumeMData.getAppFn
++  go e
++
++/-- Try to close a `Triple` goal by targeted application of local hypotheses
++whose type (possibly under `∀` quantifiers) has `Triple` as head and whose
++computation argument structurally matches the goal's computation.
++Much faster than `assumption` + `solve_by_elim` when the goal has unresolved metavariables,
++because it skips expensive `isDefEq` checks against non-matching hypotheses. -/
++private def tryApplyTripleHyp : TacticM Bool := withMainContext do
++  let target ← instantiateMVars (← getMainTarget)
++  let some goalCompFn := tripleCompFn? target | return false
++  for ldecl in ← getLCtx do
++    if ldecl.isImplementationDetail then continue
++    let hypType ← instantiateMVars ldecl.type
++    unless hasTripleHead hypType do continue
++    let some hypCompFn := tripleCompFn? hypType | continue
++    unless goalCompFn == hypCompFn do continue
++    if ← tryEvalTacticSyntax (← `(tactic| exact $(mkIdent ldecl.userName))) then
++      return true
++    if hypType.isForall then
++      let saved ← saveState
++      if ← tryEvalTacticSyntax
++          (← `(tactic| apply $(mkIdent ldecl.userName) <;> assumption)) then
++        return true
++      saved.restore
++  return false
++
++/-- Peel known transformer `wp` layers in the current goal via the cached
++`vcspec_simp` simp set. Always succeeds (errors and unchanged-goal results are
++swallowed), since callers always `discard` the outcome and rely on later
++structural dispatch to decide whether the goal can close. -/
++private def peelKnownTransformerWPInGoal : TacticM Unit :=
++  runVCSpecSimp
++
++/-- Class-method unfolds used by the close passes to expose `apply_wp` /
++`*.run` projections through overloaded `Monad{State,Reader,Writer}Of` /
++`StateT.{get,set,lift}` calls, plus the `Lean.Order.PartialOrder.rel` head
++needed for the final `le_refl` step. Kept inline (rather than in
++`vcspec_simp`) to avoid eager class-projection unfolding outside of close
++contexts. -/
++private def runVCSpecCloseUnfolds : TacticM Unit := do
++  discard <| tryEvalTacticSyntax (← `(tactic|
++    simp only [Lean.Order.PartialOrder.rel,
++      MonadStateOf.get, MonadStateOf.set, MonadReaderOf.read, MonadWriter.tell,
++      StateT.get, StateT.set, StateT.lift, ReaderT.read, WriterT.tell]))
++
++private def tryCloseNormalizedTransformerWP : TacticM Bool := do
++  let saved ← saveState
++  let target ← instantiateMVars (← getMainTarget)
++  unless (tripleGoalComp? target).isSome do
++    return false
++  -- Overloaded operations such as `MonadStateOf.get` may not expose their
++  -- concrete transformer type until the triple theorem has been applied.
++  -- Speculate cheaply, then restore if the layer peeler cannot close.
++  if ← tryEvalTacticSyntax (← `(tactic| refine Std.Do'.Triple.iff.mpr ?_)) then
++    discard <| tryEvalTacticSyntax (← `(tactic| repeat intro _))
++    runVCSpecCloseUnfolds
++    runVCSpecSimp
++    if (← getGoals).isEmpty then
++      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic| exact le_refl _)) then
++      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
++      return true
++    runVCSpecCloseUnfolds
++    runVCSpecSimp
++    discard <| tryEvalTacticSyntax (← `(tactic| repeat intro _))
++    if (← getGoals).isEmpty then
++      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic| exact le_refl _)) then
++      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
++      return true
++  saved.restore
++  return false
++
++private def tryApplySpecThenPeel (stx : TSyntax `tactic) : TacticM Bool := do
++  let saved ← saveState
++  if ← tryEvalTacticSyntax stx then
++    discard <| tryEvalTacticSyntax (← `(tactic| repeat intro _))
++    peelKnownTransformerWPInGoal
++    discard <| tryEvalTacticSyntax (← `(tactic| repeat intro _))
++    runVCSpecCloseUnfolds
++    runVCSpecSimp
++    if (← getGoals).isEmpty then
++      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic| exact le_refl _)) then
++      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
++      return true
++  saved.restore
++  return false
++
++/-- Try to close the current goal using only immediate local information.
++This is intentionally cheap: it is used while speculating on `triple_bind`, so it must not
++launch expensive proof search on goals with unresolved cut metavariables. -/
++def tryCloseSpecGoalImmediate : TacticM Bool := do
++  tryApplyTripleHyp <||>
++  tryCloseNormalizedTransformerWP <||>
++  tryApplySpecThenPeel (← `(tactic| apply
++    OracleComp.ProgramLogic.TacticInternals.Unary.stdDoTriple_StateT_get_of_rel)) <||>
++  tryApplySpecThenPeel (← `(tactic| apply
++    OracleComp.ProgramLogic.TacticInternals.Unary.stdDoTriple_ReaderT_read_of_rel)) <||>
++  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.get_StateT)) <||>
++  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.set_StateT)) <||>
++  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.modifyGet_StateT)) <||>
++  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.monadLift_StateT)) <||>
++  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.read_ReaderT)) <||>
++  tryApplySpecThenPeel (← `(tactic| apply Std.Do'.Spec.monadLift_ReaderT)) <||>
++  tryEvalTacticSyntax (← `(tactic| assumption)) <||>
++  tryEvalTacticSyntax (← `(tactic| solve_by_elim (maxDepth := 2))) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_pure _ _)) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_zero _ _)) <||>
++  tryEvalTacticSyntax (← `(tactic| exact le_refl _)) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_ofLE le_rfl))
++
++/-- Try bounded local proof search on a closed goal.
++We only invoke `solve_by_elim` once the target has no unresolved expression metavariables; this
++avoids pathological search on speculative intermediate cuts introduced by `triple_bind`. -/
++def tryCloseSpecGoalSearch : TacticM Bool := do
++  let target ← instantiateMVars (← getMainTarget)
++  if target.hasExprMVar then
++    return false
++  tryEvalTacticSyntax (← `(tactic| (
++    repeat intro
++    simp only [OracleComp.ProgramLogic.triple_iff_le_wp] at *
++    solve_by_elim (maxDepth := 6) [OracleComp.ProgramLogic.wp_mono, le_trans]
++  )))
++
++private def closeTheoremStepGoals : TacticM Unit := do
++  let goals ← getGoals
++  let mut remaining : List MVarId := []
++  for goal in goals do
++    if ← goal.isAssigned then continue
++    setGoals [goal]
++    unless ← tryCloseSpecGoalImmediate do
++      remaining := remaining ++ [goal]
++  setGoals remaining
++  unless remaining.isEmpty do
++    discard <| tryEvalTacticSyntax (← `(tactic|
++      all_goals first
++        | assumption
++        | simp [Lean.Order.PartialOrder.rel]
++        | (repeat intro; split_ifs <;> simp_all [Lean.Order.PartialOrder.rel])
++        | (
++            repeat intro
++            simp only [OracleComp.ProgramLogic.triple_iff_le_wp] at *
++            solve_by_elim (maxDepth := 4) [OracleComp.ProgramLogic.wp_mono, le_trans]
++          )))
++
++private def runVCGenStepWithTheoremDirect
++    (thm : TSyntax `term) (requireClosed : Bool := false) : TacticM Bool := do
++  let saved ← saveState
++  let ok ←
++    match ← observing? do
++      evalTactic (← `(tactic| apply $thm))
++      closeTheoremStepGoals
++    with
++    | some _ => pure true
++    | none => pure false
++  if ok && (!(requireClosed) || (← getGoals).isEmpty) then
++    return true
++  saved.restore
++  return false
++
++private def runVCGenStepWithTheoremConseq
++    (thm : TSyntax `term) (requireClosed : Bool := false) : TacticM Bool := do
++  let target ← instantiateMVars (← getMainTarget)
++  unless (tripleGoalComp? target).isSome do
++    return false
++  let saved ← saveState
++  let ok ←
++    match ← observing? do
++      evalTactic (← `(tactic| refine OracleComp.ProgramLogic.triple_conseq le_rfl ?_ $thm))
++      closeTheoremStepGoals
++    with
++    | some _ => pure true
++    | none => pure false
++  if ok && (!(requireClosed) || (← getGoals).isEmpty) then
++    return true
++  saved.restore
++  return false
++
++/-- Apply a `@[vcspec]` unary rule to the current goal.
++Default `vcstep` first tries the cached rule directly. For folded unary
++`Triple` goals, a global declaration can also be applied under `triple_conseq`,
++which lets a registered concrete postcondition theorem feed a weaker goal
++postcondition. -/
++private def runUnaryVCSpecRule
++    (entry : VCSpecEntry) (requireClosed : Bool := false) : TacticM Bool := do
++  if entry.kind == .unaryWP then
++    let saved ← saveState
++    let ok ←
++      match ← observing? do
++        unless ← runVCSpecEntryRawUnaryConsequence entry do
++          throwError "vcstep: raw unary `@[vcspec]` consequence did not apply"
++        closeTheoremStepGoals
++      with
++      | some _ => pure true
++      | none => pure false
++    if ok && (!(requireClosed) || (← getGoals).isEmpty) then
++      return true
++    saved.restore
++  let saved ← saveState
++  let ok ←
++    match ← observing? do
++      unless ← runVCSpecEntryCachedBackward entry do
++        throwError "vcstep: registered `@[vcspec]` rule did not apply"
++      closeTheoremStepGoals
++    with
++    | some _ => pure true
++    | none => pure false
++  if ok && (!(requireClosed) || (← getGoals).isEmpty) then
++    return true
++  saved.restore
++  return false
++
++/-- Apply an explicit unary theorem/assumption step and try to close any easy side goals.
++When `requireClosed` is true, the step only succeeds if no goals remain afterwards. -/
++def runVCGenStepWithTheorem (thm : TSyntax `term) (requireClosed : Bool := false) :
++    TacticM Bool := do
++  if ← runVCGenStepWithTheoremDirect thm requireClosed then
++    return true
++  runVCGenStepWithTheoremConseq thm requireClosed
++
++/-- Try to close the current goal (typically a `Triple` subgoal) using direct hypotheses,
++canonical leaf rules, or bounded local consequence search. -/
++def tryCloseSpecGoal : TacticM Bool := do
++  tryCloseSpecGoalImmediate <||> tryCloseSpecGoalSearch
++
++/-- Normalize Loom's unary triple head to VCVio's quantitative `Triple` abbrev.
++
++The two goals are definitionally equal for `OracleComp` with the no-exception
++postcondition, but proof terms produced directly against the `Std.Do'.Triple`
++head can trip Lean's kernel on anonymous proofs. Normalizing before structural
++steps keeps the Loom notation surface while making the unary tactic operate on
++its historical canonical head. -/
++private def normalizeStdDoTripleGoal : TacticM Bool := do
++  let target ← instantiateMVars (← getMainTarget)
++  unless (findAppWithHead? ``Std.Do'.Triple target).isSome do
++    return false
++  tryEvalTacticSyntax (← `(tactic| change OracleComp.ProgramLogic.Triple _ _ _))
++
++/-- Finish-only closure step: includes the support-sensitive leaf rules that are too expensive
++for the default `vcstep` hot path. -/
++def tryCloseSpecGoalFinal : TacticM Bool := do
++  tryApplyTripleHyp <||>
++  tryCloseNormalizedTransformerWP <||>
++  tryEvalTacticSyntax (← `(tactic| assumption)) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_pure _ _)) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_zero _ _)) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    classical
++    exact OracleComp.ProgramLogic.triple_support _)) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_propInd_of_support _ _ (by assumption))) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_probEvent_eq_one _ _ (by assumption))) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_probOutput_eq_one _ _ (by assumption))) <||>
++  tryEvalTacticSyntax (← `(tactic| exact le_refl _)) <||>
++  tryEvalTacticSyntax (← `(tactic|
++    exact OracleComp.ProgramLogic.triple_ofLE le_rfl)) <||>
++  tryCloseSpecGoalSearch
++
++/-- Run one bounded finish/closure pass across all current goals. -/
++def runVCGenClosePass : TacticM Bool := do
++  let goals ← getGoals
++  if goals.isEmpty then
++    return false
++  let mut progress := false
++  let mut newGoals : List MVarId := []
++  for goal in goals do
++    setGoals [goal]
++    if ← withVCGenCloseTiming tryCloseSpecGoalFinal then
++      progress := true
++      newGoals := newGoals ++ (← getGoals)
++    else
++      newGoals := newGoals ++ [goal]
++  setGoals newGoals
++  return progress
++
++/-- Try to decompose a `match` expression in the computation by case-splitting
++on its discriminant(s). Only fires when the computation is a compiled matcher
++(detected via `matchMatcherApp?`). Delegates to `split` which handles the actual
++case analysis. -/
++def tryMatchDecomp (comp : Expr) : TacticM Bool := do
++  let some _ ← Lean.Meta.matchMatcherApp? comp | return false
++  tryEvalTacticSyntax (← `(tactic| split))
++
++/-- Check if an expression is a lambda whose body does not use the bound variable
++(i.e. a constant function `fun _ => c`). -/
++def isConstantLambda (e : Expr) : Bool :=
++  match e.consumeMData with
++  | .lam _ _ body _ => !body.hasLooseBVar 0
++  | _ => false
++
++/-- Try the strongest automatic bind step: `triple_bind` plus immediate closure of the
++spec side-goal. -/
++def tryBindImmediate (comp : Expr) : TacticM Bool := do
++  if !isBindExpr comp then
++    return false
++  match ← observing? do
++    evalTactic (← `(tactic|
++      first
++        | apply OracleComp.ProgramLogic.triple_bind
++        | apply Std.Do'.Triple.bind))
++    unless ← tryCloseSpecGoalImmediate do throwError "" with
++  | some _ => return true
++  | none => return false
++
++/-- Try only the automatic loop-invariant rules, without the structural fallback rules. -/
++def tryLoopInvariantRuleAuto (comp : Expr) : TacticM Bool := do
++  let target ← instantiateMVars (← getMainTarget)
++  let some (_pre, _comp, post) := tripleGoalParts? target | return false
++  if isReplicateHead comp then
++    if isConstantLambda post then
++      match ← observing? do
++        evalTactic (← `(tactic| apply OracleComp.ProgramLogic.triple_replicate_inv))
++        unless ← tryCloseSpecGoalImmediate do throwError "" with
++      | some _ => return true
++      | none => pure ()
++  if isListFoldlMHead comp then
++    match ← observing? do
++      evalTactic (← `(tactic| apply OracleComp.ProgramLogic.triple_list_foldlM_inv))
++      unless ← tryCloseSpecGoalImmediate do throwError "" with
++    | some _ => return true
++    | none => pure ()
++  if isListMapMHead comp then
++    if isConstantLambda post then
++      match ← observing? do
++        evalTactic (← `(tactic| apply OracleComp.ProgramLogic.triple_list_mapM_inv))
++        unless ← tryCloseSpecGoalImmediate do throwError "" with
++      | some _ => return true
++      | none => pure ()
++  return false
++
++/-- Try only the structural loop fallback rules (`succ` / `cons`) after invariant search. -/
++def tryLoopFallback (comp : Expr) : TacticM Bool := do
++  if isReplicateHead comp then
++    if ← tryEvalTacticSyntax (← `(tactic|
++        apply OracleComp.ProgramLogic.triple_replicate_succ)) then
++      return true
++  if isListFoldlMHead comp then
++    if ← tryEvalTacticSyntax (← `(tactic|
++        apply OracleComp.ProgramLogic.triple_list_foldlM_cons)) then
++      return true
++  if isListMapMHead comp then
++    if ← tryEvalTacticSyntax (← `(tactic|
++        apply OracleComp.ProgramLogic.triple_list_mapM_cons)) then
++      return true
++  return false
++
++/-- Apply a loop invariant rule with an explicitly provided invariant. -/
++def runLoopInvExplicit (inv : TSyntax `term) : TacticM Bool := do
++  let target ← instantiateMVars (← getMainTarget)
++  match tripleGoalComp? target with
++  | none => return false
++  | some comp =>
++    let comp ← whnfReducible (← instantiateMVars comp)
++    if isReplicateHead comp then
++      tryEvalTacticSyntax (← `(tactic|
++        refine OracleComp.ProgramLogic.triple_replicate (I := $inv) ?_ ?_ ?_))
++    else if isListFoldlMHead comp then
++      tryEvalTacticSyntax (← `(tactic|
++        refine OracleComp.ProgramLogic.triple_list_foldlM (I := $inv) ?_ ?_ ?_))
++    else if isListMapMHead comp then
++      tryEvalTacticSyntax (← `(tactic|
++        refine OracleComp.ProgramLogic.triple_list_mapM (I := $inv) ?_ ?_ ?_))
++    else
++      return false
++
++/-- Find the local hypotheses that work as explicit bind cuts. -/
++def findHoareCutHintCandidates : TacticM (Array Name) :=
++  withVCGenLocalHintTiming <| withMainContext do
++    let target ← instantiateMVars (← getMainTarget)
++    let some comp := tripleGoalComp? target | return #[]
++    let comp ← whnfReducible (← instantiateMVars comp)
++    unless isBindExpr comp do return #[]
++    let mut found : Array Name := #[]
++    for localDecl in ← getLCtx do
++      unless localDecl.isImplementationDetail do
++        let name := localDecl.userName
++        if isUsableBinderName name then
++          let type ← instantiateMVars localDecl.type
++          unless type.isSort do
++            let saved ← saveState
++            let ok ← runHoareStepRuleUsing (mkIdent name)
++            saved.restore
++            if ok then
++              found := found.push name
++    return found
++
++/-- Find the unique local hypothesis that works as an explicit bind cut.
++Returns `none` if there are 0 or ≥ 2 viable candidates. -/
++def findUniqueHoareCutHint? : TacticM (Option Name) := do
++  let found ← findHoareCutHintCandidates
++  return found.toList.head? >>= fun first =>
++    if found.size = 1 then some first else none
++
++/-- Find the local hypotheses that work as explicit loop invariants. -/
++def findLoopInvHintCandidates : TacticM (Array Name) :=
++  withVCGenLocalHintTiming <| withMainContext do
++    let target ← instantiateMVars (← getMainTarget)
++    let some comp := tripleGoalComp? target | return #[]
++    let comp ← whnfReducible (← instantiateMVars comp)
++    unless isReplicateHead comp || isListFoldlMHead comp || isListMapMHead comp do
++      return #[]
++    let mut found : Array Name := #[]
++    for localDecl in ← getLCtx do
++      unless localDecl.isImplementationDetail do
++        let name := localDecl.userName
++        if isUsableBinderName name then
++          let type ← instantiateMVars localDecl.type
++          unless type.isSort do
++            let saved ← saveState
++            let ok ← runLoopInvExplicit (mkIdent name)
++            saved.restore
++            if ok then
++              found := found.push name
++    return found
++
++/-- Find the unique local hypothesis that works as an explicit loop invariant.
++Returns `none` if there are 0 or ≥ 2 viable candidates. -/
++def findUniqueLoopInvHint? : TacticM (Option Name) := do
++  let found ← findLoopInvHintCandidates
++  return found.toList.head? >>= fun first =>
++    if found.size = 1 then some first else none
++
++private def potentialLocalHintNames : TacticM (Array Name) := withMainContext do
++  let mut names : Array Name := #[]
++  for localDecl in ← getLCtx do
++    unless localDecl.isImplementationDetail do
++      let name := localDecl.userName
++      if isUsableBinderName name then
++        let type ← instantiateMVars localDecl.type
++        unless type.isSort do
++          names := names.push name
++  return names
++
++private def unaryGoalKindAndComp? (target : Expr) : Option (VCSpecKind × Expr) :=
++  match tripleGoalComp? target with
++  | some comp => some (.unaryTriple, comp)
++  | none =>
++      match wpGoalComp? target with
++      | some comp => some (.unaryWP, comp)
++      | none => none
++
++private def takeCandidatePrefix (entries : Array VCSpecEntry) : Array VCSpecEntry :=
++  (entries.toList.take 8).toArray
++
++private def registeredVCGenRuleCandidateTiers : TacticM (Array (Array VCSpecEntry)) := do
++  let target ← instantiateMVars (← getMainTarget)
++  let some (kind, comp) := unaryGoalKindAndComp? target | return #[]
++  let goalPattern := classifyUnaryCompPattern comp
++  let direct :=
++    (← getRegisteredUnaryVCSpecEntries comp).filter (·.kind == kind)
++  let fallbackAll :=
++    (← getVCSpecEntriesOfKind kind).filter fun entry =>
++      !(direct.any fun directEntry => directEntry.theoremName! == entry.theoremName!)
++  let fallbackPreferred := fallbackAll.filter (·.spec.compPattern == goalPattern)
++  let fallbackFallback := fallbackAll.filter (·.spec.compPattern != goalPattern)
++  let mut tiers : Array (Array VCSpecEntry) := #[]
++  for tier in #[direct, fallbackPreferred, fallbackFallback] do
++    let tier := takeCandidatePrefix tier
++    unless tier.isEmpty do
++      tiers := tiers.push tier
++  return tiers
++
++/-- Find the registered unary `@[vcspec]` entries whose bounded application
++makes progress on the current goal. Prefers direct discrimination-tree hits on
++the goal's `comp`, falling back to kind-matched entries filtered by structural
++compatibility. -/
++def findRegisteredVCGenRuleCandidates : TacticM (Array VCSpecEntry) := do
++  withVCGenRegisteredTiming do
++    for tier in ← registeredVCGenRuleCandidateTiers do
++      let mut found : Array VCSpecEntry := #[]
++      for entry in tier do
++        let saved ← saveState
++        let ok ← runUnaryVCSpecRule entry
++        saved.restore
++        if ok then
++          found := found.push entry
++      unless found.isEmpty do
++        return found
++    return #[]
++
++/-- Find the first registered unary `@[vcspec]` entry whose bounded
++application makes progress. -/
++def findRegisteredVCGenRule? : TacticM (Option VCSpecEntry) := do
++  withVCGenRegisteredTiming do
++    for tier in ← registeredVCGenRuleCandidateTiers do
++      for entry in tier do
++        let saved ← saveState
++        let ok ← runUnaryVCSpecRule entry
++        saved.restore
++        if ok then
++          return some entry
++    return none
++
++/-- Try registered `@[vcspec]` rules against a raw `wp` goal.
++
++This is intentionally direct-hit only: raw `wp` stepping is on the hot path, so
++we use the discrimination tree and avoid same-kind fallback scans. -/
++private def runRawWpVCSpecBackward : TacticM Bool := do
++  withVCGenRegisteredTiming do
++    let target ← instantiateMVars (← getMainTarget)
++    let comp? :=
++      match rawWPGoalParts? target with
++      | some (_, comp, _) => some comp
++      | none => wpGoalComp? target
++    let some comp := comp? | return false
++    let comp ← instantiateMVars comp
++    let goalPattern := classifyUnaryCompPattern comp
++    let entries ← getRegisteredUnaryVCSpecEntriesNoWhnf comp
++    let entries :=
++      takeCandidatePrefix <|
++        entries.filter (fun entry =>
++          entry.kind == .unaryWP && entry.spec.compPattern == goalPattern) ++
++          entries.filter (fun entry => entry.kind == .unaryTriple &&
++            entry.spec.compPattern == goalPattern)
++    for entry in entries do
++      if ← runUnaryVCSpecRule entry then
++        return true
++    return false
++
++def throwVCGenStepError : TacticM Unit := withMainContext do
++  let target ← instantiateMVars (← getMainTarget)
++  match tripleGoalComp? target with
++  | none =>
++      if hasProbGoal target then
++        if isProbEqGoal target then
++          throwError
++            "vcstep: found a `Pr[ ...] = Pr[ ...]` goal but no swap or congruence rule applied.\n\
++            Goal:{indentExpr target}\n\
++            Try `vcstep rw`, `vcstep rw under 1`, `vcstep rw congr`, \
++            `vcstep rw congr'`, `vcstep?`, or manual rewriting with \
++            `probEvent_bind_bind_swap`."
++        else
++          throwError
++            "vcstep: found a probability goal but could not lower it to a supported\n\
++            `Triple` or raw `wp` shape.\n\
++            Goal:{indentExpr target}\n\
++            Supported direct lowerings include `Pr[ ...] = 1`, `Pr[ ...] = Pr[ ...]`,\n\
++            and lower bounds such as `r ≤ Pr[ ...]` / `Pr[ ...] ≥ r`.\n\
++            Try `rw [probEvent_eq_wp_propInd]`, `vcstep?`, or manual rewriting."
++      else if let some comp := wpGoalComp? target then
++        let comp ← whnfReducible (← instantiateMVars comp)
++        let theoremMsg ← do
++          let tiers ← registeredVCGenRuleCandidateTiers
++          let thms := tiers.foldl (init := #[]) fun acc tier =>
++            acc ++ tier.map (·.theoremName!)
++          pure <| if thms.isEmpty then "" else
++            s!"\nRegistered `@[vcspec]` candidates: {formatCandidateNames thms}"
++        throwError
++          "vcstep: currently in raw `wp` continuation mode, but no matching rule applied to:\n\
++          {indentExpr comp}\n\
++          Try `vcstep?`, `vcstep`, or manual rewriting.{theoremMsg}"
++      else
++        throwError
++          "vcstep: expected a `Triple`, raw `wp`, or probability goal; got:{indentExpr target}"
++  | some comp =>
++      let comp ← whnfReducible (← instantiateMVars comp)
++      let cutMsg ←
++        if isBindExpr comp then
++          let cuts ← potentialLocalHintNames
++          pure <| if cuts.isEmpty then "" else
++            s!"\nPotential local cut candidates: {formatCandidateNames cuts}"
++        else
++          pure ""
++      let invMsg ←
++        if isReplicateHead comp || isListFoldlMHead comp || isListMapMHead comp then
++          let invs ← potentialLocalHintNames
++          pure <| if invs.isEmpty then "" else
++            s!"\nPotential local invariant candidates: {formatCandidateNames invs}"
++        else
++          pure ""
++      let theoremMsg ← do
++        let tiers ← registeredVCGenRuleCandidateTiers
++        let thms := tiers.foldl (init := #[]) fun acc tier =>
++          acc ++ tier.map (·.theoremName!)
++        pure <| if thms.isEmpty then "" else
++          s!"\nRegistered `@[vcspec]` candidates: {formatCandidateNames thms}"
++      throwError
++        "vcstep: found a `Triple` goal, but no matching rule applied to:{indentExpr comp}\n\
++        Try `vcstep`, or manually unfolding the remaining arithmetic side conditions.\
++        {cutMsg}{invMsg}{theoremMsg}"
++
++/-- Try to close or rewrite a `Pr[ ...] = Pr[ ...]` goal by swapping adjacent independent binds.
++Handles 0–2 layers of tsum peeling. -/
++inductive ProbEqAction where
++  | swap
++  | congr
++  | congrNoSupport
++  | rewrite
++  | rewriteUnder (depth : Nat)
++
++private def normalizeProbEqGoal : TacticM Unit := do
++  discard <| tryEvalTacticSyntax (← `(tactic|
++    simp only [map_eq_bind_pure_comp, bind_assoc]))
++
++def runProbEqSwap : TacticM Bool := do
++  normalizeProbEqGoal
++  tryEvalTacticSyntax (← `(tactic| (
++    try simp only [bind_assoc]
++    first
++      | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
++         exact probEvent_bind_bind_swap _ _ _ _)
++      | (rw [show Pr[ _ | _ >>= fun a => _ >>= fun b => _] =
++              Pr[ _ | _ >>= fun b => _ >>= fun a => _] from
++            probEvent_bind_bind_swap _ _ _ _])
++      | (conv in (Pr[ _ | _]) =>
++          rw [show Pr[ _ | _ >>= fun a => _ >>= fun b => _] =
++                Pr[ _ | _ >>= fun b => _ >>= fun a => _] from
++              probEvent_bind_bind_swap _ _ _ _])
++      | (rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
++         refine tsum_congr fun _ => ?_
++         congr 1
++         try simp only [monad_norm]
++         first
++           | exact probEvent_bind_bind_swap _ _ _ _
++           | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
++              exact probEvent_bind_bind_swap _ _ _ _))
++      | (rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
++         refine tsum_congr fun _ => ?_
++         congr 1
++         rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
++         refine tsum_congr fun _ => ?_
++         congr 1
++         try simp only [monad_norm]
++         first
++           | exact probEvent_bind_bind_swap _ _ _ _
++           | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
++              exact probEvent_bind_bind_swap _ _ _ _)))))
++
++def runProbEqCongrNoSupportWithNames (names : Array Name) : TacticM Bool := do
++  normalizeProbEqGoal
++  if ← tryEvalTacticSyntax (← `(tactic| apply probOutput_bind_congr')) then
++    discard <| introMainGoalNames names
++    return true
++  if ← tryEvalTacticSyntax (← `(tactic| apply probEvent_bind_congr')) then
++    discard <| introMainGoalNames names
++    return true
++  return false
++
++def runProbEqCongrNoSupport : TacticM Bool := do
++  let names ← getProbCongrNames false
++  runProbEqCongrNoSupportWithNames names
++
++/-- Try to decompose a `Pr[ ... | mx >>= f₁] = Pr[ ... | mx >>= f₂]` goal by congruence,
++then auto-intro the bound variable and support hypothesis. -/
++def runProbEqCongrWithNames (names : Array Name) : TacticM Bool := do
++  normalizeProbEqGoal
++  if ← tryEvalTacticSyntax (← `(tactic| apply probOutput_bind_congr)) then
++    discard <| introMainGoalNames names
++    return true
++  if ← tryEvalTacticSyntax (← `(tactic| apply probEvent_bind_congr)) then
++    discard <| introMainGoalNames names
++    return true
++  return false
++
++def runProbEqCongr : TacticM Bool := do
++  let names ← getProbCongrNames true
++  if ← runProbEqCongrWithNames names then
++    return true
++  runProbEqCongrNoSupport
++
++private def chunkNameArray
++    (names : Array Name) (width : Nat) : Option (Array (Array Name)) := Id.run do
++  if width = 0 || names.isEmpty then
++    return none
++  if names.size % width != 0 then
++    return none
++  let mut chunks : Array (Array Name) := #[]
++  let mut i := 0
++  while i < names.size do
++    chunks := chunks.push (names.extract i (i + width))
++    i := i + width
++  return some chunks
++
++def runProbEqCongrChainWithNames
++    (supportSensitive : Bool) (names : Array Name) : TacticM Bool := do
++  let width := if supportSensitive then 2 else 1
++  let some chunks := chunkNameArray names width | return false
++  let saved ← saveState
++  for chunk in chunks do
++    let ok ←
++      if supportSensitive then
++        runProbEqCongrWithNames chunk
++      else
++        runProbEqCongrNoSupportWithNames chunk
++    if !ok then
++      saved.restore
++      return false
++  return true
++
++/-- Build a theorem that swaps adjacent binds under `depth` shared prefixes. -/
++partial def mkProbSwapUnderProof (depth : Nat) : TacticM (TSyntax `term) := do
++  match depth with
++  | 0 => `(term| probEvent_bind_bind_swap _ _ _ _)
++  | depth + 1 =>
++      let inner ← mkProbSwapUnderProof depth
++      `(term| probEvent_bind_congr fun _ _ => $inner)
++
++/-- Try to rewrite one top-level bind-swap without closing the goal. -/
++def runProbEqRewrite : TacticM Bool := do
++  normalizeProbEqGoal
++  tryEvalTacticSyntax (← `(tactic| (
++    first
++      | (simp only [← probEvent_eq_eq_probOutput]
++         rw [probEvent_bind_bind_swap]
++         try simp only [probEvent_eq_eq_probOutput])
++      | rw [probEvent_bind_bind_swap])))
++
++/-- Try to rewrite one bind-swap under `depth` shared prefixes on either side. -/
++def runProbEqRewriteUnder (depth : Nat) : TacticM Bool := do
++  normalizeProbEqGoal
++  let proof ← mkProbSwapUnderProof depth
++  tryEvalTacticSyntax (← `(tactic| (
++    first
++      | (simp only [← probEvent_eq_eq_probOutput]
++         first
++           | (conv_lhs => rw [show _ from $proof])
++           | (conv_rhs => rw [show _ from $proof])
++         try simp only [probEvent_eq_eq_probOutput])
++      | first
++          | (conv_lhs => rw [show _ from $proof])
++          | (conv_rhs => rw [show _ from $proof]))))
++
++def runProbEqAction : ProbEqAction → TacticM Bool
++  | .swap => runProbEqSwap
++  | .congr => runProbEqCongr
++  | .congrNoSupport => runProbEqCongrNoSupport
++  | .rewrite => runProbEqRewrite
++  | .rewriteUnder depth =>
++      if depth = 0 then
++        runProbEqRewrite
++      else
++        runProbEqRewriteUnder depth
++
++private def renderProbEqAction : ProbEqAction → TacticM String
++  | .swap => pure "vcstep"
++  | .congr => do
++      let names ← getProbCongrNames true
++      pure s!"vcstep rw congr{renderAsClause names}"
++  | .congrNoSupport => do
++      let names ← getProbCongrNames false
++      pure s!"vcstep rw congr'{renderAsClause names}"
++  | .rewrite => pure "vcstep rw"
++  | .rewriteUnder depth => pure s!"vcstep rw under {depth}"
++
++private def renderProbEqPlan (actions : List ProbEqAction) : TacticM String := do
++  let parts ← actions.mapM renderProbEqAction
++  match parts with
++  | [] => pure "vcstep"
++  | [part] => pure part
++  | _ => pure s!"({String.intercalate "; " parts})"
++
++/-- Try a small backtracking-free sequence of probability-equality steps. -/
++def tryProbEqActions (steps : List ProbEqAction) : TacticM Bool := do
++  let saved ← saveState
++  for step in steps do
++    if (← getGoals).isEmpty then
++      return true
++    if !(← runProbEqAction step) then
++      saved.restore
++      return false
++  return true
++
++private def chooseBestProbEqPlan? (plans : List (List ProbEqAction)) :
++    TacticM (Option (List ProbEqAction × PreviewResult)) := do
++  withVCGenProbPlannerTiming do
++    let mut best? : Option (List ProbEqAction × PreviewResult) := none
++    for plan in plans do
++      let preview ← previewActionWithGoals (tryProbEqActions plan)
++      if preview.ok then
++        if preview.goalCount = 0 then
++          return some (plan, preview)
++        match best? with
++        | none => best? := some (plan, preview)
++        | some (_, bestPreview) =>
++            if preview.goalCount < bestPreview.goalCount then
++              best? := some (plan, preview)
++    return best?
++
++private def mkRewriteChain (depth : Nat) : List ProbEqAction :=
++  ((List.range depth).reverse.map fun idx => ProbEqAction.rewriteUnder (idx + 1)) ++
++    [ProbEqAction.rewrite]
++
++private def probEqCongrPlans (maxDepth : Nat) : List (List ProbEqAction) :=
++  let layers := (List.range maxDepth).map fun idx =>
++    let depth := idx + 1
++    [List.replicate depth ProbEqAction.congr,
++      List.replicate depth ProbEqAction.congrNoSupport]
++  layers.foldr List.append []
++
++private def probEqRewritePlans (maxDepth : Nat) : List (List ProbEqAction) :=
++  let layers := ((List.range (maxDepth + 1)).reverse.map fun depth =>
++    let chain := mkRewriteChain depth
++    [chain ++ [ProbEqAction.congr], chain ++ [ProbEqAction.congrNoSupport], chain])
++  layers.foldr List.append []
++
++def probEqActionPlans : List (List ProbEqAction) :=
++  [ [.swap]
++  , [.congr]
++  , [.congrNoSupport]
++  , [.rewrite, .congr]
++  , [.rewrite, .congrNoSupport]
++  , [.congr, .swap]
++  , [.congrNoSupport, .swap]
++  , [.rewriteUnder 1, .rewrite, .congr]
++  , [.rewriteUnder 1, .rewrite, .congrNoSupport]
++  , [.rewriteUnder 1, .rewrite]
++  , [.rewriteUnder 2, .rewriteUnder 1, .rewrite, .congr]
++  , [.rewriteUnder 2, .rewriteUnder 1, .rewrite, .congrNoSupport]
++  , [.rewriteUnder 2, .rewriteUnder 1, .rewrite]
++  ]
++
++private def probEqPlannerActionPlans : List (List ProbEqAction) :=
++  List.append (List.append (probEqRewritePlans 4) (probEqCongrPlans 3))
++    [ [.congr]
++    , [.congrNoSupport]
++    , [.congr, .swap]
++    , [.congrNoSupport, .swap]
++    , [.swap]
++    ]
++
++private def probExprComp? (expr : Expr) : Option Expr := do
++  let app ←
++    match findAppWithHead? ``probOutput expr with
++    | some app => some app
++    | none => findAppWithHead? ``probEvent expr
++  let args ← trailingArgs? app 2
++  let #[comp, _] := args | none
++  some comp
++
++private partial def topBindDepth (expr : Expr) : Nat :=
++  let expr := expr.consumeMData
++  if isBindExpr expr then
++    let args := expr.getAppArgs
++    if h : 0 < args.size then
++      let k := args[args.size - 1]
++      match k.consumeMData with
++      | .lam _ _ body _ => topBindDepth body + 1
++      | _ => 1
++    else
++      1
++  else
++    0
++
++private def probEqBindDepth? (target : Expr) : Option Nat := do
++  let target := target.consumeMData
++  guard <| target.isAppOfArity ``Eq 3
++  let lhsComp ← probExprComp? (target.getArg! 1)
++  let rhsComp ← probExprComp? (target.getArg! 2)
++  some (Nat.min (topBindDepth lhsComp) (topBindDepth rhsComp))
++
++private def probEqPlannerActionPlansForDepth (bindDepth : Nat) : List (List ProbEqAction) :=
++  let maxRewriteDepth := Nat.min 4 (bindDepth - 2)
++  let maxCongrDepth := Nat.min 3 bindDepth
++  List.append (List.append (probEqRewritePlans maxRewriteDepth) (probEqCongrPlans maxCongrDepth))
++    [ [.congr]
++    , [.congrNoSupport]
++    , [.congr, .swap]
++    , [.congrNoSupport, .swap]
++    , [.swap]
++    ]
++
++private def probEqPlannerActionPlansForGoal : TacticM (List (List ProbEqAction)) := do
++  let target ← instantiateMVars (← getMainTarget)
++  match probEqBindDepth? target with
++  | some depth => return probEqPlannerActionPlansForDepth depth
++  | none => return probEqPlannerActionPlans
++
++def tryProbEqPlans (plans : List (List ProbEqAction)) : TacticM Bool := do
++  match ← chooseBestProbEqPlan? plans with
++  | none => return false
++  | some (plan, _) => tryProbEqActions plan
++
++/-- Explicit probability-equality normalization.
++
++This runs the deeper planner-backed bind-rewrite/congruence search used by `vcstep?`, but only
++when the user asks for it. Plain `vcstep` keeps the smaller default plan set. -/
++def runProbEqNormalize : TacticM Bool := do
++  for plan in ← probEqPlannerActionPlansForGoal do
++    let preview ← previewActionWithGoals (tryProbEqActions plan)
++    if preview.ok && preview.goalCount = 0 then
++      return (← tryProbEqActions plan)
++  return false
++
++/-- Try to handle a `Pr[ ...] = Pr[ ...]` equality goal by swap, congr, or swap+congr.
++Also tries a fallback bridge from exact `probOutput` equalities into relational VCGen. -/
++def runProbOutputEqRelBridge : TacticM Bool := do
++  let saved ← saveState
++  let tryBridge (symmFirst : Bool) : TacticM Bool := do
++    match ← observing? do
++      if symmFirst then
++        evalTactic (← `(tactic| symm))
++      evalTactic (← `(tactic|
++        apply OracleComp.ProgramLogic.Relational.probOutput_eq_of_relTriple_eqRel))
++    with
++    | some _ => return true
++    | none => return false
++  if ← tryBridge false then
++    return true
++  saved.restore
++  if ← tryBridge true then
++    return true
++  saved.restore
++  return false
++
++/-- Try to handle a `Pr[ ...] = Pr[ ...]` equality goal by swap, congr, or swap+congr. -/
++def tryProbEqGoal : TacticM Bool := do
++  if ← tryProbEqPlans probEqActionPlans then
++    return true
++  runProbOutputEqRelBridge
++
++def throwVCGenStepRwError (depth : Nat) : TacticM Unit := withMainContext do
++  let target ← instantiateMVars (← getMainTarget)
++  if depth = 0 then
++    throwError
++      "vcstep rw: expected a `Pr[ ...] = Pr[ ...]` goal where one top-level\n\
++      bind-swap rewrite applies.\n\
++      Goal:{indentExpr target}"
++  else
++    throwError
++      "vcstep rw under {depth}: expected a `Pr[ ...] = Pr[ ...]` goal where one\n\
++      bind-swap rewrite applies under {depth} shared bind prefix(es).\n\
++      Goal:{indentExpr target}"
++
++def throwVCGenStepRwCongrError (supportSensitive : Bool) : TacticM Unit := withMainContext do
++  let target ← instantiateMVars (← getMainTarget)
++  if supportSensitive then
++    throwError
++      "vcstep rw congr: expected a `Pr[ ...] = Pr[ ...]` goal with a shared outer\n\
++      bind, leaving the bound variable and a support hypothesis.\n\
++      Goal:{indentExpr target}"
++  else
++    throwError
++      "vcstep rw congr': expected a `Pr[ ...] = Pr[ ...]` goal with a shared outer\n\
++      bind, leaving only the bound variable.\n\
++      Goal:{indentExpr target}"
++
++def throwVCGenStepRwNormalizeError : TacticM Unit := withMainContext do
++  let target ← instantiateMVars (← getMainTarget)
++  throwError
++    "vcstep rw normalize: expected a `Pr[ ...] = Pr[ ...]` goal where the bounded\n\
++    probability-equality planner can close the goal by bind-swap and congruence steps.\n\
++    Goal:{indentExpr target}"
++
++/-- Try to lower a probability goal into a `Triple`, `wp`, or probability-equality goal. -/
++def tryLowerProbGoal : TacticM Bool := do
++  let target ← instantiateMVars (← getMainTarget)
++  let isProbEventGoal := (findAppWithHead? ``probEvent target).isSome
++  let isProbOutputGoal := (findAppWithHead? ``probOutput target).isSome
++  unless isProbEventGoal || isProbOutputGoal do return false
++  if isProbEqGoal target then
++    if ← tryProbEqGoal then return true
++  if isProbEventGoal then
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [← OracleComp.ProgramLogic.triple_propInd_iff_probEvent_eq_one];
++        simp only [OracleComp.ProgramLogic.propInd_true])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [eq_comm (a := 1),
++            ← OracleComp.ProgramLogic.triple_propInd_iff_probEvent_eq_one];
++        simp only [OracleComp.ProgramLogic.propInd_true])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [← OracleComp.ProgramLogic.triple_propInd_iff_le_probEvent])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [ge_iff_le, ← OracleComp.ProgramLogic.triple_propInd_iff_le_probEvent])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [OracleComp.ProgramLogic.probEvent_eq_wp_propInd])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        simp only [OracleComp.ProgramLogic.probEvent_eq_wp_propInd])) then
++      return true
++  if isProbOutputGoal then
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [OracleComp.ProgramLogic.probOutput_eq_one_iff_triple])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [eq_comm, OracleComp.ProgramLogic.probOutput_eq_one_iff_triple])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [OracleComp.ProgramLogic.le_probOutput_iff_triple_indicator])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [ge_iff_le, OracleComp.ProgramLogic.le_probOutput_iff_triple_indicator])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        rw [OracleComp.ProgramLogic.probOutput_eq_wp_indicator])) then
++      return true
++    if ← tryEvalTacticSyntax (← `(tactic|
++        simp only [OracleComp.ProgramLogic.probOutput_eq_wp_indicator])) then
++      return true
++  return false
++
++/-- Continue structural stepping on a raw `wp` goal after probability lowering or explicit
++`wp`-level work. This stays deliberately smaller than the `Triple` path. -/
++def tryRawWpStructuralStep : TacticM Bool := do
++  let target ← instantiateMVars (← getMainTarget)
++  let comp? :=
++    match rawWPGoalParts? target with
++    | some (_, comp, _) => some comp
++    | none => wpGoalComp? target
++  let some comp := comp? | return false
++  let comp ← instantiateMVars comp
++  let isLowerBoundGoal := (rawWPGoalParts? target).isSome
++  if isLowerBoundGoal then
++    if ← runRawWpVCSpecBackward then
++      return true
++  if ← runWpStepRules then
++    return true
++  unless isLowerBoundGoal do
++    if ← runRawWpVCSpecBackward then
++      return true
++  if ← tryMatchDecomp comp then
++    return true
++  return false
++
++/-- Try to synthesize a support-based intermediate postcondition for a bind step.
++When the computation is `oa >>= f` and no explicit spec is available, tries applying
++`triple_bind` with an inferred cut and closing the spec subgoal via `triple_support`,
++which unifies the cut to `fun x => 𝟙⟦x ∈ support oa⟧`. -/
++def trySupportCutBind (comp : Expr) : TacticM Bool := do
++  if !isBindExpr comp then return false
++  match ← observing? do
++    evalTactic (← `(tactic| apply OracleComp.ProgramLogic.triple_bind))
++    unless ← tryEvalTacticSyntax (← `(tactic|
++      classical exact OracleComp.ProgramLogic.triple_support _)) do
++      throwError "" with
++  | some _ => return true
++  | none => return false
++
++/-! ### Goal classification and per-kind dispatch
++
++Mirrors `Loom.Tactic.VCGen.GoalKind` and `classifyGoalKind`: the structural
++core picks one strategy per goal kind instead of falling through a procedural
++cascade. New monad transformers / combinators become a new
++`UnaryGoalKind` constructor plus a registered `@[vcspec]` rule, not another
++`tryEvalTacticSyntax` block.
++
++Probability lowering is run opportunistically *before* classification, since
++`Pr[…]` may appear inside `wp …` goals that should ultimately dispatch via
++raw `wp` or `Triple` rules; only goals where lowering actually fires bypass
++the rest of the pipeline. -/
++
++/-- High-level classification of a unary VCGen target.
++
++Kept intentionally coarse: structural details (the bind continuation,
++ite condition, matcher app, …) live in the `comp` payload, not in the
++constructor, so per-kind handlers can share `tryEvalTacticSyntax`-style logic
++with the existing helpers. -/
++inductive UnaryGoalKind where
++  /-- A relational `RelTriple` / `RelWP` goal; defer to the relational planner. -/
++  | relational
++  /-- A unary `Triple` whose computation is a `>>=` application. -/
++  | tripleBind (comp : Expr)
++  /-- A unary `Triple` whose computation is `ite c a b` (non-dependent). -/
++  | tripleIte
++  /-- A unary `Triple` whose computation is `dite c a b` (dependent). -/
++  | tripleDite
++  /-- A unary `Triple` whose computation is a compiled `match` matcher. -/
++  | tripleMatch (comp : Expr)
++  /-- A unary `Triple` whose computation is a `replicate` / `List.mapM` /
++  `List.foldlM` head. -/
++  | tripleLoop (comp : Expr)
++  /-- A unary `Triple` whose computation does not match the cases above; the
++  dispatcher unfolds to raw `wp` and lets `@[wpStep]` rewrite. -/
++  | tripleOther
++  /-- A raw `wp` / `≤ wp` goal. -/
++  | rawWp
++  /-- Unrecognized goal shape. -/
++  | unknown
++  deriving Inhabited
++
++/-- Classify the current goal target as a `UnaryGoalKind`.
++
++Probability lowering is intentionally not a kind here: it runs opportunistically
++in `runVCGenStructuralCore` before classification, so a `wp … = ∑' u, Pr[…] * …`
++goal still classifies as `rawWp` / `tripleOther` rather than getting stuck in a
++non-lowerable prob branch. -/
++def classifyUnaryGoalKind (target : Expr) : MetaM UnaryGoalKind := do
++  if (relTripleGoalParts? target).isSome then return .relational
++  match tripleGoalComp? target with
++  | some comp =>
++      let comp ← whnfReducible (← instantiateMVars comp)
++      if isBindExpr comp then return .tripleBind comp
++      if isIfExpr comp then
++        return if comp.consumeMData.getAppFn.isConstOf ``dite then
++          .tripleDite else .tripleIte
++      if (← Lean.Meta.matchMatcherApp? comp).isSome then return .tripleMatch comp
++      if isReplicateHead comp || isListFoldlMHead comp || isListMapMHead comp then
++        return .tripleLoop comp
++      return .tripleOther
++  | none =>
++      if (wpGoalComp? target).isSome then return .rawWp
++      else return .unknown
++
++/-- Lower the current probability goal and, when the residual goal is a raw
++`wp`, follow up with one structural raw-`wp` step. Returns `true` whenever
++lowering actually fired (matching the original cascade's behaviour). -/
++private def runProbStep : TacticM Bool := do
++  unless ← tryLowerProbGoal do return false
++  if (← getGoals).isEmpty then
++    return true
++  let target ← instantiateMVars (← getMainTarget)
++  if (tripleGoalComp? target).isNone && (relTripleGoalParts? target).isNone
++      && (wpGoalComp? target).isSome then
++    discard <| tryRawWpStructuralStep
++  return true
++
++/-- Bind dispatch family: try `triple_bind` immediately, then a support-based
++cut, then the explicit `triple_bind_wp` / `stdDoTriple_bind_wp` closers. -/
++private def runTripleBindStep (comp : Expr) : TacticM Bool := do
++  if ← tryBindImmediate comp then return true
++  if ← trySupportCutBind comp then return true
++  if ← tryEvalTacticSyntax (← `(tactic|
++      apply OracleComp.ProgramLogic.triple_bind_wp)) then
++    closeTheoremStepGoals
++    return true
++  if ← tryEvalTacticSyntax (← `(tactic|
++      apply OracleComp.ProgramLogic.TacticInternals.Unary.stdDoTriple_bind_wp)) then
++    closeTheoremStepGoals
++    return true
++  return false
++
++/-- Last-ditch triple step: unfold to a raw `wp` goal and dispatch via
++`@[wpStep]`. Used when the specialized triple dispatchers do not match. -/
++private def runTripleFallback : TacticM Bool := do
++  match ← observing? do
++      evalTactic (← `(tactic| unfold OracleComp.ProgramLogic.Triple))
++      evalTactic (← `(tactic| change _ ≤ OracleComp.ProgramLogic.wp _ _))
++      unless ← runWpStepRules do
++        throwError "vcstep: no matching wp rule after unfolding `Triple`"
++    with
++  | some _ => return true
++  | none => return false
++
++end Unary
++end TacticInternals
++end OracleComp.ProgramLogic

--- a/scripts/compile_performance/measurements.json
+++ b/scripts/compile_performance/measurements.json
@@ -1,0 +1,960 @@
+{
+  "commit": "ffd0ca198fe6e640c0dd7f0f9c599943caacbf64",
+  "toolchain": "leanprover/lean4:v4.33.1",
+  "paired_protocol": "Round 0 excluded as warmup; rounds 1-5 original then candidate, serial. No instrumentation.",
+  "baseline": {
+    "Examples.ProgramLogic.RelationalStep": [
+      {
+        "wall_seconds": 2.8462351249999998,
+        "user_seconds": 2.689002,
+        "system_seconds": 0.9480959999999999,
+        "peak_rss_bytes": 1448591360,
+        "exit_code": 0,
+        "source_sha256": "2720d57d8d48108bce12d16972376805449e3e361f403c06913d407794e60faa",
+        "setup_sha256": "8e9200c42c3dd0f0443abe0699d9869a87447782858fec2d3ef47179ad0d0541"
+      },
+      {
+        "wall_seconds": 2.8490054160000007,
+        "user_seconds": 2.687608,
+        "system_seconds": 0.952019,
+        "peak_rss_bytes": 1446330368,
+        "exit_code": 0,
+        "source_sha256": "2720d57d8d48108bce12d16972376805449e3e361f403c06913d407794e60faa",
+        "setup_sha256": "8e9200c42c3dd0f0443abe0699d9869a87447782858fec2d3ef47179ad0d0541"
+      },
+      {
+        "wall_seconds": 2.8281508329999987,
+        "user_seconds": 2.674179,
+        "system_seconds": 0.941538,
+        "peak_rss_bytes": 1446641664,
+        "exit_code": 0,
+        "source_sha256": "2720d57d8d48108bce12d16972376805449e3e361f403c06913d407794e60faa",
+        "setup_sha256": "8e9200c42c3dd0f0443abe0699d9869a87447782858fec2d3ef47179ad0d0541"
+      },
+      {
+        "wall_seconds": 2.8285879169999983,
+        "user_seconds": 2.673271,
+        "system_seconds": 0.920194,
+        "peak_rss_bytes": 1446952960,
+        "exit_code": 0,
+        "source_sha256": "2720d57d8d48108bce12d16972376805449e3e361f403c06913d407794e60faa",
+        "setup_sha256": "8e9200c42c3dd0f0443abe0699d9869a87447782858fec2d3ef47179ad0d0541"
+      },
+      {
+        "wall_seconds": 2.82294325,
+        "user_seconds": 2.667749,
+        "system_seconds": 0.9489489999999999,
+        "peak_rss_bytes": 1446248448,
+        "exit_code": 0,
+        "source_sha256": "2720d57d8d48108bce12d16972376805449e3e361f403c06913d407794e60faa",
+        "setup_sha256": "8e9200c42c3dd0f0443abe0699d9869a87447782858fec2d3ef47179ad0d0541"
+      }
+    ],
+    "LatticeCrypto.MLKEM.Concrete.Encoding": [
+      {
+        "wall_seconds": 3.450577708,
+        "user_seconds": 7.368787,
+        "system_seconds": 0.957839,
+        "peak_rss_bytes": 2140553216,
+        "exit_code": 0,
+        "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+        "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+      },
+      {
+        "wall_seconds": 3.4244438330000007,
+        "user_seconds": 7.403677,
+        "system_seconds": 0.9569529999999999,
+        "peak_rss_bytes": 2139619328,
+        "exit_code": 0,
+        "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+        "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+      },
+      {
+        "wall_seconds": 3.454699875000001,
+        "user_seconds": 7.410602,
+        "system_seconds": 0.972942,
+        "peak_rss_bytes": 2140127232,
+        "exit_code": 0,
+        "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+        "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+      },
+      {
+        "wall_seconds": 3.432203083000001,
+        "user_seconds": 7.39285,
+        "system_seconds": 0.9517599999999999,
+        "peak_rss_bytes": 2141650944,
+        "exit_code": 0,
+        "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+        "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+      },
+      {
+        "wall_seconds": 3.4562785839999997,
+        "user_seconds": 7.412867,
+        "system_seconds": 0.9694959999999999,
+        "peak_rss_bytes": 2138554368,
+        "exit_code": 0,
+        "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+        "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+      }
+    ],
+    "VCVio.CryptoFoundations.FiatShamir.Sigma.Fork": [
+      {
+        "wall_seconds": 2.8167289159999997,
+        "user_seconds": 6.545161,
+        "system_seconds": 0.896079,
+        "peak_rss_bytes": 1601159168,
+        "exit_code": 0,
+        "source_sha256": "8898db5bccc52286762fa599d19c58dd439b0b563b2e413520d892764be080c7",
+        "setup_sha256": "a54df33db9e7f9d2588557c0f841cad29b4e6b56c1e8b32fb57bf49708d5a64e"
+      },
+      {
+        "wall_seconds": 2.8013454170000003,
+        "user_seconds": 6.514205,
+        "system_seconds": 0.8583569999999999,
+        "peak_rss_bytes": 1599553536,
+        "exit_code": 0,
+        "source_sha256": "8898db5bccc52286762fa599d19c58dd439b0b563b2e413520d892764be080c7",
+        "setup_sha256": "a54df33db9e7f9d2588557c0f841cad29b4e6b56c1e8b32fb57bf49708d5a64e"
+      },
+      {
+        "wall_seconds": 2.8255700410000006,
+        "user_seconds": 6.498441,
+        "system_seconds": 0.869906,
+        "peak_rss_bytes": 1603141632,
+        "exit_code": 0,
+        "source_sha256": "8898db5bccc52286762fa599d19c58dd439b0b563b2e413520d892764be080c7",
+        "setup_sha256": "a54df33db9e7f9d2588557c0f841cad29b4e6b56c1e8b32fb57bf49708d5a64e"
+      },
+      {
+        "wall_seconds": 2.821508957999999,
+        "user_seconds": 6.522314,
+        "system_seconds": 0.865269,
+        "peak_rss_bytes": 1598865408,
+        "exit_code": 0,
+        "source_sha256": "8898db5bccc52286762fa599d19c58dd439b0b563b2e413520d892764be080c7",
+        "setup_sha256": "a54df33db9e7f9d2588557c0f841cad29b4e6b56c1e8b32fb57bf49708d5a64e"
+      },
+      {
+        "wall_seconds": 2.815696667000001,
+        "user_seconds": 6.495943,
+        "system_seconds": 0.884598,
+        "peak_rss_bytes": 1601060864,
+        "exit_code": 0,
+        "source_sha256": "8898db5bccc52286762fa599d19c58dd439b0b563b2e413520d892764be080c7",
+        "setup_sha256": "a54df33db9e7f9d2588557c0f841cad29b4e6b56c1e8b32fb57bf49708d5a64e"
+      }
+    ],
+    "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain": [
+      {
+        "wall_seconds": 4.192938667,
+        "user_seconds": 14.466724,
+        "system_seconds": 1.75163,
+        "peak_rss_bytes": 1692319744,
+        "exit_code": 0,
+        "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+        "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+      },
+      {
+        "wall_seconds": 4.196699791999999,
+        "user_seconds": 14.501592,
+        "system_seconds": 1.7740719999999999,
+        "peak_rss_bytes": 1674297344,
+        "exit_code": 0,
+        "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+        "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+      },
+      {
+        "wall_seconds": 4.184245708000001,
+        "user_seconds": 14.355335,
+        "system_seconds": 1.7259039999999999,
+        "peak_rss_bytes": 1685241856,
+        "exit_code": 0,
+        "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+        "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+      },
+      {
+        "wall_seconds": 4.195446832999998,
+        "user_seconds": 14.451736,
+        "system_seconds": 1.706627,
+        "peak_rss_bytes": 1691172864,
+        "exit_code": 0,
+        "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+        "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+      },
+      {
+        "wall_seconds": 4.207472833000001,
+        "user_seconds": 14.53356,
+        "system_seconds": 1.771404,
+        "peak_rss_bytes": 1684996096,
+        "exit_code": 0,
+        "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+        "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+      }
+    ],
+    "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Compatibility": [
+      {
+        "wall_seconds": 3.265851459,
+        "user_seconds": 6.52312,
+        "system_seconds": 0.9411269999999999,
+        "peak_rss_bytes": 1583218688,
+        "exit_code": 0,
+        "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+        "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+      },
+      {
+        "wall_seconds": 3.2446768750000006,
+        "user_seconds": 6.508297,
+        "system_seconds": 0.9338799999999999,
+        "peak_rss_bytes": 1578909696,
+        "exit_code": 0,
+        "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+        "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+      },
+      {
+        "wall_seconds": 3.245692332999999,
+        "user_seconds": 6.497761,
+        "system_seconds": 0.9434739999999999,
+        "peak_rss_bytes": 1580253184,
+        "exit_code": 0,
+        "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+        "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+      },
+      {
+        "wall_seconds": 3.2513701249999993,
+        "user_seconds": 6.50926,
+        "system_seconds": 0.9449989999999999,
+        "peak_rss_bytes": 1580056576,
+        "exit_code": 0,
+        "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+        "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+      },
+      {
+        "wall_seconds": 3.296844166000003,
+        "user_seconds": 6.508657,
+        "system_seconds": 0.9875529999999999,
+        "peak_rss_bytes": 1583153152,
+        "exit_code": 0,
+        "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+        "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+      }
+    ],
+    "VCVio.CryptoFoundations.Fischlin.KnowledgeSoundness": [
+      {
+        "wall_seconds": 2.712741458,
+        "user_seconds": 6.942784,
+        "system_seconds": 1.095879,
+        "peak_rss_bytes": 1538441216,
+        "exit_code": 0,
+        "source_sha256": "a6edbfa2243a9f7cf49db68e2bb0ad9ba7d306936230b4f8a0701f20fa1696cc",
+        "setup_sha256": "5807cbe754a50306a63aaf200bfc96e6921eacff53aaa000b5dd18f529f98fea"
+      },
+      {
+        "wall_seconds": 2.6893879590000003,
+        "user_seconds": 6.894128,
+        "system_seconds": 1.091058,
+        "peak_rss_bytes": 1537998848,
+        "exit_code": 0,
+        "source_sha256": "a6edbfa2243a9f7cf49db68e2bb0ad9ba7d306936230b4f8a0701f20fa1696cc",
+        "setup_sha256": "5807cbe754a50306a63aaf200bfc96e6921eacff53aaa000b5dd18f529f98fea"
+      },
+      {
+        "wall_seconds": 2.70740975,
+        "user_seconds": 6.921665,
+        "system_seconds": 1.095216,
+        "peak_rss_bytes": 1540997120,
+        "exit_code": 0,
+        "source_sha256": "a6edbfa2243a9f7cf49db68e2bb0ad9ba7d306936230b4f8a0701f20fa1696cc",
+        "setup_sha256": "5807cbe754a50306a63aaf200bfc96e6921eacff53aaa000b5dd18f529f98fea"
+      },
+      {
+        "wall_seconds": 2.6923559170000004,
+        "user_seconds": 6.93402,
+        "system_seconds": 1.066392,
+        "peak_rss_bytes": 1537130496,
+        "exit_code": 0,
+        "source_sha256": "a6edbfa2243a9f7cf49db68e2bb0ad9ba7d306936230b4f8a0701f20fa1696cc",
+        "setup_sha256": "5807cbe754a50306a63aaf200bfc96e6921eacff53aaa000b5dd18f529f98fea"
+      },
+      {
+        "wall_seconds": 2.7082738749999997,
+        "user_seconds": 6.900913,
+        "system_seconds": 1.067825,
+        "peak_rss_bytes": 1536589824,
+        "exit_code": 0,
+        "source_sha256": "a6edbfa2243a9f7cf49db68e2bb0ad9ba7d306936230b4f8a0701f20fa1696cc",
+        "setup_sha256": "5807cbe754a50306a63aaf200bfc96e6921eacff53aaa000b5dd18f529f98fea"
+      }
+    ],
+    "VCVio.OracleComp.Coercions.Add": [
+      {
+        "wall_seconds": 4.6339591669999995,
+        "user_seconds": 4.894118,
+        "system_seconds": 0.750981,
+        "peak_rss_bytes": 1377665024,
+        "exit_code": 0,
+        "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+        "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+      },
+      {
+        "wall_seconds": 4.620540957999999,
+        "user_seconds": 4.882812,
+        "system_seconds": 0.7826649999999999,
+        "peak_rss_bytes": 1377533952,
+        "exit_code": 0,
+        "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+        "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+      },
+      {
+        "wall_seconds": 4.597520458,
+        "user_seconds": 4.858765,
+        "system_seconds": 0.748528,
+        "peak_rss_bytes": 1377927168,
+        "exit_code": 0,
+        "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+        "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+      },
+      {
+        "wall_seconds": 4.594476749999998,
+        "user_seconds": 4.863139,
+        "system_seconds": 0.753301,
+        "peak_rss_bytes": 1377779712,
+        "exit_code": 0,
+        "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+        "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+      },
+      {
+        "wall_seconds": 4.589626792000001,
+        "user_seconds": 4.852349,
+        "system_seconds": 0.760077,
+        "peak_rss_bytes": 1376763904,
+        "exit_code": 0,
+        "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+        "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+      }
+    ],
+    "VCVio.ProgramLogic.Relational.SimulateQ": [
+      {
+        "wall_seconds": 2.7432651669999997,
+        "user_seconds": 9.911478,
+        "system_seconds": 1.483782,
+        "peak_rss_bytes": 1551908864,
+        "exit_code": 0,
+        "source_sha256": "f0de403e032abfc1887f2286fde38240b9c03c10d0b30fd58472597535d1ade6",
+        "setup_sha256": "bc1365d26e0b1d98a260dd96f36372fe8b556574c997d12908e89adc2c45dfc9"
+      },
+      {
+        "wall_seconds": 2.731232417000001,
+        "user_seconds": 9.841904,
+        "system_seconds": 1.507365,
+        "peak_rss_bytes": 1551106048,
+        "exit_code": 0,
+        "source_sha256": "f0de403e032abfc1887f2286fde38240b9c03c10d0b30fd58472597535d1ade6",
+        "setup_sha256": "bc1365d26e0b1d98a260dd96f36372fe8b556574c997d12908e89adc2c45dfc9"
+      },
+      {
+        "wall_seconds": 2.7070682500000007,
+        "user_seconds": 9.796389,
+        "system_seconds": 1.501175,
+        "peak_rss_bytes": 1554726912,
+        "exit_code": 0,
+        "source_sha256": "f0de403e032abfc1887f2286fde38240b9c03c10d0b30fd58472597535d1ade6",
+        "setup_sha256": "bc1365d26e0b1d98a260dd96f36372fe8b556574c997d12908e89adc2c45dfc9"
+      },
+      {
+        "wall_seconds": 2.7244464169999993,
+        "user_seconds": 9.84093,
+        "system_seconds": 1.569147,
+        "peak_rss_bytes": 1548943360,
+        "exit_code": 0,
+        "source_sha256": "f0de403e032abfc1887f2286fde38240b9c03c10d0b30fd58472597535d1ade6",
+        "setup_sha256": "bc1365d26e0b1d98a260dd96f36372fe8b556574c997d12908e89adc2c45dfc9"
+      },
+      {
+        "wall_seconds": 2.714999292,
+        "user_seconds": 9.79754,
+        "system_seconds": 1.565732,
+        "peak_rss_bytes": 1549271040,
+        "exit_code": 0,
+        "source_sha256": "f0de403e032abfc1887f2286fde38240b9c03c10d0b30fd58472597535d1ade6",
+        "setup_sha256": "bc1365d26e0b1d98a260dd96f36372fe8b556574c997d12908e89adc2c45dfc9"
+      }
+    ],
+    "VCVio.ProgramLogic.Tactics.Relational.Internals": [
+      {
+        "wall_seconds": 3.038858542,
+        "user_seconds": 4.601839,
+        "system_seconds": 0.557738,
+        "peak_rss_bytes": 1572306944,
+        "exit_code": 0,
+        "source_sha256": "78f688ec1d95b7fa1dbfa3cc682cb0b92103d2f4cb1e2a018f2053b0eb545fcb",
+        "setup_sha256": "0c0628785b7de24253220daca842da1a1b38d87f9d05fa7e77a0f5f07a544afa"
+      },
+      {
+        "wall_seconds": 3.0285170410000006,
+        "user_seconds": 4.617413,
+        "system_seconds": 0.554102,
+        "peak_rss_bytes": 1572257792,
+        "exit_code": 0,
+        "source_sha256": "78f688ec1d95b7fa1dbfa3cc682cb0b92103d2f4cb1e2a018f2053b0eb545fcb",
+        "setup_sha256": "0c0628785b7de24253220daca842da1a1b38d87f9d05fa7e77a0f5f07a544afa"
+      },
+      {
+        "wall_seconds": 3.05336475,
+        "user_seconds": 4.64111,
+        "system_seconds": 0.549789,
+        "peak_rss_bytes": 1575403520,
+        "exit_code": 0,
+        "source_sha256": "78f688ec1d95b7fa1dbfa3cc682cb0b92103d2f4cb1e2a018f2053b0eb545fcb",
+        "setup_sha256": "0c0628785b7de24253220daca842da1a1b38d87f9d05fa7e77a0f5f07a544afa"
+      },
+      {
+        "wall_seconds": 3.036947915999999,
+        "user_seconds": 4.614222,
+        "system_seconds": 0.5559609999999999,
+        "peak_rss_bytes": 1573896192,
+        "exit_code": 0,
+        "source_sha256": "78f688ec1d95b7fa1dbfa3cc682cb0b92103d2f4cb1e2a018f2053b0eb545fcb",
+        "setup_sha256": "0c0628785b7de24253220daca842da1a1b38d87f9d05fa7e77a0f5f07a544afa"
+      },
+      {
+        "wall_seconds": 3.0307354999999987,
+        "user_seconds": 4.60904,
+        "system_seconds": 0.556488,
+        "peak_rss_bytes": 1579008000,
+        "exit_code": 0,
+        "source_sha256": "78f688ec1d95b7fa1dbfa3cc682cb0b92103d2f4cb1e2a018f2053b0eb545fcb",
+        "setup_sha256": "0c0628785b7de24253220daca842da1a1b38d87f9d05fa7e77a0f5f07a544afa"
+      }
+    ],
+    "VCVio.ProgramLogic.Tactics.Unary.Internals": [
+      {
+        "wall_seconds": 3.214954084,
+        "user_seconds": 4.715358,
+        "system_seconds": 1.238719,
+        "peak_rss_bytes": 1586200576,
+        "exit_code": 0,
+        "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+        "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+      },
+      {
+        "wall_seconds": 3.2361745829999995,
+        "user_seconds": 4.731559,
+        "system_seconds": 1.244916,
+        "peak_rss_bytes": 1587052544,
+        "exit_code": 0,
+        "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+        "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+      },
+      {
+        "wall_seconds": 3.2056573749999995,
+        "user_seconds": 4.705909,
+        "system_seconds": 1.24729,
+        "peak_rss_bytes": 1587363840,
+        "exit_code": 0,
+        "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+        "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+      },
+      {
+        "wall_seconds": 3.204521292000001,
+        "user_seconds": 4.698693,
+        "system_seconds": 1.246855,
+        "peak_rss_bytes": 1589903360,
+        "exit_code": 0,
+        "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+        "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+      },
+      {
+        "wall_seconds": 3.224277333,
+        "user_seconds": 4.728935,
+        "system_seconds": 1.245337,
+        "peak_rss_bytes": 1590018048,
+        "exit_code": 0,
+        "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+        "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+      }
+    ]
+  },
+  "paired": {
+    "LatticeCrypto.MLKEM.Concrete.Encoding": {
+      "original": [
+        {
+          "wall_seconds": 3.8294768340000003,
+          "user_seconds": 7.969608,
+          "system_seconds": 0.960163,
+          "peak_rss_bytes": 2141454336,
+          "exit_code": 0,
+          "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        },
+        {
+          "wall_seconds": 4.075422959,
+          "user_seconds": 8.417113,
+          "system_seconds": 1.011194,
+          "peak_rss_bytes": 2137817088,
+          "exit_code": 0,
+          "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        },
+        {
+          "wall_seconds": 3.784352125,
+          "user_seconds": 7.816948,
+          "system_seconds": 0.9407249999999999,
+          "peak_rss_bytes": 2141749248,
+          "exit_code": 0,
+          "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        },
+        {
+          "wall_seconds": 3.7167573330000003,
+          "user_seconds": 7.738084,
+          "system_seconds": 0.929774,
+          "peak_rss_bytes": 2142011392,
+          "exit_code": 0,
+          "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        },
+        {
+          "wall_seconds": 3.90731,
+          "user_seconds": 7.964904,
+          "system_seconds": 1.067063,
+          "peak_rss_bytes": 2142519296,
+          "exit_code": 0,
+          "source_sha256": "adedf5e5d16ee41289dc90afdd10236aae33c06c3861b31ac9538d6f595a03e3",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        }
+      ],
+      "candidate": [
+        {
+          "wall_seconds": 2.257897416,
+          "user_seconds": 6.087994,
+          "system_seconds": 0.956027,
+          "peak_rss_bytes": 1545109504,
+          "exit_code": 0,
+          "source_sha256": "b8f579b27f7566ff5fb5a599cfe2e182f0316ed22873e0e5b7e113a2da749dca",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        },
+        {
+          "wall_seconds": 2.467430917,
+          "user_seconds": 6.398156,
+          "system_seconds": 0.9873339999999999,
+          "peak_rss_bytes": 1539866624,
+          "exit_code": 0,
+          "source_sha256": "b8f579b27f7566ff5fb5a599cfe2e182f0316ed22873e0e5b7e113a2da749dca",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        },
+        {
+          "wall_seconds": 2.272605458,
+          "user_seconds": 6.033998,
+          "system_seconds": 0.931225,
+          "peak_rss_bytes": 1543241728,
+          "exit_code": 0,
+          "source_sha256": "b8f579b27f7566ff5fb5a599cfe2e182f0316ed22873e0e5b7e113a2da749dca",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        },
+        {
+          "wall_seconds": 2.226678583,
+          "user_seconds": 5.922547,
+          "system_seconds": 0.8981119999999999,
+          "peak_rss_bytes": 1545994240,
+          "exit_code": 0,
+          "source_sha256": "b8f579b27f7566ff5fb5a599cfe2e182f0316ed22873e0e5b7e113a2da749dca",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        },
+        {
+          "wall_seconds": 2.266802958,
+          "user_seconds": 5.987835,
+          "system_seconds": 0.9149529999999999,
+          "peak_rss_bytes": 1543667712,
+          "exit_code": 0,
+          "source_sha256": "b8f579b27f7566ff5fb5a599cfe2e182f0316ed22873e0e5b7e113a2da749dca",
+          "setup_sha256": "ac584e0604c23a0e75725ecc898c8a6f3f4a37345cb68f348d0eac71d0cc54c3"
+        }
+      ]
+    },
+    "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain": {
+      "original": [
+        {
+          "wall_seconds": 4.352166917,
+          "user_seconds": 14.615483,
+          "system_seconds": 1.227739,
+          "peak_rss_bytes": 1684635648,
+          "exit_code": 0,
+          "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        },
+        {
+          "wall_seconds": 4.463405083,
+          "user_seconds": 14.989169,
+          "system_seconds": 1.362034,
+          "peak_rss_bytes": 1688272896,
+          "exit_code": 0,
+          "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        },
+        {
+          "wall_seconds": 4.526224333,
+          "user_seconds": 14.927366,
+          "system_seconds": 1.381408,
+          "peak_rss_bytes": 1686618112,
+          "exit_code": 0,
+          "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        },
+        {
+          "wall_seconds": 4.4582506660000005,
+          "user_seconds": 14.724904,
+          "system_seconds": 1.320786,
+          "peak_rss_bytes": 1692205056,
+          "exit_code": 0,
+          "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        },
+        {
+          "wall_seconds": 4.5089468749999995,
+          "user_seconds": 14.882489,
+          "system_seconds": 1.405025,
+          "peak_rss_bytes": 1682702336,
+          "exit_code": 0,
+          "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        }
+      ],
+      "candidate": [
+        {
+          "wall_seconds": 4.346342209,
+          "user_seconds": 13.637921,
+          "system_seconds": 1.233455,
+          "peak_rss_bytes": 1676296192,
+          "exit_code": 0,
+          "source_sha256": "a1a21c6e44b7406a12dbe1dcae3000250f99162d1cbc4913d1e4e8fa57f8c8f6",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        },
+        {
+          "wall_seconds": 4.285782374999999,
+          "user_seconds": 13.516148,
+          "system_seconds": 1.19365,
+          "peak_rss_bytes": 1685258240,
+          "exit_code": 0,
+          "source_sha256": "a1a21c6e44b7406a12dbe1dcae3000250f99162d1cbc4913d1e4e8fa57f8c8f6",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        },
+        {
+          "wall_seconds": 4.269141209,
+          "user_seconds": 13.414259,
+          "system_seconds": 1.198537,
+          "peak_rss_bytes": 1682800640,
+          "exit_code": 0,
+          "source_sha256": "a1a21c6e44b7406a12dbe1dcae3000250f99162d1cbc4913d1e4e8fa57f8c8f6",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        },
+        {
+          "wall_seconds": 4.400347584,
+          "user_seconds": 13.701488,
+          "system_seconds": 1.316243,
+          "peak_rss_bytes": 1676951552,
+          "exit_code": 0,
+          "source_sha256": "a1a21c6e44b7406a12dbe1dcae3000250f99162d1cbc4913d1e4e8fa57f8c8f6",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        },
+        {
+          "wall_seconds": 4.386959792,
+          "user_seconds": 13.619847,
+          "system_seconds": 1.259837,
+          "peak_rss_bytes": 1687453696,
+          "exit_code": 0,
+          "source_sha256": "a1a21c6e44b7406a12dbe1dcae3000250f99162d1cbc4913d1e4e8fa57f8c8f6",
+          "setup_sha256": "53f18a2e8354305899d711d9c4a0f45fa85c3e098233a6c7805eb864f51299d8"
+        }
+      ]
+    },
+    "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Compatibility": {
+      "original": [
+        {
+          "wall_seconds": 3.606651459,
+          "user_seconds": 7.07535,
+          "system_seconds": 0.9920059999999999,
+          "peak_rss_bytes": 1584201728,
+          "exit_code": 0,
+          "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        },
+        {
+          "wall_seconds": 4.020451875,
+          "user_seconds": 7.784402,
+          "system_seconds": 0.8964789999999999,
+          "peak_rss_bytes": 1583054848,
+          "exit_code": 0,
+          "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        },
+        {
+          "wall_seconds": 3.598396625,
+          "user_seconds": 6.915105,
+          "system_seconds": 1.012813,
+          "peak_rss_bytes": 1580597248,
+          "exit_code": 0,
+          "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        },
+        {
+          "wall_seconds": 3.580806333,
+          "user_seconds": 7.037988,
+          "system_seconds": 0.969426,
+          "peak_rss_bytes": 1580285952,
+          "exit_code": 0,
+          "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        },
+        {
+          "wall_seconds": 3.480281459,
+          "user_seconds": 6.883096,
+          "system_seconds": 0.9433699999999999,
+          "peak_rss_bytes": 1582989312,
+          "exit_code": 0,
+          "source_sha256": "dcb162fe1c6e00d998a073da077bdfaffea4d6bad72f678e1badc6534a86387c",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        }
+      ],
+      "candidate": [
+        {
+          "wall_seconds": 3.5392119589999997,
+          "user_seconds": 6.54386,
+          "system_seconds": 0.992571,
+          "peak_rss_bytes": 1574076416,
+          "exit_code": 0,
+          "source_sha256": "e623f533d6cdc8d8fb4cc7351e6aa012b4ef686378d0b920a3ebbc810b9dca58",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        },
+        {
+          "wall_seconds": 3.770420916,
+          "user_seconds": 6.953978,
+          "system_seconds": 0.979552,
+          "peak_rss_bytes": 1572093952,
+          "exit_code": 0,
+          "source_sha256": "e623f533d6cdc8d8fb4cc7351e6aa012b4ef686378d0b920a3ebbc810b9dca58",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        },
+        {
+          "wall_seconds": 3.5375370839999998,
+          "user_seconds": 6.563006,
+          "system_seconds": 0.9685739999999999,
+          "peak_rss_bytes": 1571700736,
+          "exit_code": 0,
+          "source_sha256": "e623f533d6cdc8d8fb4cc7351e6aa012b4ef686378d0b920a3ebbc810b9dca58",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        },
+        {
+          "wall_seconds": 3.491124625,
+          "user_seconds": 6.438806,
+          "system_seconds": 0.956181,
+          "peak_rss_bytes": 1575567360,
+          "exit_code": 0,
+          "source_sha256": "e623f533d6cdc8d8fb4cc7351e6aa012b4ef686378d0b920a3ebbc810b9dca58",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        },
+        {
+          "wall_seconds": 3.531406958,
+          "user_seconds": 6.503094,
+          "system_seconds": 0.966923,
+          "peak_rss_bytes": 1571520512,
+          "exit_code": 0,
+          "source_sha256": "e623f533d6cdc8d8fb4cc7351e6aa012b4ef686378d0b920a3ebbc810b9dca58",
+          "setup_sha256": "7d4fbca4b4a8700aac9fc34851a13d9d1222d41d604dc1e904c6e169ddbdf0d7"
+        }
+      ]
+    },
+    "VCVio.OracleComp.Coercions.Add": {
+      "original": [
+        {
+          "wall_seconds": 5.230591834,
+          "user_seconds": 5.432791,
+          "system_seconds": 0.912052,
+          "peak_rss_bytes": 1379237888,
+          "exit_code": 0,
+          "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        },
+        {
+          "wall_seconds": 5.079587208,
+          "user_seconds": 5.270945,
+          "system_seconds": 0.9115439999999999,
+          "peak_rss_bytes": 1378779136,
+          "exit_code": 0,
+          "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        },
+        {
+          "wall_seconds": 5.1834736249999995,
+          "user_seconds": 5.289707,
+          "system_seconds": 0.9923919999999999,
+          "peak_rss_bytes": 1376911360,
+          "exit_code": 0,
+          "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        },
+        {
+          "wall_seconds": 5.1313315,
+          "user_seconds": 5.254607,
+          "system_seconds": 0.9475049999999999,
+          "peak_rss_bytes": 1377304576,
+          "exit_code": 0,
+          "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        },
+        {
+          "wall_seconds": 5.001347792000001,
+          "user_seconds": 5.143434,
+          "system_seconds": 0.9025749999999999,
+          "peak_rss_bytes": 1377730560,
+          "exit_code": 0,
+          "source_sha256": "5e42ddea24552f95629d1c30362574e8c6f08186c29bc3eb35c33606b8858b00",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        }
+      ],
+      "candidate": [
+        {
+          "wall_seconds": 2.8504380420000004,
+          "user_seconds": 2.993098,
+          "system_seconds": 0.9294819999999999,
+          "peak_rss_bytes": 1366884352,
+          "exit_code": 0,
+          "source_sha256": "5bb5dec9c7b11f55b2bba7ca52167043e79de2c6b563948bfcfa2ebc13cfdcaf",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        },
+        {
+          "wall_seconds": 2.859544708,
+          "user_seconds": 2.9908099999999997,
+          "system_seconds": 0.932615,
+          "peak_rss_bytes": 1366638592,
+          "exit_code": 0,
+          "source_sha256": "5bb5dec9c7b11f55b2bba7ca52167043e79de2c6b563948bfcfa2ebc13cfdcaf",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        },
+        {
+          "wall_seconds": 2.7085475829999996,
+          "user_seconds": 2.908405,
+          "system_seconds": 0.813894,
+          "peak_rss_bytes": 1366802432,
+          "exit_code": 0,
+          "source_sha256": "5bb5dec9c7b11f55b2bba7ca52167043e79de2c6b563948bfcfa2ebc13cfdcaf",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        },
+        {
+          "wall_seconds": 2.762902875,
+          "user_seconds": 2.951194,
+          "system_seconds": 0.8288719999999999,
+          "peak_rss_bytes": 1364688896,
+          "exit_code": 0,
+          "source_sha256": "5bb5dec9c7b11f55b2bba7ca52167043e79de2c6b563948bfcfa2ebc13cfdcaf",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        },
+        {
+          "wall_seconds": 2.745541417,
+          "user_seconds": 2.94445,
+          "system_seconds": 0.8544309999999999,
+          "peak_rss_bytes": 1365098496,
+          "exit_code": 0,
+          "source_sha256": "5bb5dec9c7b11f55b2bba7ca52167043e79de2c6b563948bfcfa2ebc13cfdcaf",
+          "setup_sha256": "17c7ce50f1443cbac25db94f74376fa08469f79f58dfa501535718218f61a66c"
+        }
+      ]
+    },
+    "VCVio.ProgramLogic.Tactics.Unary.Internals": {
+      "original": [
+        {
+          "wall_seconds": 3.746500458,
+          "user_seconds": 5.289416,
+          "system_seconds": 1.418864,
+          "peak_rss_bytes": 1589379072,
+          "exit_code": 0,
+          "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        },
+        {
+          "wall_seconds": 3.727212292,
+          "user_seconds": 5.267681,
+          "system_seconds": 1.326047,
+          "peak_rss_bytes": 1594032128,
+          "exit_code": 0,
+          "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        },
+        {
+          "wall_seconds": 3.674848167,
+          "user_seconds": 5.225823,
+          "system_seconds": 1.353075,
+          "peak_rss_bytes": 1589788672,
+          "exit_code": 0,
+          "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        },
+        {
+          "wall_seconds": 3.685431875,
+          "user_seconds": 5.224554,
+          "system_seconds": 1.343453,
+          "peak_rss_bytes": 1588117504,
+          "exit_code": 0,
+          "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        },
+        {
+          "wall_seconds": 3.595210083,
+          "user_seconds": 5.123216,
+          "system_seconds": 1.324979,
+          "peak_rss_bytes": 1588297728,
+          "exit_code": 0,
+          "source_sha256": "703f0484d7ae2d70e027d2f701b6de2b2bafa0f390a7bf0eb4a0cfe904f83ebe",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        }
+      ],
+      "candidate": [
+        {
+          "wall_seconds": 3.4403553749999998,
+          "user_seconds": 5.022287,
+          "system_seconds": 1.379735,
+          "peak_rss_bytes": 1593638912,
+          "exit_code": 0,
+          "source_sha256": "27e8a73e1e34de797661478d47e59db3bf2fcacde06b44eae7283f0efbb50b94",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        },
+        {
+          "wall_seconds": 3.437774709,
+          "user_seconds": 4.958006,
+          "system_seconds": 1.394021,
+          "peak_rss_bytes": 1591721984,
+          "exit_code": 0,
+          "source_sha256": "27e8a73e1e34de797661478d47e59db3bf2fcacde06b44eae7283f0efbb50b94",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        },
+        {
+          "wall_seconds": 3.305694125,
+          "user_seconds": 4.857894,
+          "system_seconds": 1.334643,
+          "peak_rss_bytes": 1593081856,
+          "exit_code": 0,
+          "source_sha256": "27e8a73e1e34de797661478d47e59db3bf2fcacde06b44eae7283f0efbb50b94",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        },
+        {
+          "wall_seconds": 3.325090167,
+          "user_seconds": 4.9097669999999995,
+          "system_seconds": 1.326612,
+          "peak_rss_bytes": 1586429952,
+          "exit_code": 0,
+          "source_sha256": "27e8a73e1e34de797661478d47e59db3bf2fcacde06b44eae7283f0efbb50b94",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        },
+        {
+          "wall_seconds": 3.272898667,
+          "user_seconds": 4.828619,
+          "system_seconds": 1.321174,
+          "peak_rss_bytes": 1585938432,
+          "exit_code": 0,
+          "source_sha256": "27e8a73e1e34de797661478d47e59db3bf2fcacde06b44eae7283f0efbb50b94",
+          "setup_sha256": "61c1b67d3d9406ba816fe5038dd5d2d2e067aab765005df067349f51b1e55cab"
+        }
+      ]
+    }
+  },
+  "platform": "macOS-26.4.1-arm64-arm-64bit"
+}

--- a/scripts/compile_performance/remediation-measurements.json
+++ b/scripts/compile_performance/remediation-measurements.json
@@ -1,0 +1,547 @@
+{
+  "baseline_commit": "ffd0ca198fe6e640c0dd7f0f9c599943caacbf64",
+  "toolchain": "v4.33.1",
+  "platform": "macOS arm64",
+  "native_submodules_present": false,
+  "builds": [
+    {
+      "label": "combined-screen-1-baseline",
+      "start": 333660.541499,
+      "end": 333795.743408,
+      "wall_seconds": 135.2019100000034,
+      "user_seconds": 948.276683,
+      "system_seconds": 454.710863,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    {
+      "label": "combined-screen-1-candidate",
+      "start": 333528.046898,
+      "end": 333660.414245,
+      "wall_seconds": 132.36734699999215,
+      "user_seconds": 945.956278,
+      "system_seconds": 449.65654,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    {
+      "label": "combined-screen-2-baseline",
+      "start": 333795.8755,
+      "end": 333929.467807,
+      "wall_seconds": 133.59230699995533,
+      "user_seconds": 947.299447,
+      "system_seconds": 434.032931,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    {
+      "label": "combined-screen-2-candidate",
+      "start": 333929.588182,
+      "end": 334061.605375,
+      "wall_seconds": 132.01719400001457,
+      "user_seconds": 946.40561,
+      "system_seconds": 449.754259,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    {
+      "label": "combined-screen-3-baseline",
+      "start": 334193.795212,
+      "end": 334328.270452,
+      "wall_seconds": 134.47523999999976,
+      "user_seconds": 943.532495,
+      "system_seconds": 450.014579,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    {
+      "label": "combined-screen-3-candidate",
+      "start": 334061.730952,
+      "end": 334193.680881,
+      "wall_seconds": 131.9499300000025,
+      "user_seconds": 948.341874,
+      "system_seconds": 449.176624,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    {
+      "label": "remediation-import-baseline",
+      "start": 365984.400488,
+      "end": 366113.734612,
+      "wall_seconds": 129.33412499999395,
+      "user_seconds": 949.800987,
+      "system_seconds": 467.387458,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    {
+      "label": "remediation-import-candidate",
+      "start": 366113.855243,
+      "end": 366259.065602,
+      "wall_seconds": 145.2103599999682,
+      "user_seconds": 963.688259,
+      "system_seconds": 496.434479,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    {
+      "label": "remediation-combined-screen-candidate-1",
+      "start": 366847.485062,
+      "end": 366924.532113,
+      "wall_seconds": 77.04705200000899,
+      "user_seconds": 503.576196,
+      "system_seconds": 300.360426,
+      "exit_code": -15,
+      "timed_out": false
+    }
+  ],
+  "profile": {
+    "result": {
+      "start": 337058.47494,
+      "end": 337226.410713,
+      "wall_seconds": 167.93577400001232,
+      "user_seconds": 972.443512,
+      "system_seconds": 762.347888,
+      "exit_code": 0,
+      "timed_out": false
+    },
+    "module_count": 553,
+    "module_cpu_seconds": 1680.9130140000002,
+    "residual_cpu_seconds": 53.878385999999864,
+    "peak_compilers": 14,
+    "weighted_path": [
+      127.16886900027748,
+      [
+        "ToMathlib.General",
+        "ToMathlib.ProbabilityTheory.SPMF",
+        "VCVio.EvalDist.Defs.Support",
+        "VCVio.EvalDist.Defs.Measure",
+        "VCVio.EvalDist.Defs.Basic",
+        "VCVio.EvalDist.Monad.Basic",
+        "VCVio.EvalDist.Monad.Map",
+        "VCVio.EvalDist.Monad.Seq",
+        "VCVio.EvalDist.Defs.NeverFails",
+        "VCVio.EvalDist.Option",
+        "VCVio.EvalDist.Instances.OptionT",
+        "VCVio.OracleComp.EvalDist",
+        "VCVio.OracleComp.ProbComp",
+        "VCVio.OracleComp.Constructions.SampleableType",
+        "VCVio.OracleComp.SimSemantics.QueryImpl.Constructions",
+        "VCVio.OracleComp.QueryTracking.Tracing",
+        "VCVio.OracleComp.QueryTracking.CountingOracle",
+        "VCVio.OracleComp.QueryTracking.QueryBound",
+        "VCVio.OracleComp.QueryTracking.CachingOracle",
+        "VCVio.OracleComp.QueryTracking.RandomOracle.Basic",
+        "VCVio.CryptoFoundations.PRF",
+        "Examples.PRFTagReader.Defs",
+        "Examples.PRFTagReader.Auth",
+        "Examples.PRFTagReader.Collision.ForgeStep",
+        "Examples.PRFTagReader.Collision",
+        "Examples.PRFTagReader.BadEvent",
+        "Examples.PRFTagReader",
+        "Examples.PRFTagReader.PRFReductions.Reductions",
+        "Examples.PRFTagReader.PRFReductions.IdealHandlers",
+        "Examples.PRFTagReader.PRFReductions.Structural",
+        "Examples.PRFTagReader.PRFReductions",
+        "Examples.PRFTagReader.Table",
+        "Examples.PRFTagReader.MultipleToHybrid.Setup",
+        "Examples.PRFTagReader.MultipleToHybrid.EagerSetup",
+        "Examples.PRFTagReader.DirectCoupling.StepLemmas",
+        "Examples.PRFTagReader.DirectCoupling.ReaderCase",
+        "Examples.PRFTagReader.DirectCoupling.Compose",
+        "Examples.PRFTagReader.MultipleBadCollision",
+        "Examples.PRFTagReader.UnlinkReduction",
+        "Examples.PRFTagReader.Asymptotic",
+        "Examples"
+      ]
+    ]
+  },
+  "handler_reuse": [
+    {
+      "label": "candidate-0",
+      "wall_seconds": 4.4402448340000005,
+      "user_seconds": 15.629858,
+      "system_seconds": 1.345451,
+      "exit_code": 0,
+      "source_sha256": "ff898f2c1a3a4abaccec6ead4be8856acf87d20a7f6ffd9676d0a8afb733c9e1"
+    },
+    {
+      "label": "candidate-1",
+      "wall_seconds": 4.301158208,
+      "user_seconds": 15.583618,
+      "system_seconds": 1.193429,
+      "exit_code": 0,
+      "source_sha256": "ff898f2c1a3a4abaccec6ead4be8856acf87d20a7f6ffd9676d0a8afb733c9e1"
+    },
+    {
+      "label": "candidate-2",
+      "wall_seconds": 4.316946917,
+      "user_seconds": 15.564733,
+      "system_seconds": 1.267536,
+      "exit_code": 0,
+      "source_sha256": "ff898f2c1a3a4abaccec6ead4be8856acf87d20a7f6ffd9676d0a8afb733c9e1"
+    },
+    {
+      "label": "candidate-3",
+      "wall_seconds": 4.3711646250000005,
+      "user_seconds": 15.270442,
+      "system_seconds": 1.280872,
+      "exit_code": 0,
+      "source_sha256": "ff898f2c1a3a4abaccec6ead4be8856acf87d20a7f6ffd9676d0a8afb733c9e1"
+    },
+    {
+      "label": "candidate-4",
+      "wall_seconds": 4.211297834,
+      "user_seconds": 15.094238,
+      "system_seconds": 1.112533,
+      "exit_code": 0,
+      "source_sha256": "ff898f2c1a3a4abaccec6ead4be8856acf87d20a7f6ffd9676d0a8afb733c9e1"
+    },
+    {
+      "label": "candidate-5",
+      "wall_seconds": 4.198089749999999,
+      "user_seconds": 15.038596,
+      "system_seconds": 1.168169,
+      "exit_code": 0,
+      "source_sha256": "ff898f2c1a3a4abaccec6ead4be8856acf87d20a7f6ffd9676d0a8afb733c9e1"
+    },
+    {
+      "label": "original-0",
+      "wall_seconds": 4.682405917,
+      "user_seconds": 15.602256,
+      "system_seconds": 1.382372,
+      "exit_code": 0,
+      "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806"
+    },
+    {
+      "label": "original-1",
+      "wall_seconds": 4.250812291,
+      "user_seconds": 14.667532,
+      "system_seconds": 1.2649,
+      "exit_code": 0,
+      "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806"
+    },
+    {
+      "label": "original-2",
+      "wall_seconds": 4.2480002080000006,
+      "user_seconds": 14.670196,
+      "system_seconds": 1.203247,
+      "exit_code": 0,
+      "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806"
+    },
+    {
+      "label": "original-3",
+      "wall_seconds": 4.172415083,
+      "user_seconds": 14.271368,
+      "system_seconds": 1.2382009999999999,
+      "exit_code": 0,
+      "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806"
+    },
+    {
+      "label": "original-4",
+      "wall_seconds": 4.1742430839999995,
+      "user_seconds": 14.523312,
+      "system_seconds": 1.172548,
+      "exit_code": 0,
+      "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806"
+    },
+    {
+      "label": "original-5",
+      "wall_seconds": 4.209796625,
+      "user_seconds": 14.489051,
+      "system_seconds": 1.204228,
+      "exit_code": 0,
+      "source_sha256": "394bbafc0a83611a39e3d0ee9686918a3a850ba4afdad0cec4cc722d238cf806"
+    }
+  ],
+  "native_linter": [
+    {
+      "module": "ToMathlib.General",
+      "round": 0,
+      "variant": "original",
+      "wall_seconds": 2.585299458,
+      "cpu_seconds": 5.2629079999999995,
+      "exit_code": 0
+    },
+    {
+      "module": "ToMathlib.General",
+      "round": 0,
+      "variant": "native",
+      "wall_seconds": 3.108264917,
+      "cpu_seconds": 4.96209,
+      "exit_code": 0
+    },
+    {
+      "module": "ToMathlib.General",
+      "round": 1,
+      "variant": "native",
+      "wall_seconds": 2.4576787079999995,
+      "cpu_seconds": 4.743131,
+      "exit_code": 0
+    },
+    {
+      "module": "ToMathlib.General",
+      "round": 1,
+      "variant": "original",
+      "wall_seconds": 2.545373209000001,
+      "cpu_seconds": 5.233689,
+      "exit_code": 0
+    },
+    {
+      "module": "ToMathlib.General",
+      "round": 2,
+      "variant": "original",
+      "wall_seconds": 2.5349900830000003,
+      "cpu_seconds": 5.147459,
+      "exit_code": 0
+    },
+    {
+      "module": "ToMathlib.General",
+      "round": 2,
+      "variant": "native",
+      "wall_seconds": 2.5099231250000003,
+      "cpu_seconds": 4.8203309999999995,
+      "exit_code": 0
+    },
+    {
+      "module": "ToMathlib.General",
+      "round": 3,
+      "variant": "native",
+      "wall_seconds": 2.439686,
+      "cpu_seconds": 4.777885,
+      "exit_code": 0
+    },
+    {
+      "module": "ToMathlib.General",
+      "round": 3,
+      "variant": "original",
+      "wall_seconds": 2.4450502499999978,
+      "cpu_seconds": 5.016838,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain",
+      "round": 0,
+      "variant": "original",
+      "wall_seconds": 4.474290917000001,
+      "cpu_seconds": 16.113817,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain",
+      "round": 0,
+      "variant": "native",
+      "wall_seconds": 4.282996582999999,
+      "cpu_seconds": 15.404848,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain",
+      "round": 1,
+      "variant": "native",
+      "wall_seconds": 4.317469125000002,
+      "cpu_seconds": 15.411659,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain",
+      "round": 1,
+      "variant": "original",
+      "wall_seconds": 4.387047333999995,
+      "cpu_seconds": 16.120623,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain",
+      "round": 2,
+      "variant": "original",
+      "wall_seconds": 4.453565708000006,
+      "cpu_seconds": 16.330952,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain",
+      "round": 2,
+      "variant": "native",
+      "wall_seconds": 4.522592875000001,
+      "cpu_seconds": 15.80991,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain",
+      "round": 3,
+      "variant": "native",
+      "wall_seconds": 4.456011374999996,
+      "cpu_seconds": 15.563637,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.CryptoFoundations.FiatShamir.Sigma.Stateful.Chain",
+      "round": 3,
+      "variant": "original",
+      "wall_seconds": 4.521555208000002,
+      "cpu_seconds": 16.422551,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.ProgramLogic.Tactics.Unary.Internals",
+      "round": 0,
+      "variant": "original",
+      "wall_seconds": 3.302497416999998,
+      "cpu_seconds": 6.188769,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.ProgramLogic.Tactics.Unary.Internals",
+      "round": 0,
+      "variant": "native",
+      "wall_seconds": 3.2748864170000047,
+      "cpu_seconds": 5.90195,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.ProgramLogic.Tactics.Unary.Internals",
+      "round": 1,
+      "variant": "native",
+      "wall_seconds": 3.3546776250000008,
+      "cpu_seconds": 6.010407,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.ProgramLogic.Tactics.Unary.Internals",
+      "round": 1,
+      "variant": "original",
+      "wall_seconds": 3.3147835829999934,
+      "cpu_seconds": 6.212804,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.ProgramLogic.Tactics.Unary.Internals",
+      "round": 2,
+      "variant": "original",
+      "wall_seconds": 3.2955952089999982,
+      "cpu_seconds": 6.18921,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.ProgramLogic.Tactics.Unary.Internals",
+      "round": 2,
+      "variant": "native",
+      "wall_seconds": 3.3488054170000083,
+      "cpu_seconds": 6.006579,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.ProgramLogic.Tactics.Unary.Internals",
+      "round": 3,
+      "variant": "native",
+      "wall_seconds": 3.335286874999994,
+      "cpu_seconds": 5.969548,
+      "exit_code": 0
+    },
+    {
+      "module": "VCVio.ProgramLogic.Tactics.Unary.Internals",
+      "round": 3,
+      "variant": "original",
+      "wall_seconds": 3.3028854580000058,
+      "cpu_seconds": 6.258804,
+      "exit_code": 0
+    }
+  ],
+  "goal_difference": [
+    {
+      "variant": "list",
+      "n": 0,
+      "rounds": 200,
+      "ns": 147375,
+      "checksum": 0
+    },
+    {
+      "variant": "indexed",
+      "n": 0,
+      "rounds": 200,
+      "ns": 144542,
+      "checksum": 0
+    },
+    {
+      "variant": "list",
+      "n": 1,
+      "rounds": 200,
+      "ns": 173750,
+      "checksum": 0
+    },
+    {
+      "variant": "indexed",
+      "n": 1,
+      "rounds": 200,
+      "ns": 433292,
+      "checksum": 0
+    },
+    {
+      "variant": "list",
+      "n": 4,
+      "rounds": 200,
+      "ns": 495083,
+      "checksum": 400
+    },
+    {
+      "variant": "indexed",
+      "n": 4,
+      "rounds": 200,
+      "ns": 1210292,
+      "checksum": 400
+    },
+    {
+      "variant": "list",
+      "n": 16,
+      "rounds": 200,
+      "ns": 4912000,
+      "checksum": 1600
+    },
+    {
+      "variant": "indexed",
+      "n": 16,
+      "rounds": 200,
+      "ns": 6120333,
+      "checksum": 1600
+    },
+    {
+      "variant": "list",
+      "n": 64,
+      "rounds": 200,
+      "ns": 69216417,
+      "checksum": 6400
+    },
+    {
+      "variant": "indexed",
+      "n": 64,
+      "rounds": 200,
+      "ns": 28356584,
+      "checksum": 6400
+    },
+    {
+      "variant": "list",
+      "n": 256,
+      "rounds": 200,
+      "ns": 1071333083,
+      "checksum": 25600
+    },
+    {
+      "variant": "indexed",
+      "n": 256,
+      "rounds": 200,
+      "ns": 117176417,
+      "checksum": 25600
+    }
+  ],
+  "candidate_patch_sha256": {
+    "encoding-kernel.patch": "1b5b0bfa13e887fc57a305fc42a0fabea0376553a917f15bcd1d0a4eea94e18b",
+    "chain-simp-only.patch": "76ad18fff5478ab217f788bc34bb51dbe70ea17a932605fa7e423e0a1e946d6f",
+    "handler-support-reuse.patch": "f02796740c845b65135631ce9549c31000f49ab8bc17694cd206df53454f0a60",
+    "compatibility-simp-only.patch": "1ef70a2f21e59c785b315aa1a464fd4d506ff42c9a359716ad6c3ecc456886cc",
+    "import-cleanup.patch": "2001896803ab5223baa9ba2f4e808d7adb35aef90aeb360ff254accf0981e044",
+    "add-local-diagnostic.patch": "82af2b9e1b9316e1d156e06137d2cf6d4a874c891d00b89f626932d9f2a07feb",
+    "unary-expected-type.patch": "d36dcc3834ce58f780df387147b60c76bc5a689332da1ffcc03fa670fd512ed9",
+    "unary-split.patch": "699bb4fa7760d040f0fd40c38a0cb7216e12eda30530f97b19b53fdc8aebe56f"
+  }
+}

--- a/scripts/compile_performance/validation.json
+++ b/scripts/compile_performance/validation.json
@@ -1,0 +1,22 @@
+{
+  "baseline_commit": "ffd0ca198fe6e640c0dd7f0f9c599943caacbf64",
+  "phase": "historical isolated-candidate validation before source fixes were applied; see compile-performance-remediation.md for subsequent validation",
+  "isolated_candidates": ["encoding-kernel.patch", "unary-expected-type.patch"],
+  "production_lean_files_changed": false,
+  "clean_project_build": {
+    "protocol": "Project build directory moved aside; dependencies cached; one run per variant; seven non-test libraries",
+    "baseline": {"wall_seconds": 135.27, "user_seconds": 951.02, "system_seconds": 429.41, "exit_code": 0},
+    "candidate": {"wall_seconds": 138.56, "user_seconds": 948.12, "system_seconds": 427.87, "exit_code": 0},
+    "overall_speedup_demonstrated": false
+  },
+  "test_libraries": {"wall_seconds": 15.51, "jobs": 3769, "exit_code": 0},
+  "smoke": {"wall_seconds": 1.99, "exit_code": 0},
+  "warm_rebuild": {"wall_seconds": 1.34, "exit_code": 0},
+  "axiomsweep": {"passed": true, "declarations": 17878, "modules": 553, "existing_sorry_tainted": 40, "nonstandard_axiom_tainted": 0, "new_taint": false},
+  "axiomsweep_fixture_matrix": "passed",
+  "extern_isolation": "passed",
+  "interop_isolation": "passed",
+  "pmf_boundary": "passed",
+  "native_backends": "absent; stubs; native differential executables not run",
+  "runner_checks": ["syntax", "successful replay", "invalid count", "duplicate label", "stale toolchain", "timeout"]
+}

--- a/scripts/compile_performance/whole-build-method.md
+++ b/scripts/compile_performance/whole-build-method.md
@@ -1,0 +1,82 @@
+# Whole-build measurement protocol
+
+`profile_build.py` records a complete seven-library Lake build. Python 3.9+
+and POSIX are required. Keep results and worktrees inside the repository:
+
+```sh
+python3 scripts/profile_build.py --root .lake/compile-performance/worktrees/baseline \
+  --output .lake/compile-performance/whole-build --label baseline-1 --clean
+```
+
+`--clean` moves the project's existing `.lake/build` to the result directory's
+`saved-project-build`; it does not delete it, clean dependencies, or alter the
+installed toolchain. Each label must be new. Avoid simultaneous builds during
+comparisons. Dependency caches and native-submodule state must match between arms.
+
+## Instrumentation
+
+Add `--instrument` to substitute a temporary toolchain view whose compiler
+wrappers forward to the pinned binaries and emit per-process JSON. Lean arguments,
+module setup, public visibility, and output facets are preserved. `--profile`
+adds Lean's textual profiler, except in files containing `#guard_msgs`, where
+profiler messages would invalidate expected diagnostics. These files still build
+and remain checked; their exclusion is recorded. Tracing is never used for the
+acceptance timings.
+
+```sh
+python3 scripts/profile_build.py --root .lake/compile-performance/worktrees/baseline \
+  --output .lake/compile-performance/whole-build --label timeline --clean --instrument
+python3 scripts/analyze_build_profile.py .lake/compile-performance/whole-build/timeline \
+  --build-dir .lake/compile-performance/worktrees/baseline/.lake/build \
+  --output .lake/compile-performance/whole-build/timeline/analysis.json
+```
+
+Analyze before replacing the build artifacts, or point `--build-dir` at their
+saved location. `directImports` uses the pinned Lean tuple schema; transitive
+`importArts` is not used to infer direct edges. Failed builds, missing metadata,
+duplicate module runs, and inconsistent timestamps are rejected. Start-only
+records do not count as completed compilations.
+
+The analyzer distinguishes the longest duration-weighted import path from the
+observed last-finishing dependency chain. A module's recorded launch gap starts
+at its last recorded direct dependency's completion; it can include queued work,
+cached dependency/facet checks, and wrapper startup. It is not automatically
+avoidable scheduler waste. Compiler occupancy counts active processes, not CPU
+utilization. Cumulative profiler entries overlap and must not be summed into
+exclusive CPU percentages. Peak RSS values must not be summed as simultaneous
+memory consumption.
+
+The shared timestamp clock is `clock_gettime(CLOCK_MONOTONIC)`, because Python 3.9
+on macOS gives `time.monotonic()` a process-relative origin. Records include CPU,
+context switches, source hashes and generated artifact sizes; the parent records
+commit, tracked diff, dependency-manifest hash, thread-related environment,
+command, platform, and hashes of tracked and non-ignored untracked Lean sources.
+System load averages are coarse context, not a CPU or
+memory-pressure trace. Avoid machine sleep during measurements.
+
+`--threads N --instrument` supplies Lean's supported per-file `-jN` argument
+without changing Lake's own parallelism. This is diagnostic, not a portable
+recommendation. `--lake-config key=value` forwards an explicit Lake `-K` option;
+the project must implement that option for it to affect builds. No scheduling
+default is inferred from one machine or from widely separated batches.
+
+## Acceptance
+
+Screen with three counterbalanced clean-build pairs. Confirm the frozen candidate
+with five additional pairs using uninstrumented invocations and unchanged target
+sets. Require at least a 3% median wall reduction, greater than twice the baseline
+relative median absolute deviation, and wins in at least four confirmation pairs.
+Keep separate arms for source-layout changes, previous local fixes, and their
+combination. A leaf-file win alone does not satisfy this gate.
+
+Check public declaration names/types, tests, smoke, axiom and warning budgets,
+and module boundaries. Inspect representative real-edit rebuilds separately
+from no-op cache hits. Never remove proofs, omit target libraries, or disable
+linters to manufacture a result. Preserve original import façades when moving
+declarations, and treat changes to private names separately from public APIs.
+
+Run the recorder/analyzer tests with:
+
+```sh
+PYTHONPYCACHEPREFIX=.lake/compile-performance/python-cache python3 scripts/test_build_profile.py
+```

--- a/scripts/profile_build.py
+++ b/scripts/profile_build.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Record a Lake build, optionally instrumenting compiler children without replacing Lean.
+
+POSIX only. Clean runs move the old project build tree into the result directory.
+No dependency caches or installed toolchains are modified. Existing labels are rejected.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import signal
+import subprocess
+import sys
+import time
+
+TARGETS = ['ToMathlib', 'VCVio', 'LatticeCrypto', 'Extern', 'HashSig', 'Examples', 'VCVioWidgets']
+
+
+def now():
+    # Python 3.9 on macOS uses a process-relative epoch for time.monotonic().
+    # clock_gettime has a system-wide epoch, needed to correlate child processes.
+    return time.clock_gettime(time.CLOCK_MONOTONIC)
+
+
+def sha(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def compiler():
+    """Entry point when invoked through the temporary bin/lean or bin/clang link."""
+    kind = Path(sys.argv[0]).name
+    real = Path(os.environ['VCVIO_PERF_REAL_ROOT']) / 'bin' / kind
+    args = sys.argv[1:]
+    out = Path(os.environ['VCVIO_PERF_RECORDS'])
+    module = None
+    source = next((a for a in args if a.endswith('.lean')), None)
+    if '--setup' in args:
+        setup = Path(args[args.index('--setup') + 1])
+        module = json.loads(setup.read_text())['name']
+    has_message_guards = bool(source and '#guard_msgs' in Path(source).read_text())
+    if kind == 'lean' and module:
+        # Profiler info messages change #guard_msgs expectations. Keep these
+        # modules fully checked, but do not inject profiler messages into them.
+        if os.environ.get('VCVIO_PERF_PROFILE') == '1' and not has_message_guards:
+            args += ['--profile', '-Dprofiler.threshold=10']
+        if os.environ.get('VCVIO_PERF_THREADS'):
+            args += ['-j' + os.environ['VCVIO_PERF_THREADS']]
+    start = now()
+    p = subprocess.Popen([str(real), *args])
+    (out / f'{os.getpid()}.start.json').write_text(json.dumps(dict(
+        kind=kind, module=module, pid=p.pid, start=start)) + '\n')
+    def forward(signum, _frame):
+        if p.returncode is None:
+            p.send_signal(signum)
+    signal.signal(signal.SIGTERM, forward)
+    signal.signal(signal.SIGINT, forward)
+    _, status, usage = os.wait4(p.pid, 0)
+    p.returncode = os.waitstatus_to_exitcode(status)
+    end = now()
+    artifacts = {}
+    for flag in ['-o', '-i', '-c']:
+        if flag in args and args.index(flag) + 1 < len(args):
+            path = Path(args[args.index(flag) + 1])
+            if path.is_file():
+                artifacts[str(path)] = path.stat().st_size
+            if flag == '-o' and path.suffix == '.olean':
+                for suffix in ['.olean.server', '.olean.private', '.ir', '.ir.sig']:
+                    extra = path.with_suffix(suffix)
+                    if extra.is_file():
+                        artifacts[str(extra)] = extra.stat().st_size
+    record = dict(kind=kind, module=module, source=source, pid=p.pid,
+                  profile_skipped_for_message_guards=has_message_guards,
+                  start=start, end=end, wall_seconds=end-start,
+                  user_seconds=usage.ru_utime, system_seconds=usage.ru_stime,
+                  peak_rss_bytes=usage.ru_maxrss * (1 if sys.platform == 'darwin' else 1024),
+                  voluntary_switches=usage.ru_nvcsw, involuntary_switches=usage.ru_nivcsw,
+                  exit_code=p.returncode, command=[str(real), *args], artifacts=artifacts)
+    if source and Path(source).is_file():
+        record['source_sha256'] = sha(Path(source))
+    (out / f'{os.getpid()}-{time.monotonic_ns()}.json').write_text(json.dumps(record) + '\n')
+    return p.returncode if p.returncode >= 0 else 128 - p.returncode
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--root', type=Path, default=Path.cwd())
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--label', required=True)
+    parser.add_argument('--clean', action='store_true')
+    parser.add_argument('--instrument', action='store_true')
+    parser.add_argument('--profile', action='store_true')
+    parser.add_argument('--threads', type=int)
+    parser.add_argument('--lake-config', action='append', default=[],
+                        help='explicit Lake -K configuration, recorded in provenance')
+    parser.add_argument('--timeout', type=float, default=900)
+    args = parser.parse_args()
+    if args.timeout <= 0 or (args.threads is not None and args.threads < 1):
+        parser.error('timeout and thread count must be positive')
+    if (args.profile or args.threads is not None) and not args.instrument:
+        parser.error('--profile and --threads require --instrument')
+    if not hasattr(os, 'wait4'):
+        parser.error('requires POSIX os.wait4')
+    root = args.root.resolve()
+    output = args.output.resolve() / args.label
+    if (root / '.lake/build') in output.parents:
+        parser.error('output must be outside the project build directory')
+    if output.exists():
+        parser.error('label already exists')
+    output.mkdir(parents=True)
+    records = output / 'processes'
+    records.mkdir()
+    real = Path(subprocess.check_output(['lean', '--print-prefix'], cwd=root, text=True).strip())
+    env = os.environ.copy()
+    if args.instrument:
+        view = output / 'toolchain'
+        view.mkdir()
+        (view / 'bin').mkdir()
+        for entry in real.iterdir():
+            if entry.name != 'bin':
+                (view / entry.name).symlink_to(entry, target_is_directory=entry.is_dir())
+        for entry in (real / 'bin').iterdir():
+            target = Path(__file__).resolve() if entry.name in ['lean', 'clang', 'leanc'] else entry
+            (view / 'bin' / entry.name).symlink_to(target)
+        env.update(LAKE_OVERRIDE_LEAN='true', LEAN_SYSROOT=str(view),
+                   VCVIO_PERF_REAL_ROOT=str(real), VCVIO_PERF_RECORDS=str(records),
+                   VCVIO_PERF_PROFILE='1' if args.profile else '0',
+                   VCVIO_PERF_THREADS=str(args.threads) if args.threads else '')
+    build = root / '.lake/build'
+    if args.clean and build.exists():
+        build.rename(output / 'saved-project-build')
+    command = ['lake', *['-K' + value for value in args.lake_config], 'build', *TARGETS]
+    provenance = dict(root=str(root), command=command, targets=TARGETS,
+                      commit=subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=root, text=True).strip(),
+                      diff=subprocess.check_output(['git', 'diff'], cwd=root, text=True),
+                      platform=platform.platform(), logical_cpus=os.cpu_count(),
+                      thread_environment={key: env.get(key) for key in
+                          ['LEAN_NUM_THREADS', 'LEAN_MAIN_USE_THREAD', 'OMP_NUM_THREADS']},
+                      toolchain=(root / 'lean-toolchain').read_text().strip(),
+                      started_utc=time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+                      manifest_sha256=sha(root / 'lake-manifest.json'),
+                      source_sha256={path: sha(root / path) for path in
+                          subprocess.check_output(
+                              ['git', 'ls-files', '--cached', '--others',
+                               '--exclude-standard', '--', '*.lean'],
+                              cwd=root, text=True).splitlines()
+                          if (root / path).is_file()},
+                      clean=args.clean, instrument=args.instrument, profile=args.profile,
+                      threads=args.threads)
+    (output / 'provenance.json').write_text(json.dumps(provenance, indent=2) + '\n')
+    start = now()
+    samples = []
+    with (output / 'build.log').open('wb') as log:
+        p = subprocess.Popen(command, cwd=root, env=env, stdout=log, stderr=log,
+                             start_new_session=True)
+        timed_out = False
+        while True:
+            pid, status, usage = os.wait4(p.pid, os.WNOHANG)
+            if pid:
+                break
+            if now() - start > args.timeout:
+                timed_out = True
+                os.killpg(p.pid, signal.SIGKILL)
+                _, status, usage = os.wait4(p.pid, 0)
+                break
+            samples.append(dict(time=now(), load_average=os.getloadavg()))
+            time.sleep(0.1)
+        p.returncode = os.waitstatus_to_exitcode(status)
+    result = dict(start=start, end=now(), wall_seconds=now()-start,
+                  user_seconds=usage.ru_utime, system_seconds=usage.ru_stime,
+                  exit_code=p.returncode, timed_out=timed_out)
+    (output / 'result.json').write_text(json.dumps(result, indent=2) + '\n')
+    (output / 'load.json').write_text(json.dumps(samples) + '\n')
+    print(json.dumps(dict(label=args.label, **result)), flush=True)
+    if p.returncode:
+        print((output / 'build.log').read_text(errors='replace')[-8000:], file=sys.stderr)
+    return p.returncode if p.returncode >= 0 else 128 - p.returncode
+
+
+if __name__ == '__main__':
+    sys.exit(compiler() if Path(sys.argv[0]).name in ['lean', 'clang', 'leanc'] else main())

--- a/scripts/profile_compile.py
+++ b/scripts/profile_compile.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Replay a built Lean module with its Lake setup and record isolated measurements.
+
+Build the module first. Outputs and logs go to --output, never to Lake's build tree.
+Run without profiler options for comparable timings; instrumentation is diagnostic.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import shlex
+import subprocess
+import sys
+import time
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("module")
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--label", default="baseline")
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--option", action="append", default=[])
+    parser.add_argument("--plugin", type=Path, action="append", default=[],
+                        help="load a pre-built native Lean plugin (repeatable)")
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--trace", action="store_true")
+    parser.add_argument("--sample", action="store_true",
+                        help="collect a macOS sample of the actual Lean child process")
+    parser.add_argument("--timeout", type=float, default=300,
+                        help="maximum seconds per invocation (default: 300)")
+    args = parser.parse_args()
+    if args.runs < 1 or args.warmup < 0 or args.timeout <= 0:
+        parser.error("runs and timeout must be positive and warmup nonnegative")
+    if args.sample and (sys.platform != "darwin" or not Path("/usr/bin/sample").exists()):
+        parser.error("--sample requires macOS /usr/bin/sample")
+    if not hasattr(os, "wait4"):
+        parser.error("this runner requires a POSIX platform with os.wait4")
+    root = args.root.resolve()
+    plugins = [path.resolve() for path in args.plugin]
+    if any(not path.is_file() for path in plugins):
+        parser.error("every --plugin must name an existing built library")
+    relative = Path(*args.module.split("."))
+    source = (args.source or root / relative.with_suffix(".lean")).resolve()
+    setup = root / ".lake/build/ir" / relative.with_suffix(".setup.json")
+    trace = root / ".lake/build/lib/lean" / relative.with_suffix(".trace")
+    # Use the actual recorded invocation to preserve plugins, setup, and output facets.
+    entries = json.loads(trace.read_text())["log"]
+    invocation = next(e["message"][3:] for e in entries
+                      if e["message"].startswith(".> ") and " --setup " in e["message"])
+    words = shlex.split(invocation)
+    env = os.environ.copy()
+    while words and "=" in words[0] and not words[0].startswith("-"):
+        key, value = words.pop(0).split("=", 1)
+        env[key] = value
+    binary = Path(words[0])
+    installed = subprocess.check_output(["lean", "--print-prefix"], cwd=root, text=True).strip()
+    if binary.resolve() != (Path(installed) / "bin/lean").resolve():
+        parser.error("recorded Lean binary does not match the active toolchain; rebuild first")
+    if not setup.exists():
+        parser.error("missing module setup; build first")
+    setup_data = json.loads(setup.read_text())
+    if setup_data["name"] != args.module:
+        parser.error("module setup name mismatch")
+    # Reject copied traces that still refer to a different checkout.
+    original_source = root / relative.with_suffix(".lean")
+    if str(original_source) not in words:
+        parser.error("recorded invocation belongs to another checkout; rebuild first")
+    output = args.output.resolve() / args.label / args.module
+    if (output / "runs.jsonl").exists():
+        parser.error("results already exist; use a new label to avoid mixing experiments")
+    output.mkdir(parents=True, exist_ok=True)
+    provenance = {
+        "module": args.module, "label": args.label, "root": str(root),
+        "source": str(source), "source_sha256": digest(source),
+        "setup_sha256": digest(setup), "platform": platform.platform(),
+        "lean": subprocess.check_output([str(binary), "--version"], text=True).strip(),
+        "commit": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip(),
+        "lean_path": env.get("LEAN_PATH"),
+        "plugins": [{"path": str(path), "sha256": digest(path)} for path in plugins],
+    }
+    for index in range(args.warmup + args.runs):
+        run_dir = output / f"run-{index:02d}"
+        run_dir.mkdir(exist_ok=True)
+        command = list(words)
+        command[command.index(str(original_source))] = str(source)
+        for flag, suffix in [("-o", ".olean"), ("-i", ".ilean"), ("-c", ".c")]:
+            if flag in command:
+                command[command.index(flag) + 1] = str(run_dir / (relative.name + suffix))
+        if args.profile:
+            command += ["--profile", "-Dprofiler.threshold=10"]
+        if args.trace:
+            command += ["-Dtrace.profiler=true", "-Dtrace.profiler.threshold=10",
+                        f"-Dtrace.profiler.output={run_dir / 'profile.json'}"]
+        command += ["-D" + option for option in args.option]
+        for plugin in plugins:
+            command += ["--plugin", str(plugin)]
+        log = run_dir / "lean.log"
+        stderr_log = run_dir / "lean.stderr"
+        start = time.monotonic()
+        with log.open("wb") as handle, stderr_log.open("wb") as error_handle:
+            process = subprocess.Popen(command, cwd=root, env=env, stdout=handle,
+                                       stderr=error_handle)
+            sampler = None
+            if args.sample:
+                sampler = subprocess.Popen(
+                    ["/usr/bin/sample", str(process.pid), "2", "1", "-mayDie",
+                     "-file", str(run_dir / "sample.txt")],
+                    stdout=error_handle, stderr=error_handle)
+            timed_out = False
+            while True:
+                pid, status, usage = os.wait4(process.pid, os.WNOHANG)
+                if pid:
+                    break
+                if time.monotonic() - start > args.timeout:
+                    timed_out = True
+                    process.kill()
+                    _, status, usage = os.wait4(process.pid, 0)
+                    break
+                time.sleep(0.01)
+            process.returncode = os.waitstatus_to_exitcode(status)
+        elapsed = time.monotonic() - start
+        sample_exit = sampler.wait() if sampler else None
+        record = provenance | {
+            "index": index, "warmup": index < args.warmup, "command": command,
+            "wall_seconds": elapsed, "user_seconds": usage.ru_utime,
+            "system_seconds": usage.ru_stime,
+            "peak_rss_bytes": usage.ru_maxrss * (1 if sys.platform == "darwin" else 1024),
+            "exit_code": process.returncode, "log": str(log),
+            "stderr": str(stderr_log),
+            "timed_out": timed_out,
+            "sample_exit_code": sample_exit,
+        }
+        with (output / "runs.jsonl").open("a") as handle:
+            handle.write(json.dumps(record) + "\n")
+        print(json.dumps({key: record[key] for key in
+                          ("module", "label", "index", "warmup", "wall_seconds", "exit_code")}),
+              flush=True)
+        if process.returncode:
+            errors = []
+            for line in log.read_text(errors="replace").splitlines():
+                try:
+                    message = json.loads(line)
+                except ValueError:
+                    continue
+                if message.get("severity") == "error":
+                    errors.append(str(message.get("data", message)))
+            print("\n".join(errors)[-6000:] or log.read_text(errors="replace")[-6000:],
+                  file=sys.stderr)
+            print(stderr_log.read_text()[-6000:], file=sys.stderr)
+            return process.returncode
+        if sample_exit not in (None, 0):
+            print(stderr_log.read_text()[-6000:], file=sys.stderr)
+            return sample_exit
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_build_profile.py
+++ b/scripts/test_build_profile.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Small falsifiable tests for full-build measurement and graph analysis."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from analyze_build_profile import analyze
+from profile_build import now
+
+
+class BuildProfileTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / 'processes').mkdir()
+        self.build = self.root / 'build'
+        (self.build / 'lib/lean').mkdir(parents=True)
+        self.result = dict(start=10., end=19., wall_seconds=9., user_seconds=8.,
+                           system_seconds=1., exit_code=0)
+        self.write_result()
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def write_result(self):
+        (self.root / 'result.json').write_text(json.dumps(self.result))
+
+    def module(self, name, start, end, imports=()):
+        row = dict(kind='lean', module=name, start=start, end=end,
+                   wall_seconds=end-start, user_seconds=1., system_seconds=0., exit_code=0)
+        (self.root / 'processes' / (name + '.json')).write_text(json.dumps(row))
+        (self.build / 'lib/lean' / (name + '.ilean')).write_text(json.dumps(
+            dict(directImports=[[n, True, False, False] for n in imports])))
+
+    def test_actual_waiting_and_weighted_path_are_distinct(self):
+        self.module('A', 11., 13.)
+        self.module('B', 13., 17., ['A'])
+        self.module('C', 15., 16., ['A'])
+        self.module('D', 18., 19., ['B', 'C'])
+        d = analyze(self.root, self.build)
+        self.assertEqual(d['observed_terminal_path'], ['A', 'B', 'D'])
+        self.assertEqual(d['weighted_path'], (7., ['A', 'B', 'D']))
+        rows = {r['module']: r for r in d['modules']}
+        self.assertEqual(rows['D']['launch_gap_seconds'], 1.)
+        self.assertEqual(rows['A']['descendants'], 3)
+        self.assertEqual(d['peak_compilers'], 2)
+        self.assertAlmostEqual(sum(d['compiler_occupancy_seconds'].values()), 9.)
+
+    def test_cache_hit_is_not_a_compile_profile(self):
+        with self.assertRaisesRegex(ValueError, 'cache hit'):
+            analyze(self.root, self.build)
+
+    def test_failure_is_not_a_speedup(self):
+        self.result['exit_code'] = 1
+        self.write_result()
+        with self.assertRaisesRegex(ValueError, 'failed builds'):
+            analyze(self.root, self.build)
+
+    def test_inconsistent_timestamps_are_rejected(self):
+        self.module('A', 11., 15.)
+        self.module('B', 14., 17., ['A'])
+        with self.assertRaisesRegex(ValueError, 'inconsistent timestamps'):
+            analyze(self.root, self.build)
+
+    def test_failed_child_is_rejected_even_with_successful_parent(self):
+        self.module('A', 11., 13.)
+        path = self.root / 'processes/A.json'
+        row = json.loads(path.read_text())
+        row['exit_code'] = 1
+        path.write_text(json.dumps(row))
+        with self.assertRaisesRegex(ValueError, 'failed compiler'):
+            analyze(self.root, self.build)
+
+    def test_duplicate_module_is_rejected(self):
+        self.module('A', 11., 13.)
+        original = self.root / 'processes/A.json'
+        (self.root / 'processes/duplicate.json').write_bytes(original.read_bytes())
+        with self.assertRaisesRegex(ValueError, 'duplicate module'):
+            analyze(self.root, self.build)
+
+    def test_missing_plugin_is_rejected_before_replay(self):
+        output = self.root / 'replay'
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).with_name('profile_compile.py')),
+             'ToMathlib.General', '--output', str(output),
+             '--plugin', str(self.root / 'missing.so')],
+            capture_output=True, text=True)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn('every --plugin', result.stderr)
+        self.assertFalse(output.exists())
+
+    def test_start_records_are_not_completed_compiles(self):
+        self.module('A', 11., 13.)
+        (self.root / 'processes/123.start.json').write_text('{}')
+        self.assertEqual(analyze(self.root, self.build)['module_count'], 1)
+
+    def test_clock_epoch_is_shared_across_processes(self):
+        before = now()
+        env = os.environ.copy()
+        if env.get('PYTHONPYCACHEPREFIX'):
+            env['PYTHONPYCACHEPREFIX'] = str(Path(env['PYTHONPYCACHEPREFIX']).resolve())
+        child = float(subprocess.check_output(
+            [sys.executable, '-c', 'from profile_build import now; print(now())'],
+            cwd=Path(__file__).parent, env=env, text=True))
+        self.assertLessEqual(before, child)
+        self.assertLessEqual(child, now())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Stack and scope

Stacked on #668 (`perf/compile-local-fixes-20260907`), **not directly on main**. The two local source fixes belong to that smaller PR; this draft adds the investigation/reproduction infrastructure and an opt-in prototype. Retarget to main after #668 lands.

The independent import-only experiment is #669. Unary splitting, handler reuse, and the Add-instance shortcut remain stored candidate patches, not active source changes.

## Changes

- Exact Lake-invocation file replay with source/setup provenance, warmups, timeouts, scoped profiling/tracing, optional native sampling and ordered native plugins.
- Seven-library clean-build recorder with recoverable build-tree moves, optional compiler timelines, source hashes, and an import-graph analyzer that distinguishes weighted paths from observed waiting.
- Nine regression tests for timing/analysis safeguards, including failed builds, failed children, duplicate modules, clock epochs and missing plugins.
- `ToMathlib.Perf`: side-effect-free indexed goal differences, a general equivalence theorem, and `TacticInfo` adapters. Five Lean regression examples cover empty, disjoint, reordered and duplicate lists. No linter/tactic/instance registration or default runtime change.
- Reports, compact measurements, reproducible negative experiments and candidate patch hashes. Raw caches, traces, worktrees and logs stay ignored under `.lake/`.

## Findings and limits

- No verified whole-build speedup. The five most expensive modules were only 3.67% of recorded module CPU; cumulative profiler categories overlap and do not establish exclusive attribution.
- Indexed goal differences helped synthetic large lists but slowed small ones. This is not an installed linter optimization.
- Narrow native-plugin probes had mixed wall results; broad `Mathlib.Init` native loading crashed. These remain opt-in experiments.
- Handler support-law reuse showed no benefit (about 2.2% slower median in its diagnostic batch).
- Whole-build screening/confirmation and representative real-edit rebuild measurements remain unfinished. One screen run was terminated; unrelated Lean work was observed on the host. Do not count failed runs as speedups.

## Validation

- Prior pinned-toolchain validation of this Lean source selection: all seven libraries plus three test libraries, direct smoke, axiom-sweep fixtures/check, warning budget, generated umbrellas, and PMF/Extern/Interop/PolyFun/complexity boundaries passed.
- All 20,169 existing public declaration names/types preserved; four Perf declarations added. No new axiom/sorry taint or linter suppressions.
- Nine Python regression tests re-run successfully while preparing this PR.
- The new import and layout patches passed `git apply --check` against the recorded baseline; their prior correctness/timing status is documented individually.

Validation used `ffd0ca198fe6e640c0dd7f0f9c599943caacbf64` plus the selected changes, before newer main commits, with Lean/Mathlib 4.33.1. Native backends were absent in the validation checkout; native differential executables were not run. Keep draft for tooling/prototype review and current-base CI.
