### PR TITLE
feat(CryptoFoundations): lift the final-validity monitor invariant to a run

### DIFF
--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
@@ -205,6 +205,13 @@ theorem collectionOracle_run [DecidableEq Tweak] (tweakOf : Q → Tweak)
       pure (thColl.eval q.1 pk q.2.1 q.2.2, st.recordCollection tweakOf q.2.1) := by
   simp [collectionOracle]
 
+/-- At the empty collection (`ι := Empty`) the oracle's query type is uninhabited, so a game
+instantiated there cannot issue a collection query at all. This is what makes the stand-alone notion
+recovered rather than merely approximated, so it is pinned rather than asserted. -/
+theorem isEmpty_domain_collectionSpec_empty :
+    IsEmpty (collectionSpec (TweakableHashCollection.empty PkSeed Tweak Y)).Domain :=
+  ⟨fun q => q.1.elim⟩
+
 /-! ## Semantic pins -/
 
 variable [DecidableEq Tweak] (tweakOf : Q → Tweak)

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/FinalValidity.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 
 module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.Collection
+public import VCVio.OracleComp.SimSemantics.StateT.PreservesInv
 
 /-!
 # Source-final-validity monitoring for multi-target tweakable-hash games
@@ -211,6 +212,27 @@ recovered rather than merely approximated, so it is pinned rather than asserted.
 theorem isEmpty_domain_collectionSpec_empty :
     IsEmpty (collectionSpec (TweakableHashCollection.empty PkSeed Tweak Y)).Domain :=
   ⟨fun q => q.1.elim⟩
+
+/-! ## Invariant preservation -/
+
+/-- The private-randomness summand of a game's oracle implementation answers by lifting its query
+into the state monad, so it never writes the monitor state and preserves every invariant. The state
+belongs to the target and collection summands, which record through `State.recordTarget` and
+`State.recordCollection`. -/
+theorem preservesInv_privateRandomness {σ : Type} (Inv : σ → Prop) :
+    QueryImpl.PreservesInv
+      ((QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT σ ProbComp)) Inv := fun t => by
+  rw [QueryImpl.liftTarget_apply, QueryImpl.ofLift_apply]
+  exact StateT.preservesInv_monadLift _ Inv
+
+/-- The collection summand records its query's tweak and writes nothing else, so it maintains the
+monitor invariant at the collection-recording step. -/
+theorem preservesInv_collectionOracle [DecidableEq Tweak] (numTargets : ℕ) (tweakOf : Q → Tweak)
+    (thColl : TweakableHashCollection ι PkSeed Tweak Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (collectionOracle tweakOf thColl pk) (Invariant numTargets tweakOf) :=
+  fun q st hst z hz => by
+    rw [collectionOracle_run, support_pure, Set.mem_singleton_iff] at hz
+    exact hz ▸ hst.recordCollection numTargets tweakOf st q.2.1
 
 /-! ## Semantic pins -/
 

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTDSPRFinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTDSPRFinalValidity.lean
@@ -7,6 +7,7 @@ Authors: Quang Dao
 module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.OracleComp.SimSemantics.Append
+public import VCVio.OracleComp.SimSemantics.StateT.PreservesInv
 
 /-!
 # Source-final-validity SM-DT-DSPR
@@ -177,6 +178,43 @@ theorem challengeOracle_run :
     (challengeOracle prob pk (t, m)).run st =
       pure (prob.th.eval pk t m, st.recordTarget prob.numTargets Prod.fst (t, m)) := by
   simp [challengeOracle]
+
+/-! ## Run-level final-validity correspondence -/
+
+section Reachable
+
+/-- The target summand answers every query and records it, so it maintains the monitor invariant at
+the target-recording step. -/
+theorem challengeOracle_preservesInv (prob : Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (challengeOracle prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets Prod.fst) :=
+  fun (t, m) st hst z hz => by
+    rw [challengeOracle_run, support_pure, Set.mem_singleton_iff] at hz
+    exact hz ▸ hst.recordTarget prob.numTargets Prod.fst st (t, m)
+
+/-- Every summand of the target-selection oracle implementation maintains the monitor invariant:
+private randomness leaves the state untouched, and the challenge and collection oracles record
+through `SourceFinalValidity.State.recordTarget` and
+`SourceFinalValidity.State.recordCollection`. -/
+theorem oracles_preservesInv (prob : Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (oracles prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets Prod.fst) :=
+  (SourceFinalValidity.preservesInv_privateRandomness _).add
+    ((challengeOracle_preservesInv prob pk).add
+      (SourceFinalValidity.preservesInv_collectionOracle _ _ _ _))
+
+/-- The sticky bit decides the final predicate on every reachable state: the run-level form of the
+monitor invariant, obtained from the initial state and the two recording steps. Both `Experiment`
+and `SPExperiment` read `gameState.valid`, so this is what makes their shared guard mean
+`SourceFinalValidity.Valid`. -/
+theorem valid_eq_decide_valid_of_reachable {prob : Problem ι PkSeed Tweak M Y}
+    (adv : Adversary prob) (pk : PkSeed) {z : adv.State × State Tweak M}
+    (hz : z ∈ support ((simulateQ (oracles prob pk) adv.choose).run .initial)) :
+    z.2.valid = decide (SourceFinalValidity.Valid prob.numTargets Prod.fst z.2) :=
+  (OracleComp.simulateQ_run_preservesInv (oracles prob pk) _ (oracles_preservesInv prob pk)
+    adv.choose .initial (SourceFinalValidity.invariant_initial _ _) z hz).eq_decide _ _ _
+
+end Reachable
 
 end SM_DT_DSPR_SourceFinalValidity
 

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTOpenPREFinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTOpenPREFinalValidity.lean
@@ -8,6 +8,7 @@ module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.OracleComp.Constructions.SampleableType
 public import VCVio.OracleComp.SimSemantics.Append
+public import VCVio.OracleComp.SimSemantics.StateT.PreservesInv
 
 /-!
 # Source-final-validity SM-DT-OpenPRE
@@ -159,6 +160,55 @@ noncomputable def Advantage [DecidableEq Tweak] [DecidableEq Y] [Inhabited M]
     {prob : Problem ι PkSeed Tweak M Y}
     (adv : Adversary prob) : ℝ≥0∞ :=
   Pr[= true | Experiment adv]
+
+/-! ## Run-level final-validity correspondence -/
+
+section Reachable
+
+variable [DecidableEq Tweak]
+
+/-- Both summands of the commitment-phase oracle implementation maintain the monitor invariant:
+private randomness leaves the state untouched, and the collection oracle records through
+`SourceFinalValidity.State.recordCollection`. -/
+theorem pickOracles_preservesInv (prob : Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (pickOracles prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets Prod.fst) :=
+  (SourceFinalValidity.preservesInv_privateRandomness _).add
+    (SourceFinalValidity.preservesInv_collectionOracle _ _ _ _)
+
+/-- Target sampling maintains the monitor invariant: every retained tweak is recorded through
+`SourceFinalValidity.State.recordTarget`, so a duplicate or collection-clashing tweak in the
+committed list poisons the monitor exactly as an adversarial target query would. -/
+theorem initializeTargets_preservesInv (prob : Problem ι PkSeed Tweak M Y) (pk : PkSeed)
+    (ts : List Tweak) :
+    StateT.PreservesInv (initializeTargets prob pk ts)
+      (SourceFinalValidity.Invariant prob.numTargets Prod.fst) := by
+  induction ts with
+  | nil => exact StateT.preservesInv_pure _ _
+  | cons t ts ih =>
+      refine StateT.preservesInv_bind _ _ _ (StateT.preservesInv_monadLift _ _) fun x => ?_
+      refine StateT.preservesInv_get_bind _ fun st hst => ?_
+      refine StateT.preservesInv_bind _ _ _
+        (StateT.preservesInv_set_of _ (hst.recordTarget prob.numTargets Prod.fst st (t, x)))
+        fun _ => StateT.preservesInv_bind _ _ _ ih fun _ => StateT.preservesInv_pure _ _
+
+/-- The sticky bit decides the final predicate on every state reachable through both monitor
+phases: the commitment phase's collection queries followed by target sampling on the retained
+prefix. The inversion phase carries its own opening state and never reaches the monitor, so this is
+exactly the state whose `valid` field `Experiment` reads. -/
+theorem valid_eq_decide_valid_of_reachable {prob : Problem ι PkSeed Tweak M Y}
+    (adv : Adversary prob) (pk : PkSeed)
+    {w : (adv.State × List Tweak) × State Tweak M}
+    (hw : w ∈ support ((simulateQ (pickOracles prob pk) adv.pick).run .initial))
+    {z : List Y × State Tweak M}
+    (hz : z ∈ support ((initializeTargets prob pk (w.1.2.take prob.numTargets)).run w.2)) :
+    z.2.valid = decide (SourceFinalValidity.Valid prob.numTargets Prod.fst z.2) :=
+  (initializeTargets_preservesInv prob pk _ w.2
+    (OracleComp.simulateQ_run_preservesInv (pickOracles prob pk) _
+      (pickOracles_preservesInv prob pk) adv.pick .initial
+      (SourceFinalValidity.invariant_initial _ _) w hw) z hz).eq_decide _ _ _
+
+end Reachable
 
 /-! ## Oracle behavior pins -/
 

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTPREFinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTPREFinalValidity.lean
@@ -7,6 +7,7 @@ Authors: Nicolas Consigny, Matthias Meijers, Quang Dao
 module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTPRE
+public import VCVio.OracleComp.SimSemantics.StateT.PreservesInv
 
 /-!
 # Source-final-validity SM-DT-PRE
@@ -130,5 +131,43 @@ theorem challengeOracle_run :
       (fun x => (prob.th.eval pk t (prob.emb x),
         st.recordTarget prob.numTargets Prod.fst (t, x))) <$> ($ᵗ M') := by
   simp [challengeOracle, Functor.map_map]
+
+/-! ## Run-level final-validity correspondence -/
+
+section Reachable
+
+/-- The target summand draws its preimage, answers with the digest, and records the drawn pair, so
+it maintains the monitor invariant at the target-recording step. The drawn message enters the
+history but not the invariant's proof. -/
+theorem challengeOracle_preservesInv (prob : Problem ι PkSeed Tweak M M' Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (challengeOracle prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets Prod.fst) :=
+  fun t st hst z hz => by
+    rw [challengeOracle_run, support_map] at hz
+    obtain ⟨x, -, rfl⟩ := hz
+    exact hst.recordTarget prob.numTargets Prod.fst st (t, x)
+
+/-- Every summand of the first-phase oracle implementation maintains the monitor invariant:
+private randomness leaves the state untouched, and the target and collection oracles record
+through `SourceFinalValidity.State.recordTarget` and
+`SourceFinalValidity.State.recordCollection`. -/
+theorem oracles_preservesInv (prob : Problem ι PkSeed Tweak M M' Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (oracles prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets Prod.fst) :=
+  (SourceFinalValidity.preservesInv_privateRandomness _).add
+    ((challengeOracle_preservesInv prob pk).add
+      (SourceFinalValidity.preservesInv_collectionOracle _ _ _ _))
+
+/-- The sticky bit decides the final predicate on every reachable state: the run-level form of the
+monitor invariant, obtained from the initial state and the two recording steps. This is what lets a
+winning condition read `gameState.valid` and mean `SourceFinalValidity.Valid`. -/
+theorem valid_eq_decide_valid_of_reachable {prob : Problem ι PkSeed Tweak M M' Y}
+    (adv : Adversary prob) (pk : PkSeed) {z : adv.State × State Tweak M'}
+    (hz : z ∈ support ((simulateQ (oracles prob pk) adv.choose).run .initial)) :
+    z.2.valid = decide (SourceFinalValidity.Valid prob.numTargets Prod.fst z.2) :=
+  (OracleComp.simulateQ_run_preservesInv (oracles prob pk) _ (oracles_preservesInv prob pk)
+    adv.choose .initial (SourceFinalValidity.invariant_initial _ _) z hz).eq_decide _ _ _
+
+end Reachable
 
 end TweakableHash.SM_DT_PRE_SourceFinalValidity

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTTCRFinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTTCRFinalValidity.lean
@@ -7,6 +7,7 @@ Authors: Nicolas Consigny, Matthias Meijers, Quang Dao
 module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.SMDTTCR
+public import VCVio.OracleComp.SimSemantics.StateT.PreservesInv
 
 /-!
 # Source-final-validity SM-DT-TCR
@@ -92,7 +93,7 @@ def oracles [DecidableEq Tweak] (prob : Problem ι PkSeed Tweak M Y) (pk : PkSee
     (challengeOracle prob pk +
       SourceFinalValidity.collectionOracle (Q := Tweak × M) Prod.fst prob.thColl pk)
 
-/-- The source-final-validity SM-DT-TCR experiment. A forgery wins exactly when final validity
+/-- The source-final-validity SM-DT-TCR experiment. An adversary wins exactly when final validity
 holds and it names a recorded target with a distinct colliding message. -/
 noncomputable def Experiment [DecidableEq Tweak] [DecidableEq M] [DecidableEq Y]
     {prob : Problem ι PkSeed Tweak M Y} (adv : Adversary prob) : ProbComp Bool := do
@@ -117,5 +118,40 @@ theorem challengeOracle_run :
     (challengeOracle prob pk (t, m)).run st =
       pure (prob.th.eval pk t m, st.recordTarget prob.numTargets Prod.fst (t, m)) := by
   simp [challengeOracle]
+
+/-! ## Run-level final-validity correspondence -/
+
+section Reachable
+
+/-- The target summand answers every query and records it, so it maintains the monitor invariant at
+the target-recording step. -/
+theorem challengeOracle_preservesInv (prob : Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (challengeOracle prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets Prod.fst) :=
+  fun (t, m) st hst z hz => by
+    rw [challengeOracle_run, support_pure, Set.mem_singleton_iff] at hz
+    exact hz ▸ hst.recordTarget prob.numTargets Prod.fst st (t, m)
+
+/-- Every summand of the first-phase oracle implementation maintains the monitor invariant: private
+randomness leaves the state untouched, and the target and collection oracles record through
+`SourceFinalValidity.State.recordTarget` and `SourceFinalValidity.State.recordCollection`. -/
+theorem oracles_preservesInv (prob : Problem ι PkSeed Tweak M Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (oracles prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets Prod.fst) :=
+  (SourceFinalValidity.preservesInv_privateRandomness _).add
+    ((challengeOracle_preservesInv prob pk).add
+      (SourceFinalValidity.preservesInv_collectionOracle _ _ _ _))
+
+/-- The sticky bit decides the final predicate on every reachable state: the run-level form of the
+monitor invariant, obtained from the initial state and the two recording steps. This is what lets a
+winning condition read `gameState.valid` and mean `SourceFinalValidity.Valid`. -/
+theorem valid_eq_decide_valid_of_reachable {prob : Problem ι PkSeed Tweak M Y}
+    (adv : Adversary prob) (pk : PkSeed) {z : adv.State × State Tweak M}
+    (hz : z ∈ support ((simulateQ (oracles prob pk) adv.choose).run .initial)) :
+    z.2.valid = decide (SourceFinalValidity.Valid prob.numTargets Prod.fst z.2) :=
+  (OracleComp.simulateQ_run_preservesInv (oracles prob pk) _ (oracles_preservesInv prob pk)
+    adv.choose .initial (SourceFinalValidity.invariant_initial _ _) z hz).eq_decide _ _ _
+
+end Reachable
 
 end TweakableHash.SM_DT_TCR_SourceFinalValidity

--- a/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTUDFinalValidity.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/TweakableHash/SMDTUDFinalValidity.lean
@@ -8,6 +8,7 @@ module
 public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.FinalValidity
 public import VCVio.OracleComp.Constructions.SampleableType
 public import VCVio.OracleComp.SimSemantics.Append
+public import VCVio.OracleComp.SimSemantics.StateT.PreservesInv
 public import ToMathlib.Data.ENNReal.AbsDiff
 
 /-!
@@ -239,6 +240,46 @@ theorem challengeOracle_run :
       (fun y => (y, st.recordTarget prob.numTargets id t)) <$>
         response world prob pk t := by
   simp [challengeOracle, Functor.map_map]
+
+/-! ## Run-level final-validity correspondence -/
+
+section Reachable
+
+/-- The target summand draws its response before writing the state, so the post-state is the same in
+both worlds and the argument does not branch on `world`. -/
+theorem challengeOracle_preservesInv (world : World) (prob : Problem ι PkSeed Tweak M M' Y)
+    (pk : PkSeed) :
+    QueryImpl.PreservesInv (challengeOracle world prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets id) :=
+  fun t st hst z hz => by
+    rw [challengeOracle_run, support_map, Set.mem_image] at hz
+    obtain ⟨y, -, rfl⟩ := hz
+    exact hst.recordTarget prob.numTargets id st t
+
+/-- Every summand of the first-phase oracle implementation maintains the monitor invariant:
+private randomness leaves the state untouched, and the challenge and collection oracles record
+through `SourceFinalValidity.State.recordTarget` and
+`SourceFinalValidity.State.recordCollection`. -/
+theorem oracles_preservesInv (world : World) (prob : Problem ι PkSeed Tweak M M' Y) (pk : PkSeed) :
+    QueryImpl.PreservesInv (oracles world prob pk)
+      (SourceFinalValidity.Invariant prob.numTargets id) :=
+  (SourceFinalValidity.preservesInv_privateRandomness _).add
+    ((challengeOracle_preservesInv world prob pk).add
+      (SourceFinalValidity.preservesInv_collectionOracle _ _ _ _))
+
+/-- The sticky bit decides the final predicate on every reachable state: the run-level form of the
+monitor invariant, obtained from the initial state and the two recording steps. This is what lets a
+winning condition read `gameState.valid` and mean `SourceFinalValidity.Valid`. -/
+theorem valid_eq_decide_valid_of_reachable (world : World)
+    {prob : Problem ι PkSeed Tweak M M' Y} (adv : Adversary prob) (pk : PkSeed)
+    {z : adv.State × State Tweak}
+    (hz : z ∈ support ((simulateQ (oracles world prob pk) adv.pick).run .initial)) :
+    z.2.valid = decide (SourceFinalValidity.Valid prob.numTargets id z.2) :=
+  (OracleComp.simulateQ_run_preservesInv (oracles world prob pk) _
+    (oracles_preservesInv world prob pk) adv.pick .initial
+    (SourceFinalValidity.invariant_initial _ _) z hz).eq_decide _ _ _
+
+end Reachable
 
 end SM_DT_UD_SourceFinalValidity
 

--- a/VCVioTest/SMDTDSPRFinalValidity.lean
+++ b/VCVioTest/SMDTDSPRFinalValidity.lean
@@ -197,6 +197,60 @@ theorem poison_not_rejection_canary :
   exact ⟨experiment_exceedCap, baseline_exceedCap, experiment_clashCollection,
     baseline_clashCollection⟩
 
+section RunLevelInvariant
+
+open SM_DT_DSPR_SourceFinalValidity
+
+/-- Transfer of the run-level monitor invariant along a transcript pinned to one outcome, in the
+direction that concludes the final predicate holds. -/
+private lemma valid_of_run {prob : Problem Unit Seed Bool Bool Bool} {adv : Adversary prob}
+    {ps : adv.State} {gs : State Bool Bool}
+    (hrun : (simulateQ (oracles prob .only) adv.choose).run .initial = pure (ps, gs))
+    (hvalid : gs.valid = true) :
+    ∀ z ∈ support ((simulateQ (oracles prob .only) adv.choose).run .initial),
+      SourceFinalValidity.Valid prob.numTargets Prod.fst z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable adv .only hz
+  rw [hrun, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- Transfer of the run-level monitor invariant along a transcript pinned to one outcome, in the
+direction that concludes the final predicate fails. -/
+private lemma not_valid_of_run {prob : Problem Unit Seed Bool Bool Bool} {adv : Adversary prob}
+    {ps : adv.State} {gs : State Bool Bool}
+    (hrun : (simulateQ (oracles prob .only) adv.choose).run .initial = pure (ps, gs))
+    (hvalid : gs.valid = false) :
+    ∀ z ∈ support ((simulateQ (oracles prob .only) adv.choose).run .initial),
+      ¬ SourceFinalValidity.Valid prob.numTargets Prod.fst z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable adv .only hz
+  rw [hrun, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- The lifted monitor invariant decides the final predicate correctly on every canary transcript.
+`exceedCap` isolates the target-cap conjunct: `collidingProblem` allows one target and the two
+committed tweaks are distinct and unused by the collection oracle, so the cap is the only conjunct
+that fails. `clashCollection` isolates target/collection disjointness. -/
+theorem reachable_valid_decides_canary :
+    (∀ z ∈ support
+          ((simulateQ (oracles collidingProblem .only) predictCollision.choose).run .initial),
+        SourceFinalValidity.Valid collidingProblem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles injectiveProblem .only) predictNoCollision.choose).run .initial),
+        SourceFinalValidity.Valid injectiveProblem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles collidingProblem .only) exceedCap.choose).run .initial),
+        ¬ SourceFinalValidity.Valid collidingProblem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles collidingProblem .only) clashCollection.choose).run .initial),
+        ¬ SourceFinalValidity.Valid collidingProblem.numTargets Prod.fst z.2) :=
+  ⟨valid_of_run run_predictCollision rfl, valid_of_run run_predictNoCollision rfl,
+    not_valid_of_run run_exceedCap rfl, not_valid_of_run run_clashCollection rfl⟩
+
+end RunLevelInvariant
+
 /-- The phase types themselves pin seed/oracle access: `choose` gets the oracle bundle but no seed,
 whereas `guess` gets the seed but has type `ProbComp` and therefore no challenge oracle. -/
 example : OracleComp (Specs collidingProblem) predictCollision.State :=

--- a/VCVioTest/SMDTOpenPREFinalValidity.lean
+++ b/VCVioTest/SMDTOpenPREFinalValidity.lean
@@ -218,6 +218,97 @@ theorem quantitative_reduction_interface_canary :
       SM_DT_OpenPRE_SourceFinalValidity.TCRDSPRBound valid :=
   SM_DT_OpenPRE_SourceFinalValidity.advantage_le_tcrDsprBound valid validCountingInterface
 
+section RunLevelInvariant
+
+open SM_DT_OpenPRE_SourceFinalValidity
+
+private lemma pick_valid :
+    (simulateQ (pickOracles problem1 .only) valid.pick).run .initial =
+      pure (((), [false]), .initial) := by
+  rfl
+
+private lemma pick_overlong :
+    (simulateQ (pickOracles problem1 .only) overlong.pick).run .initial =
+      pure (((), [false, true]), .initial) := by
+  rfl
+
+private lemma pick_collectionClash :
+    (simulateQ (pickOracles problem1 .only) collectionClash.pick).run .initial =
+      pure ((true, [false]), ⟨[], [false], true⟩) := by
+  rfl
+
+private lemma pick_duplicateTargets :
+    (simulateQ (pickOracles problem2 .only) duplicateTargets.pick).run .initial =
+      pure (((), [false, false]), .initial) := by
+  rfl
+
+private lemma initialize_collectionClash :
+    (initializeTargets problem1 .only ([false].take problem1.numTargets)).run
+        ⟨[], [false], true⟩ =
+      pure ([false], ⟨[(false, .only)], [false], false⟩) := by
+  rfl
+
+private lemma initialize_duplicateTargets :
+    (initializeTargets problem2 .only ([false, false].take problem2.numTargets)).run .initial =
+      pure ([false, false], ⟨[(false, .only), (false, .only)], [], false⟩) := by
+  rfl
+
+/-- Transfer of the two-phase run-level monitor invariant along a transcript pinned to one outcome,
+in the direction that concludes the final predicate holds. -/
+private lemma valid_of_run {prob : Problem Unit Seed Bool Input Bool} {adv : Adversary prob}
+    {w : (adv.State × List Bool) × State Bool Input} {ys : List Bool} {gs : State Bool Input}
+    (hpick : (simulateQ (pickOracles prob .only) adv.pick).run .initial = pure w)
+    (hinit : (initializeTargets prob .only (w.1.2.take prob.numTargets)).run w.2 = pure (ys, gs))
+    (hvalid : gs.valid = true) :
+    ∀ z ∈ support ((initializeTargets prob .only (w.1.2.take prob.numTargets)).run w.2),
+      SourceFinalValidity.Valid prob.numTargets Prod.fst z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable adv .only (by simp [hpick]) hz
+  rw [hinit, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- Transfer of the two-phase run-level monitor invariant along a transcript pinned to one outcome,
+in the direction that concludes the final predicate fails. -/
+private lemma not_valid_of_run {prob : Problem Unit Seed Bool Input Bool} {adv : Adversary prob}
+    {w : (adv.State × List Bool) × State Bool Input} {ys : List Bool} {gs : State Bool Input}
+    (hpick : (simulateQ (pickOracles prob .only) adv.pick).run .initial = pure w)
+    (hinit : (initializeTargets prob .only (w.1.2.take prob.numTargets)).run w.2 = pure (ys, gs))
+    (hvalid : gs.valid = false) :
+    ∀ z ∈ support ((initializeTargets prob .only (w.1.2.take prob.numTargets)).run w.2),
+      ¬ SourceFinalValidity.Valid prob.numTargets Prod.fst z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable adv .only (by simp [hpick]) hz
+  rw [hinit, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- The lifted monitor invariant decides the final predicate correctly across both monitor phases.
+`overlong` pins that truncation is not a violation: the dropped tweak never reaches the monitor, so
+the predicate holds. `collectionClash` is the genuinely two-phase case — the clashing tweak is
+recorded by the commitment phase and the violation only occurs when target sampling reaches it —
+and `duplicateTargets` is the duplicate created by the sampling loop itself rather than by an
+adversarial query. -/
+theorem reachable_valid_decides_canary :
+    (∀ z ∈ support ((initializeTargets problem1 .only
+          ([false].take problem1.numTargets)).run .initial),
+        SourceFinalValidity.Valid problem1.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support ((initializeTargets problem1 .only
+            ([false, true].take problem1.numTargets)).run .initial),
+        SourceFinalValidity.Valid problem1.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support ((initializeTargets problem1 .only
+            ([false].take problem1.numTargets)).run ⟨[], [false], true⟩),
+        ¬ SourceFinalValidity.Valid problem1.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support ((initializeTargets problem2 .only
+            ([false, false].take problem2.numTargets)).run .initial),
+        ¬ SourceFinalValidity.Valid problem2.numTargets Prod.fst z.2) :=
+  ⟨valid_of_run pick_valid initialize_one rfl,
+    valid_of_run pick_overlong initialize_bounded_prefix rfl,
+    not_valid_of_run pick_collectionClash initialize_collectionClash rfl,
+    not_valid_of_run pick_duplicateTargets initialize_duplicateTargets rfl⟩
+
+end RunLevelInvariant
+
 /-- Mutation-resistant pins for prefix truncation, final validity, and the adaptive opening
 phase. -/
 theorem exact_game_canary :

--- a/VCVioTest/SMDTPREFinalValidity.lean
+++ b/VCVioTest/SMDTPREFinalValidity.lean
@@ -134,4 +134,51 @@ theorem final_validity_branch_canary :
       TweakableHash.SM_DT_PRE_SourceFinalValidity.Experiment collectionClash = pure false :=
   ⟨experiment_valid, experiment_duplicateTarget, experiment_collectionClash⟩
 
+section RunLevelInvariant
+
+open TweakableHash TweakableHash.SM_DT_PRE_SourceFinalValidity
+
+/-- Transfer of the run-level monitor invariant along a transcript pinned to one outcome, in the
+direction that concludes the final predicate holds. -/
+private lemma valid_of_run {adv : Adversary problem} {ps : adv.State} {gs : State Bool Input}
+    (hrun : (simulateQ (oracles problem .only) adv.choose).run .initial = pure (ps, gs))
+    (hvalid : gs.valid = true) :
+    ∀ z ∈ support ((simulateQ (oracles problem .only) adv.choose).run .initial),
+      SourceFinalValidity.Valid problem.numTargets Prod.fst z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable adv .only hz
+  rw [hrun, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- Transfer of the run-level monitor invariant along a transcript pinned to one outcome, in the
+direction that concludes the final predicate fails. -/
+private lemma not_valid_of_run {adv : Adversary problem} {ps : adv.State} {gs : State Bool Input}
+    (hrun : (simulateQ (oracles problem .only) adv.choose).run .initial = pure (ps, gs))
+    (hvalid : gs.valid = false) :
+    ∀ z ∈ support ((simulateQ (oracles problem .only) adv.choose).run .initial),
+      ¬ SourceFinalValidity.Valid problem.numTargets Prod.fst z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable adv .only hz
+  rw [hrun, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- The lifted monitor invariant decides the final predicate correctly on every canary transcript,
+including across the oracle-side message draw: the sampled preimage enters the recorded history but
+the predicate depends only on the tweaks. -/
+theorem reachable_valid_decides_canary :
+    (∀ z ∈ support ((simulateQ (oracles problem .only) valid.choose).run .initial),
+        SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles problem .only) duplicateTarget.choose).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles problem .only) collectionClash.choose).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) :=
+  ⟨valid_of_run run_valid rfl, not_valid_of_run run_duplicateTarget rfl,
+    not_valid_of_run run_collectionClash rfl⟩
+
+end RunLevelInvariant
+
 end SMDTPREFinalValidityTest

--- a/VCVioTest/SMDTTCRFinalValidity.lean
+++ b/VCVioTest/SMDTTCRFinalValidity.lean
@@ -191,4 +191,66 @@ theorem final_validity_branch_canary :
   ⟨experiment_challengeOnly, experiment_challengeThenCollection,
     experiment_collectionThenChallenge, experiment_repeatedCollection, experiment_repeatedTarget⟩
 
+section RunLevelInvariant
+
+open TweakableHash TweakableHash.SM_DT_TCR_SourceFinalValidity
+
+/-- Transfer of the run-level monitor invariant along a transcript pinned to one outcome, in the
+direction that concludes the final predicate holds. -/
+private lemma valid_of_run {adv : Adversary problem} {ps : adv.State} {gs : State Bool Bool}
+    (hrun : (simulateQ (oracles problem .only) adv.choose).run .initial = pure (ps, gs))
+    (hvalid : gs.valid = true) :
+    ∀ z ∈ support ((simulateQ (oracles problem .only) adv.choose).run .initial),
+      SourceFinalValidity.Valid problem.numTargets Prod.fst z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable adv .only hz
+  rw [hrun, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- Transfer of the run-level monitor invariant along a transcript pinned to one outcome, in the
+direction that concludes the final predicate fails. -/
+private lemma not_valid_of_run {adv : Adversary problem} {ps : adv.State} {gs : State Bool Bool}
+    (hrun : (simulateQ (oracles problem .only) adv.choose).run .initial = pure (ps, gs))
+    (hvalid : gs.valid = false) :
+    ∀ z ∈ support ((simulateQ (oracles problem .only) adv.choose).run .initial),
+      ¬ SourceFinalValidity.Valid problem.numTargets Prod.fst z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable adv .only hz
+  rw [hrun, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- The lifted monitor invariant decides the final predicate correctly on every canary transcript:
+`SourceFinalValidity.Valid` holds on the two legal runs and fails on both clash orders and on the
+repeated target, including after the monitor keeps answering.
+
+Quantifying over the whole support is what makes the run-level lifting load-bearing: the outcome is
+read off `SourceFinalValidity.Valid` at the reachable state, not off the recorded bit. The
+`repeatedTarget` and `poisonThenCollection` cases pin the distinct-target-tweak conjunct and the
+clash orders pin target/collection disjointness. -/
+theorem reachable_valid_decides_canary :
+    (∀ z ∈ support ((simulateQ (oracles problem .only) challengeOnly.choose).run .initial),
+        SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support ((simulateQ (oracles problem .only) repeatedCollection.choose).run .initial),
+        SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles problem .only) challengeThenCollection.choose).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles problem .only) collectionThenChallenge.choose).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support ((simulateQ (oracles problem .only) repeatedTarget.choose).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles problem .only) poisonThenCollection.choose).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets Prod.fst z.2) :=
+  ⟨valid_of_run run_challengeOnly rfl, valid_of_run run_repeatedCollection rfl,
+    not_valid_of_run run_challengeThenCollection rfl,
+    not_valid_of_run run_collectionThenChallenge rfl,
+    not_valid_of_run run_repeatedTarget rfl,
+    not_valid_of_run poison_then_collection_history_canary rfl⟩
+
+end RunLevelInvariant
+
 end SMDTTCRFinalValidityTest

--- a/VCVioTest/SMDTUDFinalValidity.lean
+++ b/VCVioTest/SMDTUDFinalValidity.lean
@@ -335,6 +335,68 @@ theorem subspace_emb_applied_canary :
     SM_DT_UD_SourceFinalValidity.RealSuccess, SM_DT_UD_SourceFinalValidity.IdealSuccess,
     experiment_subspaceProbe_real, experiment_subspaceProbe_ideal]
 
+section RunLevelInvariant
+
+open TweakableHash TweakableHash.SM_DT_UD_SourceFinalValidity
+
+/-- Transfer of the run-level monitor invariant along a transcript pinned to one outcome, in the
+direction that concludes the final predicate holds. -/
+private lemma valid_of_run {world : World} {adv : Adversary problem} {ps : adv.State}
+    {gs : State Bool}
+    (hrun : (simulateQ (oracles world problem .only) adv.pick).run .initial = pure (ps, gs))
+    (hvalid : gs.valid = true) :
+    ∀ z ∈ support ((simulateQ (oracles world problem .only) adv.pick).run .initial),
+      SourceFinalValidity.Valid problem.numTargets id z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable world adv .only hz
+  rw [hrun, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- Transfer of the run-level monitor invariant along a transcript pinned to one outcome, in the
+direction that concludes the final predicate fails. -/
+private lemma not_valid_of_run {world : World} {adv : Adversary problem} {ps : adv.State}
+    {gs : State Bool}
+    (hrun : (simulateQ (oracles world problem .only) adv.pick).run .initial = pure (ps, gs))
+    (hvalid : gs.valid = false) :
+    ∀ z ∈ support ((simulateQ (oracles world problem .only) adv.pick).run .initial),
+      ¬ SourceFinalValidity.Valid problem.numTargets id z.2 := by
+  intro z hz
+  have hdecide := valid_eq_decide_valid_of_reachable world adv .only hz
+  rw [hrun, support_pure, Set.mem_singleton_iff] at hz
+  subst hz
+  simpa [hvalid] using hdecide.symm
+
+/-- The sticky bit decides the final predicate on every reachable state, in both worlds. Reading the
+outcome off `SourceFinalValidity.Valid` at the reachable state rather than off the recorded bit is
+what makes this more than a restatement of the transcript: a vacuously lifted invariant would not
+close these. The real and ideal runs of the same adversary reach the same state, because the
+challenge response is drawn before the state is written. -/
+theorem reachable_valid_decides_canary :
+    (∀ z ∈ support ((simulateQ (oracles .real problem .only) separate.pick).run .initial),
+        SourceFinalValidity.Valid problem.numTargets id z.2) ∧
+      (∀ z ∈ support ((simulateQ (oracles .ideal problem .only) separate.pick).run .initial),
+        SourceFinalValidity.Valid problem.numTargets id z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles .real problem .only) repeatCollection.pick).run .initial),
+        SourceFinalValidity.Valid problem.numTargets id z.2) ∧
+      (∀ z ∈ support
+          ((simulateQ (oracles .ideal problem .only) repeatCollection.pick).run .initial),
+        SourceFinalValidity.Valid problem.numTargets id z.2) ∧
+      (∀ z ∈ support ((simulateQ (oracles .real problem .only) exceedCap.pick).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets id z.2) ∧
+      (∀ z ∈ support ((simulateQ (oracles .real problem .only) duplicateTarget.pick).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets id z.2) ∧
+      (∀ z ∈ support ((simulateQ (oracles .real problem .only) crossClash.pick).run .initial),
+        ¬ SourceFinalValidity.Valid problem.numTargets id z.2) :=
+  ⟨valid_of_run run_separate_real rfl, valid_of_run run_separate_ideal rfl,
+    valid_of_run run_repeatCollection_real rfl, valid_of_run run_repeatCollection_ideal rfl,
+    not_valid_of_run run_exceedCap_real rfl,
+    not_valid_of_run run_duplicateTarget_real rfl,
+    not_valid_of_run run_crossClash_real rfl⟩
+
+end RunLevelInvariant
+
 /-- The phase types expose the challenge/collection bundle only before seed reveal. -/
 example : OracleComp Specs separate.State := separate.pick
 


### PR DESCRIPTION
Lifts #594's per-step `Invariant` chain to a whole run, for all five
source-final-validity games.

`FinalValidity.lean` says of `Invariant` that "the sticky bit is exactly the
decision procedure for the final predicate, rather than merely a one-way
soundness flag", and proves that per step. Nothing turns those steps into a
statement about the state an experiment actually ends in, so every `Experiment`
reads `gameState.valid` raw with nothing connecting that bit to
`SourceFinalValidity.Valid`.

Adds, per game, `challengeOracle_preservesInv`, `oracles_preservesInv` and
`valid_eq_decide_valid_of_reachable`: each oracle summand preserves the
invariant, so their sum does, and on every reachable state `valid` decides
`Valid`. Plus the missing `isEmpty_domain_collectionSpec_empty` analogue on the
monitor side, so the stand-alone instance is pinned rather than asserted in
prose.

### Built on #656

The structural `PreservesInv` rules added by #656 are what this PR consumes, so
no summand argument is hand-rolled:

- every `oracles` is `privateRandomness + (challengeOracle + collectionOracle)`,
  so each `oracles_preservesInv` is a term built from
  `QueryImpl.PreservesInv.add` over three per-summand lemmas, with no `match`
  over `Sum` and no `QueryImpl.add_apply_inl`/`add_apply_inr` rewriting;
- `preservesInv_privateRandomness` is `StateT.preservesInv_monadLift` after the
  two handler-application equations;
- `SMDTOpenPREFinalValidity.initializeTargets_preservesInv` walks its `do` block
  clause by clause through `preservesInv_bind`, `preservesInv_get_bind`,
  `preservesInv_set_of`, `preservesInv_monadLift` and `preservesInv_pure`,
  instead of a `simp only` over the run equations plus a nine-component
  `obtain` pattern.

The collection summand is shared rather than repeated: one generic
`SourceFinalValidity.preservesInv_collectionOracle` in `FinalValidity.lean`
serves all five games.

### Shape

One prose change rides along, in `SMDTTCRFinalValidity.Experiment`'s docstring:
"A forgery wins exactly when…" becomes "An adversary wins exactly when…". This is
a hash game, not a signature game, and `forgery` occurs as an identifier nowhere
under `HardnessAssumptions/`. (The `SM_DT_TCR_Adversary.forge` *field* is left
alone — renaming it to `collide` or `find`, matching `invert`/`guess`/`distinguish` on the
sibling games, is a public-API change across six files and belongs in its own PR.)

Otherwise additive: +549/−0 across eleven files, all under
`CryptoFoundations/HardnessAssumptions/TweakableHash/` and `VCVioTest/`. No
definition, oracle result type or winning condition changes, and no file is
added — so the expose-boundary counts are untouched by construction.

SM-DT-UD is the one non-transcription: its history is `List Tweak`, so its
`tweakOf` is `id` rather than `Prod.fst`, and its oracle takes a world parameter
the argument never branches on — the response is drawn before the state is
written.

### Series

One of five PRs completing the tweakable-hash foundation. This one is
independent of the other four and can merge in any order.

### Validation

`./scripts/validate.sh --lint --test --axioms` exits 0 against `main` at
`40481e53`: the seven proof libraries with the warning budget,
`scripts/check-imports.sh`, the boundary ratchets, `lake exe lint-style`, the
agent-docs checks, the Batteries environment linters, `lake test`, and the axiom
sweep. `scripts/nolints.json`, `scripts/axiom_baseline.json`,
`scripts/pmf_boundary_baseline.tsv` and `scripts/expose_boundary_baseline.tsv`
are all unchanged.

