### PR TITLE
fix(validation): enforce test warnings and preserve wrapper flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Check generated umbrella modules
         run: |
           python3 scripts/test-check-imports.py
+          python3 scripts/test-validation.py
           bash scripts/check-imports.sh
 
   complexity_backend:

--- a/ToMathlib/Data/ENNReal/SumSquares.lean
+++ b/ToMathlib/Data/ENNReal/SumSquares.lean
@@ -20,9 +20,8 @@ open Finset ENNReal
 
 namespace ENNReal
 
-/-- The `ℝ≥0∞` form of Mathlib's root `two_mul_le_add_sq` (which needs an ordered ring with
-`ExistsAddOfLE` and `MulPosStrictMono`, so it does not apply to `ℝ≥0∞`); inside `open ENNReal` the
-unqualified name resolves to this lemma. -/
+/-- The `ℝ≥0∞` form of Mathlib's root `two_mul_le_add_sq`. The root lemma requires strict
+multiplication and additive order reflection, which fail in the presence of `⊤`. -/
 lemma two_mul_le_add_sq (a b : ℝ≥0∞) :
     2 * a * b ≤ a ^ 2 + b ^ 2 := by
   rcases eq_or_ne a ⊤ with rfl | ha
@@ -33,8 +32,7 @@ lemma two_mul_le_add_sq (a b : ℝ≥0∞) :
   exact_mod_cast _root_.two_mul_le_add_sq a.toNNReal b.toNNReal
 
 /-- The `ℝ≥0∞` form of Mathlib's root `sq_sum_le_card_mul_sum_sq`
-(`Mathlib/Algebra/Order/Chebyshev`, stated for linearly ordered rings); inside `open ENNReal` the
-unqualified name resolves to this lemma. -/
+(`Mathlib/Algebra/Order/Chebyshev`), whose strict ordered-semiring assumptions exclude `ℝ≥0∞`. -/
 lemma sq_sum_le_card_mul_sum_sq {ι' : Type*}
     (s : Finset ι') (f : ι' → ℝ≥0∞) :
     (∑ i ∈ s, f i) ^ 2 ≤ s.card * ∑ i ∈ s, f i ^ 2 := by

--- a/docs/reading/internal-duplication.md
+++ b/docs/reading/internal-duplication.md
@@ -18,7 +18,7 @@ quantified over the query index, for a `QueryImpl spec (StateT σ ProbComp)`. Th
 `∀ t, StateT.PreservesInv (impl t) Inv`, so `QueryImpl.preservesInv_iff` is `Iff.rfl` and the
 `StateT` lemmas (`preservesInv_bind`, `preservesInv_of_statePreserving`, …) apply to each query
 implementation directly. The consumers (`ProgrammingOracle`, `CachingOracle`, the
-`PRFTagReader` example) are unchanged because the unfolding is definitional.
+`PRFTagReader` example) retain their statements; the example proofs use the structural rules.
 
 ## Layered, not duplicated
 
@@ -43,19 +43,20 @@ where the two presentations need care.
 **Cost-instrumentation layers.** `CostModel`, `CountingOracle`, `WriterCost`, and `QueryCost`
 are four presentations of "run the computation and accumulate a cost". `AddWriterT`
 (`VCVio/OracleComp/QueryTracking/WriterCost.lean`) is canonical: `CostModel.expectedCost`
-already delegates to `AddWriterT.expectedCost`. The odd one out is `CountingOracle.withCost`,
-which writes into the *multiplicative* `QueryCount` writer (`Structures.lean` gives
+already delegates to `AddWriterT.expectedCost`. `QueryImpl.withCost`, defined in
+`CountingOracle.lean`, supports arbitrary monoid-valued costs. Its `withCounting` specialization
+writes into the *multiplicative* `QueryCount` writer (`Structures.lean` gives
 `QueryCount ι := ι → ℕ` a `Monoid` whose `mul` is `+`). Folding it onto `AddWriterT` is blocked
 by the `QueryCount` design item in the ledger: the definition is `@[reducible]`, so that
 `Monoid` instance leaks onto every `ι → ℕ` (`#synth Monoid (ℕ → ℕ)` finds it), and the fold has
 to change the carrier (the repo already uses `κ →₀ ℕ` in `ResourceProfile.lean`) before it can
 change the writer.
 
-**`QueryImpl`/`ProbHandler` versus PolyFun's `Sampler`/`Decoration`.** A `QueryImpl spec m` is a
-per-query interpretation into `m`; PolyFun's `Spec.Sampler m spec` is `Decoration (fun X => m X)
-spec`, the same data in the interaction layer's vocabulary (`VCVio/Interaction/UC/Runtime.lean`
-already threads samplers through processes). `ProbHandler` (`VCVio/OracleComp/Coinductive/
-DynSystem.lean`) is a third spelling for the coinductive runtime. These stay two vocabularies for
-one concept until the Kleisli–Mealy wiring that PolyFun's own ledger tracks lands; at that point
-`QueryImpl` should become the `OracleSpec`-indexed alias of the PolyFun notion, the way the
-`OracleSpec` operations already are.
+**Oracle handlers and interaction samplers.** `QueryImpl spec m` already specializes PolyFun's
+`PFunctor.Handler m spec.toPFunctor` through `QueryImpl.eq_handler`; `ProbHandler` in
+`VCVio/OracleComp/Coinductive/DynSystem.lean` specializes that handler to the discrete probability
+backend. `TypeTree.Sampler m tree` decorates every interaction-tree node with a computation of
+its answer type. These have different indexing structures: an oracle signature versus a tree
+of possible interaction nodes. `VCVio/Interaction/UC/Runtime.lean` consumes the latter through
+`TypeTree.samplePath`. A further unification needs an explicit bridge between the index
+structures and execution laws, rather than another alias of the existing handler.

--- a/scripts/build-project.sh
+++ b/scripts/build-project.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 if [[ "${1:-}" == "--ffi" ]]; then
-  exec "$REPO_ROOT/scripts/validate.sh" --test --ffi
+  shift
+  exec "$REPO_ROOT/scripts/validate.sh" --test --ffi "$@"
 fi
 exec "$REPO_ROOT/scripts/validate.sh" --test "$@"

--- a/scripts/extract-doc-fragments.py
+++ b/scripts/extract-doc-fragments.py
@@ -11,6 +11,8 @@ Usage:
   python scripts/extract-doc-fragments.py --check    # check if docs are up to date
 """
 
+from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path

--- a/scripts/test-validation.py
+++ b/scripts/test-validation.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Exercise validation failure propagation with lightweight command substitutes."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class ValidationTests(unittest.TestCase):
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory(prefix="vcvio-validation-")
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        scripts = self.root / "scripts"
+        scripts.mkdir()
+        source = Path(__file__).parent
+        for name in ("validate.sh", "build-project.sh", "check-warning-log.py"):
+            shutil.copy2(source / name, scripts / name)
+        for name in ("check-imports", "test-polyfun-boundary", "check-polyfun-boundary",
+                     "test-pmf-boundary", "check-pmf-boundary", "test-expose-boundary",
+                     "check-expose-boundary", "test-complexity-backend-isolation",
+                     "check-complexity-backend-isolation", "check-extern-isolation",
+                     "check-interop-isolation", "test-axiomsweep"):
+            self.script(scripts / f"{name}.sh", 'exit 0\n')
+        for name in ("test-check-imports.py", "test-validation.py", "check-agent-docs.py",
+                     "extract-doc-fragments.py"):
+            (scripts / name).write_text("pass\n")
+        binary = self.root / "bin"
+        binary.mkdir()
+        self.script(binary / "lake", '''
+printf '%s\\n' "$*" >> "$VALIDATION_CALLS"
+if [ "$1" = test ]; then
+  printf '%s\\n' "${VALIDATION_WARNING:-}"
+  exit "${VALIDATION_TEST_EXIT:-0}"
+fi
+''')
+        self.script(binary / "git", 'exit 0\n')
+        self.env = dict(os.environ, PATH=f"{binary}{os.pathsep}{os.environ['PATH']}",
+                        VALIDATION_CALLS=str(self.root / "calls"))
+
+    @staticmethod
+    def script(path, body):
+        path.write_text("#!/usr/bin/env bash\nset -eu\n" + body)
+        path.chmod(0o755)
+
+    def validate(self, *args, wrapper=False, **env):
+        name = "build-project.sh" if wrapper else "validate.sh"
+        return subprocess.run(["bash", f"scripts/{name}", *args], cwd=self.root,
+                              env=dict(self.env, **env), text=True, capture_output=True,
+                              timeout=15)
+
+    def test_clean_tests_pass(self):
+        result = self.validate("--test")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("validate: OK.", result.stdout)
+        self.assertIn("test", (self.root / "calls").read_text().splitlines())
+
+    def test_each_test_library_warning_fails(self):
+        for library in ("VCVioTest", "LatticeCryptoTest", "HashSigTest"):
+            with self.subTest(library=library):
+                result = self.validate("--test", VALIDATION_WARNING=
+                                       f"warning: {library}/Canary.lean:1:1: unused tactic")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("test-library warnings", result.stdout + result.stderr)
+
+    def test_dependency_sorry_does_not_spend_test_budget(self):
+        result = self.validate("--test", VALIDATION_WARNING=
+                               "warning: VCVio/Existing.lean:1:1: declaration uses `sorry`")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_test_failure_survives_tee(self):
+        for flags in (("--test",), ("--test", "--ffi")):
+            with self.subTest(flags=flags):
+                result = self.validate(*flags, VALIDATION_TEST_EXIT="7")
+                self.assertEqual(result.returncode, 7, result.stdout + result.stderr)
+
+    def test_ffi_wrapper_preserves_other_flags(self):
+        result = self.validate("--ffi", "--axioms", wrapper=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        calls = (self.root / "calls").read_text().splitlines()
+        self.assertIn("test -- --ffi", calls)
+        self.assertIn("exe axiomsweep --check", calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -53,7 +53,8 @@ fi
 
 PROOF_LIBS=(ToMathlib VCVio LatticeCrypto Extern HashSig Examples VCVioWidgets)
 BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/vcvio-validate-build.XXXXXX")"
-trap 'rm -f "$BUILD_LOG"' EXIT
+TEST_LOG="$(mktemp "${TMPDIR:-/tmp}/vcvio-validate-test.XXXXXX")"
+trap 'rm -f "$BUILD_LOG" "$TEST_LOG"' EXIT
 
 echo "# Building the proof libraries"
 lake build "${PROOF_LIBS[@]}" 2>&1 | tee "$BUILD_LOG"
@@ -71,6 +72,7 @@ python3 ./scripts/check-warning-log.py "$BUILD_LOG" "${warning_args[@]}" \
 echo ""
 echo "# Checking generated umbrella modules"
 python3 ./scripts/test-check-imports.py
+python3 ./scripts/test-validation.py
 ./scripts/check-imports.sh
 
 echo ""
@@ -98,7 +100,8 @@ while IFS= read -r module; do
   test_modules+=("$module")
 done < <(git ls-files 'VCVioTest/*.lean' 'LatticeCryptoTest/*.lean' \
   'HashSigTest/*.lean' | sed -e 's/\.lean$//' -e 's#/#.#g')
-lake exe lint-style "${PROOF_LIBS[@]}" Interop "${test_modules[@]}"
+# Bash 3.2 treats an empty array as unset under nounset.
+lake exe lint-style "${PROOF_LIBS[@]}" Interop ${test_modules[@]+"${test_modules[@]}"}
 
 echo ""
 echo "# Checking the agent documentation"
@@ -120,10 +123,14 @@ if (( run_test )); then
   echo "# Running lake test"
   if (( run_ffi )); then
     git submodule update --init --recursive
-    lake test -- --ffi
+    lake test -- --ffi 2>&1 | tee "$TEST_LOG"
   else
-    lake test
+    lake test 2>&1 | tee "$TEST_LOG"
   fi
+  python3 ./scripts/check-warning-log.py "$TEST_LOG" \
+    --path-prefix VCVioTest/ --path-prefix VCVioTest.lean \
+    --path-prefix LatticeCryptoTest/ --path-prefix LatticeCryptoTest.lean \
+    --path-prefix HashSigTest/ --label 'test-library warnings'
 fi
 
 if (( run_axioms )); then


### PR DESCRIPTION
## Summary

Local validation can currently accept warnings from test libraries, and `build-project.sh --ffi --axioms` silently drops `--axioms`. Enforce the same test-warning budget as CI, preserve additional wrapper arguments, and retain failing test exit codes through log capture.

The regression suite exercises both native and ordinary test failure propagation, warning rejection for all three test libraries, wrapper forwarding, and completion with an empty discovered-module list on Bash 3.2. CI runs these tests without building native executables. Postponed annotations also let the documentation extractor run on Python 3.9.

Correct the foundation documentation to name the actual semiring assumptions, cost-handler APIs, and existing `QueryImpl.eq_handler` bridge. These are documentation-only Lean changes. This follow-up carries the remaining useful repairs from the reviews of the now-merged #654 and #656.

## Verification

- `lake exe cache get && lake build`: all seven proof libraries pass (3982 jobs).
- `python3 scripts/test-validation.py`: five tests pass, including subcases for all test libraries and both test modes.
- `python3 scripts/test-check-imports.py`: five tests pass.
- Agent documentation, generated documentation fragments, shell syntax, and `git diff --check` pass on macOS with Python 3.9.6 and Bash 3.2.
- `./scripts/validate.sh --test --axioms`: passes, including all three test libraries, smoke and SLH-DSA executables, warning budgets, generated umbrellas, boundaries, style checks, axiom-sweep fixtures, and the axiom sweep (18,144 declarations; no new axiom/sorry taint).

## Checklist

- [x] Existing Lean headers preserved; new-file Lean module/exposure requirements do not apply.
- [x] No theorem, executable Lean definition, tactic registration, or simp/grind/gcongr set changes.
- [x] No linter suppression, deprecated alias, native trust, or baseline changes.
- [x] Documentation checks pass; validation regression fixtures use command substitutes and do not run native FFI tests in PR CI.
- [x] Integration validation passes, including generated umbrellas and axiom sweep; committed baselines are unchanged.
