### PR TITLE
feat(tactics): improve generalized relation automation for cost and measure bounds

### DIFF
--- a/ToMathlib/MeasureTheory/Measure/Monotone.lean
+++ b/ToMathlib/MeasureTheory/Measure/Monotone.lean
@@ -38,6 +38,14 @@ theorem bind_mono_right {μ : Measure α} {f g : α → Measure β}
   rw [Measure.bind_apply hs hf, Measure.bind_apply hs hg]
   exact lintegral_mono_ae <| hfg.mono fun _ hx => hx s
 
+/-- Giry bind preserves pointwise order of almost-everywhere measurable continuations.
+The pointwise hypothesis lets generalized congruence descend into the continuations. -/
+@[gcongr]
+theorem bind_mono_right_of_forall {μ : Measure α} {f g : α → Measure β}
+    (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) (hfg : ∀ x, f x ≤ g x) :
+    μ.bind f ≤ μ.bind g :=
+  bind_mono_right hf hg (Filter.Eventually.of_forall hfg)
+
 private theorem iSup_tsum_of_monotone (f : ℕ → ℕ → ENNReal)
     (hf : ∀ i, Monotone fun n => f n i) :
     (⨆ n, ∑' i, f n i) = ∑' i, ⨆ n, f n i := by

--- a/VCVio/CryptoFoundations/Fischlin/CostAccounting.lean
+++ b/VCVio/CryptoFoundations/Fischlin/CostAccounting.lean
@@ -7,6 +7,7 @@ Authors: Oleksandr Vovkotrub
 module
 
 public import VCVio.CryptoFoundations.Fischlin.Defs
+import Mathlib.Tactic.GRewrite
 
 /-!
 # Fischlin Transform: Query-Cost Accounting
@@ -125,10 +126,9 @@ private lemma fischlinSearchAuxWithUnitCost_queryBoundedAboveBy
           (fun h => ?_))
         (by omega)
       by_cases hh : h.val = 0
-      · simpa [hashStep, hh] using
-          AddWriterT.queryBoundedAboveBy_mono
-            (AddWriterT.queryBoundedAboveBy_pure ((some (ω, resp)) : Option (Chal × Resp)))
-            (Nat.zero_le rest.length)
+      · grw [← Nat.zero_le rest.length]
+        simpa [hashStep, hh] using
+          AddWriterT.queryBoundedAboveBy_pure ((some (ω, resp)) : Option (Chal × Resp))
       · let newBest : Option (Chal × Resp × Fin (2 ^ b)) := match best with
           | none => some (ω, resp, h)
           | some (ω', resp', h') =>
@@ -225,11 +225,9 @@ private lemma fischlinSearchAuxWithAddCost_pathwiseCostAtMost
         have htell :
             AddWriterT.PathwiseCostAtMost
               (AddWriterT.addTell (M := m) (costFn ⟨pk, msg, comList, i, chal, resp⟩))
-              w :=
-          AddWriterT.pathwiseCostAtMost_mono
-            (AddWriterT.pathwiseCostAtMost_addTell
-              (m := m) (costFn ⟨pk, msg, comList, i, chal, resp⟩))
-            (hcost _)
+              w := by
+          grw [← hcost ⟨pk, msg, comList, i, chal, resp⟩]
+          exact AddWriterT.pathwiseCostAtMost_addTell _
         refine AddWriterT.pathwiseCostAtMost_bind (w₁ := w) (w₂ := rest.length • w) htell ?_
         intro _
         have hhash :
@@ -251,16 +249,15 @@ private lemma fischlinSearchAuxWithAddCost_pathwiseCostAtMost
               (m := m) (runtime ⟨pk, msg, comList, i, chal, resp⟩)) ?_
           intro h
           by_cases hh : h.val = 0
-          · simpa [hh] using
-              AddWriterT.pathwiseCostAtMost_mono
-                (AddWriterT.pathwiseCostAtMost_pure ((some (chal, resp)) : Option (Chal × Resp)))
-                (zero_le)
+          · grw [← (zero_le : 0 ≤ rest.length • w)]
+            simpa [hh] using
+              AddWriterT.pathwiseCostAtMost_pure ((some (chal, resp)) : Option (Chal × Resp))
           · let newBest : Option (Chal × Resp × Fin (2 ^ b)) := match best with
               | none => some (chal, resp, h)
               | some (ω', resp', h') =>
                   if h.val < h'.val then some (chal, resp, h) else some (ω', resp', h')
             simpa [hh, newBest] using ih (best := newBest)
-        exact AddWriterT.pathwiseCostAtMost_mono hhash (by simp [zero_add])
+        simpa only [zero_add] using hhash
       simpa [succ_nsmul'] using
         (AddWriterT.pathwiseCostAtMost_bind (w₁ := 0) (w₂ := w + rest.length • w)
           (AddWriterT.pathwiseCostAtMost_monadLift (m := m) (σ.respond pk sk sc chal))
@@ -436,10 +433,9 @@ theorem sign_usesAtMostRhoCardOmegaQueries
           rcases pair with ⟨ω, resp⟩
           simpa [finish] using AddWriterT.queryBoundedAboveBy_pure
             (m := m) ((comVec i, ω, resp) : Commit × Chal × Resp)
-    exact AddWriterT.queryBoundedAboveBy_mono
+    simpa only [add_zero, hlen] using
       (AddWriterT.queryBoundedAboveBy_bind (n₁ := (FinEnum.toList Chal).length) (n₂ := 0)
         hsearch hcont)
-      (by simp [hlen])
   let commitComp : AddWriterT ℕ m (Fin ρ → Commit × PrvState) :=
     Fin.mOfFn ρ fun _ => (liftM (σ.commit pk sk) : AddWriterT ℕ m (Commit × PrvState))
   have hcommit :
@@ -552,10 +548,9 @@ theorem sign_usesWeightedQueryCostAtMost
           rcases pair with ⟨ω, resp⟩
           simpa [finish] using AddWriterT.pathwiseCostAtMost_pure
             (m := m) ((comVec i, ω, resp) : Commit × Chal × Resp)
-    refine AddWriterT.pathwiseCostAtMost_mono
+    simpa only [add_zero, hlen] using
       (AddWriterT.pathwiseCostAtMost_bind (w₁ := (FinEnum.toList Chal).length • w) (w₂ := 0)
-        hsearch hcont) ?_
-    simp [hlen]
+        hsearch hcont)
   let commitComp : AddWriterT κ m (Fin ρ → Commit × PrvState) :=
     Fin.mOfFn ρ fun _ => (liftM (σ.commit pk sk) : AddWriterT κ m (Commit × PrvState))
   have hcommit :
@@ -611,7 +606,7 @@ theorem sign_usesWeightedQueryCostAtMost
 
 end signCostAccounting
 
-section expectedWeightedQueryCost
+section expectedQueryCost
 
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 variable [FinEnum Chal] [Inhabited Chal] [Inhabited Resp]
@@ -638,16 +633,6 @@ theorem sign_expectedQueryCost_le
       (costFn := costFn) (w := w) hcost)
     hval
 
-end expectedWeightedQueryCost
-
-section expectedQueries
-
-variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
-variable [FinEnum Chal] [Inhabited Chal] [Inhabited Resp]
-  (hr : GenerableRelation Stmt Wit rel) (S : ℕ)
-  [DecidableEq M] [MonadLiftT m SPMF]
-  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
-
 /-- Fischlin signing has expected query count at most `ρ * |Ω|` in the unit-cost runtime model.
 
 This is the expectation-level counterpart of
@@ -662,7 +647,7 @@ theorem sign_expectedQueries_le_rhoCardOmega
       (σ := σ) (hr := hr) (ρ := ρ) (b := b) (S := S) (M := M)
       (runtime := runtime) (pk := pk) (sk := sk) (msg := msg))
 
-end expectedQueries
+end expectedQueryCost
 
 section expectedQueriesPMF
 

--- a/VCVio/EvalDist/ResumptionMeasure.lean
+++ b/VCVio/EvalDist/ResumptionMeasure.lean
@@ -130,10 +130,10 @@ theorem outputMeasure_le_succ [∀ a, DiscreteMeasurableSpace (P.B a)]
           eq_of_dest_eq (by simpa using hdest)
         subst computation
         rw [outputMeasure_query_succ, outputMeasure_query_succ]
-        exact Measure.bind_mono_right
-          Measurable.of_discrete.aemeasurable
-          Measurable.of_discrete.aemeasurable
-          (Filter.Eventually.of_forall fun direction => ih (next direction))
+        gcongr with direction
+        · exact Measurable.of_discrete.aemeasurable
+        · exact Measurable.of_discrete.aemeasurable
+        · exact ih (next direction)
 
 /-- The finite returned-output observations form an increasing sequence of measures. -/
 theorem monotone_outputMeasure [∀ a, DiscreteMeasurableSpace (P.B a)]

--- a/VCVio/OracleComp/QueryTracking/CostModel.lean
+++ b/VCVio/OracleComp/QueryTracking/CostModel.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Polynomial.Eval.Defs
 public import VCVio.OracleComp.QueryTracking.QueryBound
 public import VCVio.OracleComp.QueryTracking.QueryCost
 public import VCVio.ProgramLogic.Unary.HoareTriple
+import Mathlib.Tactic.GRewrite
 
 /-!
 # Cost Models for Oracle Computations
@@ -151,12 +152,9 @@ theorem expectedCost_le_of_support_bound (oa : OracleComp spec α) (cm : CostMod
     (val : ω → ℝ≥0∞) (c : ℝ≥0∞)
     (h : ∀ z ∈ support (costDist oa cm), val (Multiplicative.toAdd z.2) ≤ c) :
     expectedCost oa cm val ≤ c := by
-  rw [expectedCost_eq_wp_costDist, ← wp_const (costDist oa cm) c, wp_eq_tsum, wp_eq_tsum]
-  refine ENNReal.tsum_le_tsum fun z => ?_
-  by_cases hz : z ∈ support (costDist oa cm)
-  · gcongr
-    exact h z hz
-  · simp [probOutput_eq_zero_of_not_mem_support hz]
+  rw [expectedCost_eq_wp_costDist, ← wp_const (costDist oa cm) c]
+  gcongr with z hz
+  exact h z hz
 
 end ExpectedCost
 
@@ -336,10 +334,8 @@ theorem IsPerIndexQueryBound.toWorstCaseCostBound_unit_sum
     induction oa using OracleComp.inductionOn with
     | pure x =>
         intro qb _
-        exact AddWriterT.queryBoundedAboveBy_mono
-          (by simpa [instrumentedRun] using
-            (AddWriterT.queryBoundedAboveBy_pure (m := OracleComp spec) x))
-          (Nat.zero_le _)
+        grw [← Nat.zero_le (∑ i, qb i)]
+        simpa [instrumentedRun] using AddWriterT.queryBoundedAboveBy_pure x
     | query_bind t mx ih =>
         intro qb hqb
         rw [isPerIndexQueryBound_query_bind_iff] at hqb

--- a/VCVio/OracleComp/QueryTracking/WriterCost.lean
+++ b/VCVio/OracleComp/QueryTracking/WriterCost.lean
@@ -228,8 +228,10 @@ noncomputable abbrev expectedCostNat
     (oa : AddWriterT ℕ m α) : ENNReal :=
   expectedCost oa (fun n ↦ ↑n)
 
+section tailBounds
+
 omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m]
-    in
+
 /-- Tail-sum formula for the natural-valued expected cost of an `AddWriterT` computation:
 
 `E[cost] = ∑ i, Pr[i < cost]`.
@@ -245,8 +247,6 @@ lemma expectedCostNat_eq_tsum_tail_probs
   refine tsum_congr fun n ↦ ?_
   by_cases h : i < n <;> simp [Set.indicator, h]
 
-omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m]
-    in
 /-- Tail domination bounds the expected natural-valued writer cost.
 
 If the tail probability `Pr[i < cost]` is bounded by `a i` for every `i`, then
@@ -256,6 +256,8 @@ lemma expectedCostNat_le_tsum_of_tail_probs_le
     (h : ∀ i : ℕ, Pr[ fun c ↦ i < c | oa.costs ] ≤ a i) :
     expectedCostNat oa ≤ ∑' i : ℕ, a i :=
   (expectedCostNat_eq_tsum_tail_probs oa).trans_le (ENNReal.tsum_le_tsum h)
+
+end tailBounds
 
 omit [LawfulMonadLiftT m SPMF] in
 /-- Finite tail-sum formula for natural-valued writer cost under a pathwise upper bound.
@@ -435,6 +437,7 @@ lemma pathwiseHasCost_probCompLift_of_supportNonempty [LawfulMonad m] [MonadLift
   pathwiseHasCost_monadLift_of_supportNonempty (m := m) (ω := ω) (x := (liftM x : m α)) hx
 
 omit [Monad m] [LawfulMonadLiftT m SetM] in
+@[gcongr]
 lemma pathwiseCostAtMost_mono {oa : AddWriterT ω m α} {w₁ w₂ : ω}
     (h : PathwiseCostAtMost oa w₁) (hw : w₁ ≤ w₂) :
     PathwiseCostAtMost oa w₂ :=
@@ -644,6 +647,7 @@ lemma queryBoundedBelowBy_monadLift [LawfulMonad m] (x : m α) :
   pathwiseCostAtLeast_monadLift x
 
 omit [Monad m] [LawfulMonadLiftT m SetM] in
+@[gcongr]
 lemma queryBoundedAboveBy_mono {oa : AddWriterT ℕ m α} {n₁ n₂ : ℕ}
     (h : QueryBoundedAboveBy oa n₁) (hn : n₁ ≤ n₂) :
     QueryBoundedAboveBy oa n₂ :=

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -43,6 +43,8 @@ public import VCVioTest.Tactic.Expectation
 public import VCVioTest.Tactic.Finiteness
 public import VCVioTest.Tactic.FunProp
 public import VCVioTest.Tactic.GCongr
+public import VCVioTest.Tactic.GeneralizedRelations
+public import VCVioTest.Tactic.GeneralizedRelationsExperiments
 public import VCVioTest.Tactic.Positivity
 public import VCVioTest.ToMathlib.AbsDiff
 public import VCVioTest.UniformOn

--- a/VCVioTest/Tactic/GeneralizedRelations.lean
+++ b/VCVioTest/Tactic/GeneralizedRelations.lean
@@ -1,0 +1,273 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import VCVio.OracleComp.QueryTracking.WriterCost
+public import VCVio.ProgramLogic.Unary.HoareTriple
+public import ToMathlib.MeasureTheory.Measure.Monotone
+public import Mathlib.Probability.Kernel.Defs
+public import Mathlib.Tactic.GRewrite
+
+/-!
+# Generalized congruence and rewriting
+
+Ordinary-import tests for probability, support, cost predicates, and measure bind. Terminal
+examples exercise `gcongr`, `grw`, and `rel`; interactive examples pin the obligations exposed by
+congruence and rewrite normalization. Dated gap pairs distinguish partial progress from closure.
+The companion `GeneralizedRelationsExperiments` module isolates proposed registrations.
+-/
+
+public section
+
+open OracleComp OracleComp.EvalDist OracleComp.ProgramLogic OracleSpec MeasureTheory
+open scoped ENNReal
+
+namespace VCVioTest.GeneralizedRelations
+
+/-! ## Existing expectation and event rules -/
+
+section Probability
+
+variable {α β : Type} (mx : ProbComp α) (f g : α → ℝ≥0∞)
+
+example (h : ∀ x, f x ≤ g x) : expectedValue mx f ≤ expectedValue mx g := by grw [h]
+
+example (h : ∀ x ∈ support mx, f x ≤ g x) :
+    expectedValue mx f ≤ expectedValue mx g := by
+  -- gap(gcongr, 2026-09-08): the support-restricted hypothesis needs an explicit application.
+  fail_if_success (gcongr; done)
+  gcongr with x hx
+  guard_hyp hx : x ∈ support mx
+  guard_target = f x ≤ g x
+  exact h x hx
+
+/-- A rewrite theorem's own support premise remains a side goal. -/
+example (h : ∀ x ∈ support mx, f x ≤ g x) :
+    expectedValue mx f ≤ expectedValue mx g := by
+  -- gap(grw, 2026-09-08): the rewrite's support premise needs an explicit closer.
+  fail_if_success (grw [h]; done)
+  grw [h]
+  assumption
+
+-- Support-restricted `grw` on WP and nested expectations shares the gap above.
+example (h : ∀ x ∈ support mx, f x ≤ g x) : wp mx f ≤ wp mx g := by
+  grw [h]
+  assumption
+
+example (h : ∀ x ∈ support mx, f x ≤ g x) :
+    Std.Do'.wp mx f Lean.Order.bot ≤ Std.Do'.wp mx g Lean.Order.bot := by
+  -- gap(gcongr, 2026-09-08): the raw WP head needs explicit facade normalization.
+  fail_if_success gcongr
+  change wp mx f ≤ wp mx g
+  guard_target = wp mx f ≤ wp mx g
+  gcongr with x hx
+  guard_hyp hx : x ∈ support mx
+  guard_target = f x ≤ g x
+  exact h x hx
+
+example (p q : α → Prop) (h : ∀ x, p x → q x) : Pr[ p | mx] ≤ Pr[ q | mx] := by
+  apply_rw [h]
+
+example (p q : α → Prop) (h : ∀ x, p x → q x) (c : ℝ≥0∞)
+    (hq : Pr[ q | mx] ≤ c) : Pr[ p | mx] ≤ c := by
+  apply_rw [h]
+  guard_target = Pr[ q | mx] ≤ c
+  exact hq
+
+example (h : ∀ x, g x ≤ f x) : 1 - expectedValue mx f ≤ 1 - expectedValue mx g := by
+  grw [h]
+
+example (h : ∀ x, f x ≤ g x) (c : ℝ≥0∞) (hf : c ≤ expectedValue mx f) :
+    c ≤ expectedValue mx g := by
+  grw [h] at hf
+  guard_hyp hf : c ≤ expectedValue mx g
+  exact hf
+
+example (f' g' : α → ProbComp β) (p : β → Prop)
+    (h : ∀ x ∈ support mx, Pr[ p | f' x] ≤ Pr[ p | g' x]) :
+    Pr[ p | mx >>= f'] ≤ Pr[ p | mx >>= g'] := by
+  -- gap(gcongr, 2026-09-08): bind probability needs the expectation normal form.
+  fail_if_success gcongr
+  rw [probEvent_bind_eq_expectedValue, probEvent_bind_eq_expectedValue]
+  grw [h]
+  assumption
+
+example (my : α → ProbComp β) (u v : α → β → ℝ≥0∞)
+    (h : ∀ x ∈ support mx, ∀ y ∈ support (my x), u x y ≤ v x y) :
+    expectedValue mx (fun x => expectedValue (my x) (u x)) ≤
+      expectedValue mx (fun x => expectedValue (my x) (v x)) := by
+  grw [h] <;> assumption
+
+example (h : ∀ x, f x ≤ g x) :
+    expectedValue mx f + expectedValue mx f ≤ expectedValue mx g + expectedValue mx f := by
+  -- gap(nth_grw, 2026-09-08): occurrence abstraction does not eta-expand the function argument.
+  fail_if_success nth_grw 1 [h]
+  nth_grw 1 [expectedValue_mono mx h]
+
+/-- `rel` is a finishing tactic with an explicit list of main-goal facts. -/
+example (a b c d : ℝ≥0∞) (hab : a ≤ b) (hcd : c ≤ d) : a + c ≤ b + d := by
+  rel [hab, hcd]
+
+example (a b c d : ℝ≥0∞) (hab : a ≤ b) (hcd : c ≤ d) : a + c ≤ b + d := by
+  fail_if_success rel [hab]
+  rel [hab, hcd]
+
+end Probability
+
+/-! ## Support does not require probability semantics -/
+
+example {ι α : Type} {spec : OracleSpec ι} (oa : OracleComp spec α)
+    (o₁ o₂ : QueryImpl spec Set) (h : ∀ q, o₁ q ⊆ o₂ q) :
+    supportWhen o₁ oa ⊆ supportWhen o₂ oa := by
+  gcongr with q
+  guard_target = o₁ q ⊆ o₂ q
+  exact h q
+
+/-! ## Implication through cost predicates -/
+
+section Costs
+
+variable {α : Type} {m : Type → Type*} [Monad m] [MonadLiftT m SetM]
+variable (oa : AddWriterT ℕ m α) {a b c : ℕ}
+
+example (h : a ≤ b) :
+    AddWriterT.QueryBoundedAboveBy oa a → AddWriterT.QueryBoundedAboveBy oa b := by gcongr
+
+example (h : a ≤ b) :
+    AddWriterT.QueryBoundedAboveBy oa (a + c) →
+      AddWriterT.QueryBoundedAboveBy oa (b + c) := by gcongr
+
+-- Goal and hypothesis rewrites below pin the normalized certificate; the closer supplies it.
+example (h : a ≤ b) (ha : AddWriterT.QueryBoundedAboveBy oa a) :
+    AddWriterT.QueryBoundedAboveBy oa b := by
+  -- gap(grw, 2026-09-08): rewriting the bound does not close from a certificate in context.
+  fail_if_success (grw [← h]; done)
+  grw [← h]
+  guard_target = AddWriterT.QueryBoundedAboveBy oa a
+  exact ha
+
+example (h : a ≤ b) (ha : AddWriterT.QueryBoundedAboveBy oa a) :
+    AddWriterT.QueryBoundedAboveBy oa b := by
+  grw +useKAbstract [← h]
+  guard_target = AddWriterT.QueryBoundedAboveBy oa a
+  exact ha
+
+example (h : a ≤ b) (ha : AddWriterT.QueryBoundedAboveBy oa a) :
+    AddWriterT.QueryBoundedAboveBy oa b := by
+  grw [h] at ha
+  guard_hyp ha : AddWriterT.QueryBoundedAboveBy oa b
+  exact ha
+
+example (h : a ≤ b) (hcost : AddWriterT.QueryBoundedAboveBy oa (a + c)) :
+    AddWriterT.QueryBoundedAboveBy oa (b + c) := by
+  grw [← h]
+  guard_target = AddWriterT.QueryBoundedAboveBy oa (a + c)
+  exact hcost
+
+/-- Bounds can be weakened, but these rules cannot strengthen them. -/
+example (h : a ≤ b) (ha : AddWriterT.QueryBoundedAboveBy oa a) :
+    AddWriterT.QueryBoundedAboveBy oa b := by
+  fail_if_success grw [h]
+  grw [← h]
+  guard_target = AddWriterT.QueryBoundedAboveBy oa a
+  exact ha
+
+example {ω : Type} [AddCommMonoid ω] [PartialOrder ω]
+    (oa : AddWriterT ω m α) {a b : ω} (h : a ≤ b) :
+    AddWriterT.PathwiseCostAtMost oa a → AddWriterT.PathwiseCostAtMost oa b := by gcongr
+
+example {ω : Type} [AddCommMonoid ω] [PartialOrder ω]
+    (oa : AddWriterT ω m α) {a b : ω} (h : a ≤ b)
+    (ha : AddWriterT.PathwiseCostAtMost oa a) : AddWriterT.PathwiseCostAtMost oa b := by
+  grw [← h]
+  guard_target = AddWriterT.PathwiseCostAtMost oa a
+  exact ha
+
+example {ι : Type} (oa : AddWriterT (ι → ℕ) m α) {a b : ι → ℕ}
+    (h : ∀ i, a i ≤ b i) :
+    AddWriterT.PathwiseCostAtMost oa a → AddWriterT.PathwiseCostAtMost oa b := by
+  -- gap(gcongr, 2026-09-08): function order remains a main goal after cost descent.
+  fail_if_success (gcongr; done)
+  gcongr
+  guard_target = a ≤ b
+  exact h
+
+example (oa : AddWriterT ℝ≥0∞ m α) (a : ℝ≥0∞) :
+    AddWriterT.PathwiseCostAtMost oa a → AddWriterT.PathwiseCostAtMost oa ⊤ := by
+  rel [show a ≤ ⊤ from le_top]
+
+end Costs
+
+/-! ## Measures and measurable kernels -/
+
+section Measures
+
+variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+variable (μ : Measure α) (f g : α → Measure β)
+
+example (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) (h : ∀ x, f x ≤ g x) :
+    μ.bind f ≤ μ.bind g := by grw [h]
+
+example (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) (h : ∀ x, f x ≤ g x) :
+    μ.bind f ≤ μ.bind g := by
+  gcongr with x
+  guard_target = f x ≤ g x
+  exact h x
+
+/-- Monotonicity does not silently assume measurability. -/
+example (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) (h : ∀ x, f x ≤ g x) :
+    μ.bind f ≤ μ.bind g := by
+  fail_if_success (clear hf hg; grw [h]; done)
+  grw [h]
+
+example (h : ∀ᵐ x ∂μ, f x ≤ g x) (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
+    μ.bind f ≤ μ.bind g := by
+  -- gap(gcongr, 2026-09-08): the registered pointwise rule cannot consume an AE bound.
+  fail_if_success (gcongr; done)
+  exact Measure.bind_mono_right hf hg h
+
+example (κ η : ProbabilityTheory.Kernel α β) (h : ∀ x, κ x ≤ η x) :
+    μ.bind κ ≤ μ.bind η := by
+  -- gap(grw, 2026-09-08): bundled kernel measurability must be supplied to the discharger.
+  fail_if_success (grw [h]; done)
+  have hκ := κ.measurable.aemeasurable (μ := μ)
+  have hη := η.measurable.aemeasurable (μ := μ)
+  grw [h]
+
+/-! Nested binds distinguish measurability of the outer continuation from measurability in
+each inner source. Universal measurability hypotheses need explicit application. -/
+
+variable {γ : Type*} [MeasurableSpace γ] (k : α → Measure β) (u v : β → Measure γ)
+
+example (hku : AEMeasurable (fun x => (k x).bind u) μ)
+    (hkv : AEMeasurable (fun x => (k x).bind v) μ)
+    (hu : ∀ x, AEMeasurable u (k x)) (hv : ∀ x, AEMeasurable v (k x))
+    (h : ∀ y, u y ≤ v y) :
+    μ.bind (fun x => (k x).bind u) ≤ μ.bind (fun x => (k x).bind v) := by
+  -- gap(grw, 2026-09-08): the discharger does not apply quantified measurability hypotheses.
+  fail_if_success (grw [h]; done)
+  grw [h]
+  case hf x =>
+    guard_target = AEMeasurable u (k x)
+    exact hu x
+  case hg x =>
+    guard_target = AEMeasurable (fun y => v y) (k x)
+    exact hv x
+
+example (hu : AEMeasurable u (μ.bind k)) (hv : AEMeasurable v (μ.bind k))
+    (h : ∀ y, u y ≤ v y) : (μ.bind k).bind u ≤ (μ.bind k).bind v := by grw [h]
+
+example (hu : AEMeasurable u (μ.bind k)) (hv : AEMeasurable v (μ.bind k))
+    (h : ∀ y, u y ≤ v y) (ν : Measure γ) (hν : ν ≤ (μ.bind k).bind u) :
+    ν ≤ (μ.bind k).bind v := by
+  grw [h] at hν
+  guard_hyp hν : ν ≤ (μ.bind k).bind v
+  exact hν
+
+end Measures
+
+end VCVioTest.GeneralizedRelations

--- a/VCVioTest/Tactic/GeneralizedRelationsExperiments.lean
+++ b/VCVioTest/Tactic/GeneralizedRelationsExperiments.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import VCVioTest.Tactic.GeneralizedRelations
+public import VCVio.ProgramLogic.Tactics
+public import VCVio.ProgramLogic.Relational.Measure
+public import Mathlib.Tactic.Monotonicity
+public import Mathlib.Tactic.ApplyCongr
+public import Mathlib.Tactic.CongrM
+
+/-!
+# Experiments with generalized relations
+
+Local registrations separate feasible extensions from the production tactic contract. These
+examples cover game equivalence, postconditions, support-restricted equality, and alternative
+congruence tactics. Local instances and attributes do not escape their sections.
+-/
+
+public section
+
+open OracleComp OracleComp.EvalDist OracleComp.ProgramLogic OracleSpec MeasureTheory
+open scoped ENNReal
+
+namespace VCVioTest.GeneralizedRelationsExperiments
+
+/-! ## Game equivalence needs congruence and transitivity -/
+
+section Games
+
+variable {α β γ : Type} {oa ob oc : ProbComp α}
+variable {f g : α → ProbComp β} {k l : β → ProbComp γ}
+
+example (h : GameEquiv oa ob) : GameEquiv (oa >>= f) (ob >>= f) := by
+  -- gap(gcongr, 2026-09-08): bind congruence is available but not registered globally.
+  fail_if_success gcongr
+  exact GameEquiv.bind_congr h fun _ => GameEquiv.rfl
+
+attribute [local gcongr] GameEquiv.bind_congr GameEquiv.map_congr
+
+example (h : GameEquiv oa ob) : GameEquiv (oa >>= f) (ob >>= f) := by gcongr
+
+example (h : GameEquiv oa ob) : GameEquiv (oa >>= f) (ob >>= f) := by
+  -- gap(grw, 2026-09-08): bind congruence does not supply transitivity of the outer relation.
+  fail_if_success grw [h]
+  gcongr
+
+local instance : IsTrans (ProbComp α) GameEquiv := ⟨fun _ _ _ => GameEquiv.trans⟩
+
+example (h : GameEquiv oa ob) (hbc : GameEquiv ob oc) : GameEquiv oa oc := by grw [h, hbc]
+
+example (h : GameEquiv oa ob) : GameEquiv (oa >>= f) (ob >>= f) := by grw [h]
+
+example (h : GameEquiv oa ob) (p : α → β) : GameEquiv (p <$> oa) (p <$> ob) := by grw [h]
+
+example (h : GameEquiv oa ob) (hfg : ∀ x, GameEquiv (f x) (g x))
+    (hkl : ∀ y, GameEquiv (k y) (l y)) :
+    GameEquiv ((oa >>= f) >>= k) ((ob >>= g) >>= l) := by grw [h, hfg, hkl]
+
+example (h : GameEquiv oa ob) (hfg : ∀ x, GameEquiv (f x) (g x)) :
+    GameEquiv (oa >>= f) (ob >>= g) := by grw [h, hfg]
+
+end Games
+
+/-! ## Congruence registries for equality are separate -/
+
+section Equality
+
+variable {α : Type} (mx : ProbComp α) (f g : α → ℝ≥0∞)
+
+example (h : ∀ x ∈ support mx, f x = g x) : expectedValue mx f = expectedValue mx g := by
+  -- gap(gcongr, 2026-09-08): support-aware equality congruence is not registered globally.
+  fail_if_success gcongr
+  exact expectedValue_congr_of_support h
+
+attribute [local gcongr] expectedValue_congr_of_support
+
+/--
+error: Invalid `congr` theorem: Argument #2 of parameter #9 contains unresolved parameter
+  x ∈ support ?mx
+-/
+#guard_msgs in
+attribute [local congr] expectedValue_congr_of_support
+
+example (h : ∀ x ∈ support mx, f x = g x) : expectedValue mx f = expectedValue mx g := by
+  gcongr with x hx
+  guard_hyp hx : x ∈ support mx
+  guard_target = f x = g x
+  exact h x hx
+
+example (h : ∀ x ∈ support mx, f x = g x) : expectedValue mx f = expectedValue mx g := by
+  -- gap(grw, 2026-09-08): equality rules use ordinary rewriting without support context.
+  fail_if_success grw [h]
+  exact expectedValue_congr_of_support h
+
+example (h : ∀ x, f x = g x) : expectedValue mx f = expectedValue mx g := by
+  congrm expectedValue mx ?_
+  guard_target = f = g
+  exact funext h
+
+example (h : ∀ x, f x = g x) : expectedValue mx f = expectedValue mx g := by
+  congr! 1
+  guard_target = f = g
+  exact funext h
+
+example (h : ∀ x ∈ support mx, f x = g x) : expectedValue mx f = expectedValue mx g := by
+  conv_lhs =>
+    apply_congr (expectedValue_congr_of_support (mx := mx) (g := f) (h := g))
+    tactic => exact h _ (by assumption)
+
+end Equality
+
+/-! ## Qualitative consequence has an abbreviation boundary -/
+
+section Relational
+
+open OracleComp.ProgramLogic.Relational
+
+attribute [local gcongr] relTriple_post_mono
+
+example {α β : Type} (oa : ProbComp α) (ob : ProbComp β) (R S : α → β → Prop)
+    (h : ∀ a b, R a b → S a b) : RelTriple oa ob R → RelTriple oa ob S := by
+  -- gap(gcongr, 2026-09-08): the reducible triple's lookup head differs from its registration.
+  fail_if_success gcongr
+  intro hR
+  rel_conseq with R
+  · exact hR
+  · exact fun {a b} => h a b
+
+end Relational
+
+/-! ## Measure-native postconditions and almost-everywhere bounds -/
+
+section MeasurePosts
+
+/--
+error: `f` appears on the LHS and `g` on the RHS, but there is no corresponding hypothesis `f ~ g` or `g ~ f`.
+
+This means that the `@[gcongr]` lemma cannot be used in the `grw` tactic. Please use `@[gcongr only]` instead.
+-/
+#guard_msgs in
+attribute [local gcongr] Measure.bind_mono_right
+
+attribute [local gcongr] MeasureProgramLogic.eRelWP_mono MeasureProgramLogic.CouplingPost.mono
+
+example {α β : Type} [MeasurableSpace α] [MeasurableSpace β]
+    {m : Type → Type} [EvalDistSemantics m]
+    (mx : m α) (my : m β) (g h : α → β → ℝ≥0∞)
+    (hgh : ∀ a b, g a b ≤ h a b) :
+    MeasureProgramLogic.eRelWP mx my g ≤ MeasureProgramLogic.eRelWP mx my h := by grw [hgh]
+
+example {α β : Type} [MeasurableSpace α] [MeasurableSpace β]
+    (μ : Measure α) (ν : Measure β) (R S : α → β → Prop)
+    (h : ∀ a b, R a b → S a b) :
+    MeasureProgramLogic.CouplingPost μ ν R → MeasureProgramLogic.CouplingPost μ ν S := by
+  gcongr with a b
+  guard_target = R a b → S a b
+  exact h a b
+
+attribute [local gcongr only] Measure.bind_mono_right
+
+example {α β : Type} [MeasurableSpace α] [MeasurableSpace β]
+    (μ : Measure α) (f g : α → Measure β)
+    (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) (h : ∀ᵐ x ∂μ, f x ≤ g x) :
+    μ.bind f ≤ μ.bind g := by gcongr
+
+end MeasurePosts
+
+/-! ## Monotonicity search and lower cost bounds -/
+
+section Costs
+
+attribute [local mono] AddWriterT.queryBoundedAboveBy_mono
+attribute [local gcongr] AddWriterT.pathwiseCostAtLeast_mono AddWriterT.queryBoundedBelowBy_mono
+
+variable {α : Type} (oa : AddWriterT ℕ ProbComp α) {a b : ℕ}
+
+example (h : a ≤ b) (ha : AddWriterT.QueryBoundedAboveBy oa a) :
+    AddWriterT.QueryBoundedAboveBy oa b := by mono
+
+example (h : a ≤ b) (hb : AddWriterT.PathwiseCostAtLeast oa b) :
+    AddWriterT.PathwiseCostAtLeast oa a := by
+  grw [h]
+  guard_target = AddWriterT.PathwiseCostAtLeast oa b
+  exact hb
+
+example (h : a ≤ b) (hb : AddWriterT.QueryBoundedBelowBy oa b) :
+    AddWriterT.QueryBoundedBelowBy oa a := by
+  grw [h]
+  guard_target = AddWriterT.QueryBoundedBelowBy oa b
+  exact hb
+
+end Costs
+
+end VCVioTest.GeneralizedRelationsExperiments

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -376,6 +376,8 @@ Use the tactic that matches the mathematical obligation:
 |---|---|
 | Ordered expectations or postconditions | `gcongr with x hx` on `expectedValue` or `OracleComp.ProgramLogic.wp` exposes support membership. |
 | An expectation of a mapped computation | `simp` precomposes the payoff using `expectedValue_map`, retaining the expectation head. |
+| Directed replacement inside a probability bound | Import `Mathlib.Tactic.GRewrite`; use `grw [h]` for inequalities and `apply_rw [h]` for event implications. A support-restricted rewrite theorem can leave membership as a side goal. |
+| Measure bind ordered in its continuation | `Measure.bind_mono_right_of_forall` supports `gcongr` and `grw`, with explicit `AEMeasurable` side conditions. Use `Measure.bind_mono_right` directly for an almost-everywhere bound. |
 | A finite expectation on a finite result type | `finiteness` uses `expectedValue_ne_top_of_finite` / `wp_ne_top_of_finite` and asks for finite functional values. |
 | A supplied finite bound on an arbitrary result type | Apply `expectedValue_ne_top_of_le mx hc h`; the bound remains explicit. |
 | Nonnegative total variation arithmetic | Import `VCVio.EvalDist.TVDist.Positivity` and use `positivity`; this also arrives through `VCVio.ProgramLogic.Tactics`. |
@@ -394,6 +396,11 @@ For a sum of `wp` bounds, rewrite with `wp_eq_expectedValue` and
 `← expectedValue_finsetSum`, then apply `expectedValue_le_of_support`. This avoids expanding
 probability sums and proving the zero-mass cases separately. To keep a whole sum as the next
 congruence obligation, use `gcongr (OracleComp.ProgramLogic.wp _ (fun _ => ?_)) with x`.
+
+See the [generalized-relation investigation](../reading/generalized-relation-automation.md) for
+tested rewrite directions, theorem-shape requirements, and the distinction between `gcongr`
+and `grw` registrations. Measure-bind rewriting requires importing
+`ToMathlib.MeasureTheory.Measure.Monotone`; pointwise order does not discharge measurability.
 
 ### Normalization discipline
 

--- a/docs/agents/program-logic.md
+++ b/docs/agents/program-logic.md
@@ -40,6 +40,14 @@ pointwise finite. An arbitrary quantitative postcondition may still take the val
 The regression module `VCVioTest/ProgramLogic/GCongr.lean` checks the support binders and the
 explicit raw-WP script, so these examples can be pasted into ordinary-import proofs.
 
+For directional rewriting, explicitly import `Mathlib.Tactic.GRewrite`. With
+`h : ∀ x, f x ≤ g x`, `grw [h]` rewrites through `wp` and `expectedValue`. If `h` is restricted
+to `support oa`, the rewrite leaves that support premise as a side goal; `grw [h]; assumption`
+closes the direct comparison. `gcongr with x hx` remains useful when the pointwise proof needs
+the support fact explicitly. The [generalized-relation investigation](../reading/generalized-relation-automation.md)
+compares these tactics with `mono`, equality congruence, and relational VCGen, and records which
+candidate registrations are experimental.
+
 ### Proof Mode Entry
 
 | Tactic | Goal shape | What it does |

--- a/docs/agents/query-tracking.md
+++ b/docs/agents/query-tracking.md
@@ -281,6 +281,25 @@ ExpectedQueries[ oa in runtime ]
 
 ## Worked Examples
 
+### Weakening a cost bound
+
+Import `Mathlib.Tactic.GRewrite` to rewrite through `AddWriterT.PathwiseCostAtMost` and
+`AddWriterT.QueryBoundedAboveBy`. Given `h : a ≤ b`, `grw [h] at hcost` weakens a certificate
+with upper bound `a` to one with upper bound `b`. On a goal with upper bound `b`, use
+`grw [← h]` to reduce it to the stronger obligation with upper bound `a`. The computation
+stays fixed; these are implication rules, so `gcongr` also handles an implication between
+the two cost predicates.
+
+`Fischlin/CostAccounting.lean` uses this for early returns and a weighted query charge;
+`OracleComp/QueryTracking/CostModel.lean` uses it for the pure branch of the total-query bound.
+The rule also applies to function-valued cost vectors: `gcongr` leaves the pointwise order goal,
+which can be supplied with `exact h`. Normalize equal bounds with `simpa only` when no weakening
+is needed.
+Lower-bound registrations remain local experiments; use `pathwiseCostAtLeast_mono` or
+`queryBoundedBelowBy_mono` explicitly. The
+[generalized-relation investigation](../reading/generalized-relation-automation.md) records the
+tests and the promotion criteria for additional rules.
+
 ### Fiat-Shamir
 
 See `VCVio/CryptoFoundations/FiatShamir/Sigma.lean`.

--- a/docs/reading/README.md
+++ b/docs/reading/README.md
@@ -29,6 +29,7 @@ section or the pinned source tree.
 |---|---|---|
 | [`upstream-alignment.md`](upstream-alignment.md) | Living ledger, re-run at each pin bump | Which of VCVio's general-purpose machinery and tooling does Lean core, Mathlib, Batteries, cslib, or PolyFun already own, and what is the verdict (adopt / keep / upstream / track) for each, with the evidence? Includes a broad reading of the adjacent Mathlib areas and the idioms they suggest. |
 | [`internal-duplication.md`](internal-duplication.md) | Living record | Where does VCVio say the same thing twice *inside* the repository (cost layers, invariant predicates, the two Merkle engines, `OracleSpec` operations versus PolyFun's), which spelling is canonical, and what blocks folding the rest? |
+| [`generalized-relation-automation.md`](generalized-relation-automation.md) | Investigation with tested pilots | How do `gcongr`, `grw`, and related tactics apply to VCVio's relations, which registrations simplify current proofs, and which candidates should remain experimental? |
 
 ## Keeping these honest
 

--- a/docs/reading/generalized-relation-automation.md
+++ b/docs/reading/generalized-relation-automation.md
@@ -1,0 +1,364 @@
+# Generalized relation automation in VCVio
+
+Investigated on 2026-09-08 against VCVio
+`bda0be2da973b1304e016589bb794b22ca299f45`, Lean `v4.33.1`, and Mathlib
+`0df444a360eaa60ab8c11dca51a86af692955474`. The experiments and production pilots accompany
+this report. Dependency pins are unchanged.
+
+## Findings and retained changes
+
+The main opportunity is to make existing mathematical interfaces usable by generalized rewriting.
+VCVio already registers expectation, event-probability, support-handler, query-slack, and unary-WP
+monotonicity. Repeating that tagging pass would miss the remaining problems.
+
+Two production pilots have current callers:
+
+1. **Upper cost bounds.** Register `AddWriterT.pathwiseCostAtMost_mono` and
+   `queryBoundedAboveBy_mono` with `gcongr`. Both tactics can now transport an inequality through
+   these predicates using implication. Fischlin's search proof uses `grw` to weaken its unit and
+   weighted early-return bounds and the cost of its weighted query. The unit-cost model bridge
+   uses the same interface for its pure branch.
+2. **Measure bind.** Add `Measure.bind_mono_right_of_forall`, with explicit `AEMeasurable`
+   hypotheses and a pointwise continuation inequality. Register it for both `gcongr` and `grw`.
+   `PFunctor.Resumption.outputMeasure_le_succ` now descends to the induction hypothesis using
+   `gcongr`, without manually wrapping it in `Filter.Eventually.of_forall`.
+
+The latter proof keeps its two measurability obligations and has the same number of tactic lines.
+Its improvement is the direct pointwise continuation goal. Neither pilot changes the semantic
+definitions or adds a tactic implementation. Only these three declarations enter the global
+congruence registry. The new theorem lives below VCVio, in the existing Mathlib-facing measure
+module. The two cost theorem signatures are unchanged.
+
+Other promising registrations remain local to an experimental test module. Their value and missing
+production justification are recorded below. A successful registration alone is insufficient reason
+to enlarge a default tactic set.
+
+A second caller search also removed a manual support case split from
+`expectedCost_le_of_support_bound` using the existing support-aware WP rule. Three Fischlin
+weakening applications only reconciled equal bounds; `simpa only` now handles them directly.
+These improvements require no additional global registrations.
+
+## Choosing a tactic
+
+| Obligation | First choice | What to expect |
+|---|---|---|
+| Compare matching expressions through monotone operations | `gcongr`, optionally with a pattern or depth | Pointwise relational goals and explicit side conditions. |
+| Replace a subexpression using an inequality, inclusion, or equivalence | `grw [h]` / `grewrite [h]` | A valid implication from the rewritten goal to the original; polarity matters. |
+| Rewrite using a theorem whose intended relation is implication | `apply_rw [h]` | For example, event inclusion from `h : ∀ x, p x → q x`. |
+| Close a comparison with a deliberately chosen list of facts | `rel [h₁, h₂]` | Finishing-only; it does not silently use every local hypothesis as a main-goal fact. |
+| Apply a collection of monotonicity rules as proof search | `mono` | A separate `@[mono]` database, with different search and failure behavior. |
+| Match corresponding pieces by equality | `congr!` / `congrm` / `congr(...)` | Equality obligations, even when the original relation is merely reflexive. |
+| Rewrite a specific operand using a contextual equality lemma | `conv => apply_congr lemma` | Useful for support-restricted equality without changing the global simp-congruence database. |
+| Establish a coupling, supply a cut relation, or rearrange games | `rvcstep` / `rvcgen` / `rel_conseq` | Keep witnesses and program-logic structure explicit. |
+| Normalize structural equations or close symbolic facts | `simp` / `grind` | Their existing normal-form and fail-fast contract still applies. |
+| Search through numeric bounds and positivity conditions | `bound` | A separate Aesop rule set; useful adjacent machinery, reviewed in source rather than promoted in this slice. |
+
+Use explicit `import Mathlib.Tactic.GRewrite` for generalized rewriting; availability of
+`gcongr` does not itself promise this syntax. The cost proof imports it as an implementation
+dependency. The test modules use ordinary public imports, without `import all` or visibility
+options.
+
+The implementation of `mono` in this pin is a non-backtracking `apply_rules`/`solve_by_elim`
+wrapper with reducible transparency and `exfalso` disabled. `mono` and `mono*` have the same
+behavior here; its parsed `left`/`right`, `with`, and `using` options are unsupported. This makes
+it a useful comparison, but does not justify mirroring the new registrations into another global
+database. See the [pinned monotonicity implementation][mono-source].
+
+## What a registration actually buys
+
+The authoritative sources for this investigation are the pinned
+[congruence implementation][gcongr-source], [rewrite engine][grw-source], and
+[rewrite frontend][grw-elab-source], read alongside their `MathlibTest/Tactic` counterparts.
+
+### Shape, lookup, and priorities
+
+`gcongr` indexes by the relation's name, the expression's head constant, and its arity. For
+ordinary registrations, differing arguments of the head must be free variables after the supported
+reductions. A theorem about `expectedValue mx f` fits; a theorem about
+`probEvent p (mx >>= f)` does not directly expose `f` as an argument of `probEvent`.
+
+Premises relating varying arguments become recursive **main goals**. Universally quantified
+variables and support assumptions in these premises are introduced; `gcongr with x hx` names them.
+Other premises become **side goals**, such as measurability. Numeric priority is considered first;
+within a priority, fewer varying arguments are preferred. VCVio's support-aware expectation rule
+therefore retains its priority over the unrestricted pointwise fallback.
+
+Main goals are checked against local facts, symmetry, reflexivity, and imported
+`gcongr_forward` extensions. This is bounded forward reasoning, not arbitrary application of every
+universally quantified hypothesis. Side goals use the extensible `gcongr_discharger`, including
+imported `assumption`/`positivity` behavior. Neither mechanism is a general measurability prover.
+`gcongr` may succeed while leaving goals; tests of closure must include `done`.
+
+Implication registrations can use an existing theorem with its proof premise before the inequality
+premise. The attribute finds a matching predicate hypothesis and may generate an auxiliary theorem
+with reordered binders. Thus the cost lemmas need attributes, not reordered public signatures.
+
+### Three attributes with different contracts
+
+| Attribute | Contract |
+|---|---|
+| `@[gcongr]` | Checks correspondence between each varying argument pair and a suitable premise, so the rule can also construct a rewrite. |
+| `@[gcongr only]` | Relaxes that correspondence check and excludes the rule from `grw`. It does not remove all conclusion-shape requirements. |
+| `@[gcongr strict]` | Allows different head constants on the two sides, supporting such operations as transporting between strict and non-strict inequalities. It is not a request for more aggressive search. |
+
+The two tactics share registered lemmas, but their engines differ. Default `grw` constructs
+replacements during its own traversal; `nth_grw` and `grw +useKAbstract` use abstraction followed
+by generalized congruence. Default equality/iff rewrite rules take the ordinary rewrite path.
+Successful `gcongr` tests therefore do not substitute for `grw` tests.
+
+The corpus checks the alternate `grw +useKAbstract` traversal on cost predicates. It also pins an
+occurrence-selection boundary: `nth_grw 1 [h]` with `h : ∀ x, f x ≤ g x` fails when `f` occurs
+as the unexpanded function argument of `expectedValue`. Supplying
+`nth_grw 1 [expectedValue_mono mx h]` instead selects the complete expectation expression and
+closes the tested sum comparison.
+
+### Concrete boundaries found in the experiments
+
+- **Support premises:** with `h : ∀ x ∈ support mx, f x ≤ g x`, `grw [h]` changes the
+  expectation but leaves the rewrite theorem's support premise, even though support membership
+  is available in the generated context. `grw [h]; assumption` finishes. Existing
+  `gcongr with x hx; exact h x hx` is still a good interface. No global discharger was added.
+- **Bind normalization:** retain `rw [probEvent_bind_eq_expectedValue, ...]` before descent.
+  Neither the normal-form contract nor the existing negative bind test is relaxed. A new facade
+  solely to make bind-shaped inequalities look indexable is unnecessary for these callers.
+- **Raw unary WP:** explicitly `change wp mx f ≤ wp mx g` on a raw `Std.Do'.wp` goal.
+  The ordinary-import test checks both the failed direct descent and the working facade.
+- **Qualitative triples:** registering `relTriple_post_mono` succeeds but direct descent through
+  the `RelTriple` implication still fails. Registration and runtime reduction of the abbreviations
+  expose different heads. The existing `rel_conseq with R` works; a diagnostic test preserves the
+  failure rather than adding another facade.
+- **Equality congruence:** `expectedValue_congr_of_support` works as a local `gcongr` rule,
+  but the same theorem is rejected by `@[congr]`: its support premise contains the unresolved
+  fixed computation parameter. Explicit `apply_congr` works when the computation and function
+  arguments are supplied. The test pins this rejection. `congr!` without a contextual rule asks
+  for function equality, which loses the support restriction.
+- **Almost everywhere:** `Measure.bind_mono_right` is rejected as a normal `gcongr` rule because
+  its AE premise is not the required pointwise relation between the function arguments. A local
+  `gcongr only` registration can close a goal when the AE fact is already supplied, but does not
+  make it a generalized rewrite rule. The new pointwise companion preserves the original AE API.
+- **Measurability:** a pointwise bound alone does not suffice for measure-bind rewriting. Kernel
+  arguments provide measurability via their bundled proof. In the dependent resumption caller,
+  `fun_prop` did not find the discrete-space proof, so the proof keeps
+  `Measurable.of_discrete.aemeasurable` explicitly. There is no new measurability assumption on
+  the resumption theorem.
+- **Nested binds:** measurability of the outer continuation does not discharge measurability in
+  each inner source. A rewrite under two binds leaves the two inner obligations even with
+  `∀ x, AEMeasurable f (k x)` in context; explicit applications close them. The tests pin these
+  residual goals, as well as rewriting a bind whose source is itself a bind.
+- **Cost vectors and infinite bounds:** the cost rule works for `ι → ℕ` and `ℝ≥0∞`, in the same
+  support-only monad context as scalar costs. `gcongr` exposes the function-order goal for a
+  vector; `exact h` supplies its pointwise proof. `rel [show a ≤ ⊤ from le_top]` closes the
+  infinite-bound implication without adding a finiteness hypothesis.
+
+## Candidate ledger
+
+Every row refers to current source or a compiled local experiment, not the historical counts in
+the upstream-alignment survey.
+
+| Candidate and relevant shape | Evidence / callers | Decision |
+|---|---|---|
+| `pathwiseCostAtMost_mono`: `w₁ ≤ w₂ → (PathwiseCostAtMost oa w₁ → PathwiseCostAtMost oa w₂)` | Weighted Fischlin query charge and early return; generic ordered additive costs, per-oracle vectors, infinite bounds, and both rewrite locations tested. | **Adopt attribute.** Existing statement uses `AddCommMonoid` and `PartialOrder`; do not claim only a preorder suffices for that registered theorem. |
+| `queryBoundedAboveBy_mono`: `n₁ ≤ n₂ → (QueryBoundedAboveBy oa n₁ → QueryBoundedAboveBy oa n₂)` | Fischlin early return and cost-model pure branch; nested arithmetic, both rewrite traversals, wrong-polarity rejection, and generic support-only monads tested. | **Adopt attribute.** |
+| `bind_mono_right_of_forall`: `AEMeasurable f μ → AEMeasurable g μ → (∀ x, f x ≤ g x) → μ.bind f ≤ μ.bind g` | Resumption observations; arbitrary measurable spaces, explicit side conditions, and kernels tested. | **Adopt helper and attribute.** Mathlib-facing follow-up candidate. |
+| Existing `expectedValue_mono[_of_support]`, `probEvent_mono`, `wp_mono[_of_support]` | Pointwise/support-restricted rewriting, implication, subtraction, and hypotheses tested. | **Keep registrations; improve documentation.** |
+| Existing `supportWhen_mono`, `expectedQuerySlack_mono` and its step rule | Already tagged; support-handler test uses an arbitrary oracle signature without probability classes. | **Keep.** Not missing registrations. |
+| `GameEquiv.bind_congr`, `map_congr`, plus `IsTrans _ GameEquiv` | Local tests compose bind/map and rewrite nested equivalent games. Tags alone allow descent; `grw` also needs transitivity of the outer relation. | **Experimental.** Existing OTP callers need a coupling bijection; the current program-logic walkthrough already has short `rvcgen` proofs. Future composed-game proofs with supplied equivalences are a concrete use. |
+| `expectedValue_congr_of_support` | Local equality descent works; direct theorem application already handles current callers. | **Experimental.** Promote when equality under a larger shared context removes repeated manual congruence. |
+| `relTriple_post_mono` | Attribute accepted, facade descent fails; existing `rel_conseq` succeeds. | **Defer.** Address the abbreviation/indexing boundary only with a caller that needs compositional rewriting. |
+| `MeasureProgramLogic.eRelWP_mono`, `CouplingPost.mono` | Local pointwise quantitative/qualitative postcondition tests pass. | **Experimental.** Future measure-native relational proofs can use them; current witness and bridge proofs do not become clearer merely by replacing a direct theorem call. |
+| `Measure.bind_mono_right` with `gcongr only` | Local AE closing test passes; ordinary registration rejection is checked. | **Keep explicit API.** Do not suggest AE facts become pointwise facts. |
+| Lower pathwise/unit-cost bounds | Local contravariant `grw` tests pass; no independent current callers of these weakening lemmas were found. | **Experimental.** Promote with a lower-cost proof caller. |
+| `@[mono] queryBoundedAboveBy_mono` | Local `mono` closes a supplied bound/inequality example. | **Defer global tag.** Explicit generalized rewriting already serves retained callers. |
+| New VCVio tactic or global `gcongr_forward`/discharger | No retained caller requires one. | **Reject for this slice.** Additional search would broaden behavior without demonstrated benefit. |
+
+## Before and after at proof sites
+
+Fischlin's weighted charge originally constructed an explicit weakening proof:
+
+```lean
+AddWriterT.pathwiseCostAtMost_mono
+  (AddWriterT.pathwiseCostAtMost_addTell
+    (m := m) (costFn ⟨pk, msg, comList, i, chal, resp⟩))
+  (hcost _)
+```
+
+The retained proof rewrites the bound and then proves the exact charge:
+
+```lean
+by
+  grw [← hcost ⟨pk, msg, comList, i, chal, resp⟩]
+  exact AddWriterT.pathwiseCostAtMost_addTell _
+```
+
+The reverse arrow is deliberate: to establish an upper bound `w`, it suffices to establish the
+smaller bound `costFn query`. Conversely, `grw [h] at hcost` weakens a supplied cost certificate.
+The computation is fixed throughout.
+
+For resumption observations, the old final step supplied the AE wrapper manually:
+
+```lean
+exact Measure.bind_mono_right
+  Measurable.of_discrete.aemeasurable
+  Measurable.of_discrete.aemeasurable
+  (Filter.Eventually.of_forall fun direction => ih (next direction))
+```
+
+It now exposes the continuation comparison:
+
+```lean
+gcongr with direction
+· exact Measurable.of_discrete.aemeasurable
+· exact Measurable.of_discrete.aemeasurable
+· exact ih (next direction)
+```
+
+Where measurability hypotheses are already in context, the test corpus closes the analogous goal
+with `grw [h]`. Simple direct applications can still be shorter and faster; these additions are
+compositional interfaces, not a prescription to rewrite every existing proof.
+
+The cost-model support bound previously unfolded both weakest preconditions into infinite sums
+and split on support membership. Its complete proof is now:
+
+```lean
+rw [expectedCost_eq_wp_costDist, ← wp_const (costDist oa cm) c]
+gcongr with z hz
+exact h z hz
+```
+
+This uses the existing `wp_mono_of_support` registration. In contrast, the signing proofs' final
+continuation bounds differ only by `+ 0` and the enumeration-length equation. They now finish
+with `simpa only [add_zero, hlen] using ...`, without a separate monotonicity proof.
+
+The following counts cover the complete changed proof bodies, excluding declaration signatures,
+the initial `:= by`, and blank lines. Attribute-only and assumption-scope edits do not change proof
+bodies and are excluded.
+
+| Proof | Before | After |
+|---|---:|---:|
+| Fischlin `fischlinSearchAuxWithUnitCost_queryBoundedAboveBy` | 46 | 45 |
+| Fischlin `fischlinSearchAuxWithAddCost_pathwiseCostAtMost` | 69 | 66 |
+| Fischlin `sign_usesAtMostRhoCardOmegaQueries` | 104 | 103 |
+| Fischlin `sign_usesWeightedQueryCostAtMost` | 104 | 103 |
+| Cost model `expectedCost_le_of_support_bound` | 6 | 3 |
+| Cost model `IsPerIndexQueryBound.toWorstCaseCostBound_unit_sum` | 31 | 29 |
+| Resumption `outputMeasure_le_succ` | 26 | 26 |
+
+The caller search also covered Fiat–Shamir with abort, Fujisaki–Okamoto, replay forking, and
+Diffie–Hellman reductions. Short direct theorem applications and proofs requiring substantial
+algebra or case analysis were retained where generalized rewriting did not improve them. No
+existing caller of `GameEquiv.bind_congr` or `GameEquiv.map_congr` was found outside their
+defining module and the new experiments, so their proposed registrations remain local.
+
+## Reproduction and validation
+
+The ordinary-import corpus is
+[`VCVioTest/Tactic/GeneralizedRelations.lean`](../../VCVioTest/Tactic/GeneralizedRelations.lean).
+Local candidate registrations, rejection diagnostics, and alternative tactics are in
+[`GeneralizedRelationsExperiments.lean`](../../VCVioTest/Tactic/GeneralizedRelationsExperiments.lean).
+Both are included in the generated test umbrella. Their local attributes and instance do not
+modify downstream defaults.
+
+The expanded corpus contains 57 examples and two checked attribute-rejection diagnostics.
+Terminal entries check closure; interactive congruence and rewrite entries pin exposed targets
+or hypotheses. Dated gap pairs check the support, raw-WP, occurrence-selection, cost-vector,
+measurability, and custom-relation boundaries. The nested game-equivalence example now closes
+with one `grw [h, hfg, hkl]` call.
+
+Run:
+
+```sh
+lake build VCVioTest.Tactic.GeneralizedRelationsExperiments
+./scripts/validate.sh --lint --test --axioms
+```
+
+The original two `GCongr` modules, probability batteries, `GrindFailFast`, and
+`LongChainPrograms` remain regression gates. No heartbeat limits, linter settings, exposure
+baselines, or axiom allowances are increased. New failures do not get hidden by replacing a
+terminal test with unrelated search.
+
+To satisfy the touched-file PMF ratchet without introducing semantic aliases, the writer module's
+two tail lemmas share one scoped `omit`, and Fischlin's adjacent expected-cost theorems share their
+identical section assumptions. These are scope-only changes: explicit finite-distribution
+identifiers decrease while theorem requirements and parameter ordering stay intact.
+
+Validation completed successfully:
+
+- `lake exe cache get` and the baseline `lake build` succeeded.
+- `./scripts/validate.sh --lint --test --axioms` passed: proof builds, warning budgets,
+  generated umbrellas, boundary checks, style and environment linters, the full test driver, and
+  axiom sweep. The sweep covered 18,153 declarations in 567 proof modules, with no new axiom or
+  `sorry` taint.
+- The new test modules also passed an explicit `lint-style` invocation, since the style driver's
+  `git ls-files` expansion does not include untracked additions before staging.
+- Documentation path/coverage checks and generated-fragment checks passed after the guide edits.
+- `scripts/check-pmf-boundary.sh --ratchet HEAD` passed for the complete working diff.
+- Eight public signature checks across the writer and Fischlin assumption-scope edits matched the
+  base revision, including the affected tail lemmas and expected-cost theorems.
+
+### Elaboration measurements
+
+Three fresh `lake env lean <file>` runs per module, using already-built imports, gave the following
+wall times for the initial production pilots, before the additional cost-model and signing proof
+simplifications. These include process startup and import loading. The unchanged notation module
+is a control; differences of a few hundredths of a second are not evidence of an optimization.
+
+| Module | Before, seconds (three runs) | Initial pilot, seconds (three runs) |
+|---|---|---|
+| `VCVioTest/LongChainPrograms` | 3.051, 2.955, 2.956 | 3.084, 2.917, 2.918 |
+| `VCVioTest/GrindFailFast` | 7.225, 7.244, 7.281 | 7.142, 7.184, 7.163 |
+| `VCVio/ProgramLogic/NotationCore` | 1.793, 1.791, 1.764 | 1.765, 1.758, 1.752 |
+| `VCVio/OracleComp/QueryTracking/WriterCost` | 2.093, 2.080, 2.101 | 2.079, 2.086, 2.080 |
+| `VCVio/CryptoFoundations/Fischlin/CostAccounting` | 1.779, 1.783, 1.794 | 1.762, 1.778, 1.771 |
+| `VCVio/EvalDist/ResumptionMeasure` | 1.495, 1.500, 1.512 | 1.503, 1.501, 1.510 |
+
+After the expanded caller search and full validation, three further runs with no concurrent
+builds measured `CostModel` at 1.658, 1.666, 1.661 seconds for the base proof bodies and
+1.667, 1.666, 1.666 for the final proofs. Final Fischlin cost accounting measured
+1.770, 1.771, 1.777 seconds. These remain indistinguishable from ordinary run-to-run variation.
+
+For a more focused comparison, minimal goal pairs using the test-corpus hypotheses were elaborated
+with `Mathlib.Util.CountHeartbeats`, `set_option Elab.async false`, and `#count_heartbeats in`
+around each declaration. Disabling asynchronous proof elaboration here is essential: measuring
+only the command's scheduling work gives misleadingly identical before/after counts.
+
+| Goal pair | Explicit / existing proof | Generalized rewrite | Heartbeats, before → after |
+|---|---|---|---|
+| Upper cost certificate from `ha` and `hab : a ≤ b` | `queryBoundedAboveBy_mono ha hab` | `grw [← hab]; exact ha` | 28 → 37 |
+| Measure bind, measurable continuations and pointwise `h` | `bind_mono_right hf hg (Filter.Eventually.of_forall h)` | `grw [h]` | 56 → 108 |
+| Expectation with support-restricted `h` | `gcongr with x hx; exact h x hx` | `grw [h]; assumption` | 94 → 68 |
+| Two nested binds with game equivalences `h`, `hfg`, `hkl` | `GameEquiv.bind_congr (GameEquiv.bind_congr h hfg) hkl` | `grw [h, hfg, hkl]`, with the experimental local registrations and instance | 68 → 148 |
+
+These are synchronous whole-declaration snapshots in user-facing heartbeat units, not permanent
+thresholds. To repeat them, use the corresponding parameterized goals in the corpus and the two
+proof bodies in the table; the nested game goal extends the single-bind rewrite example with its
+second continuation. All were well below the default 200,000-heartbeat limit. Direct theorem
+applications often cost less, as expected. The evidence supports adding a compositional interface
+without a material module-level regression, not a claim that generalized rewriting is always faster.
+
+## Follow-up work and upstream distinction
+
+1. **First eligible caller:** when a proof composes existing `GameEquiv` facts under bind/map,
+   promote the tested congruence registrations together with the transitivity instance. Compare
+   against `rvcgen` and direct `GameEquiv.bind_congr` before choosing the proof interface.
+2. **Measure-native relational development:** promote the local postcondition rules when a real
+   quantitative/qualitative measure proof benefits. Measurable coupling families and gluing remain
+   mathematical prerequisites for sequential rules; congruence cannot synthesize them.
+3. **Mathlib-facing proposal:** the pointwise Giry-bind helper has a direct resumption caller and
+   mirrors Mathlib's explicit-forall integral monotonicity rule. A future upstream proposal should
+   include the ordinary registration rejection for the AE theorem and tests for both tactics.
+4. **Diagnostics, not speculative search:** retain small reproducers for the qualitative-triple
+   head mismatch and contextual congruence rejection. Before changing tactic internals, establish
+   whether a generic upstream theorem shape or explicit normalization addresses the caller.
+
+The rolling upstream [GCongr documentation][rolling-gcongr] was checked on 2026-09-08. It documents
+`gconvert e`, which transports a proof to the target by generalized congruence and supports binder
+patterns. This command is absent from VCVio's pinned `GCongr/Core.lean`; none of the experiments
+or retained proofs use it. It is relevant to future consequence/weakening ergonomics, but its
+presence in rolling documentation is not evidence that it is available in this build. Reevaluate
+it at a coordinated toolchain/Mathlib upgrade rather than backporting a competing local tactic.
+
+[gcongr-source]: https://github.com/leanprover-community/mathlib4/blob/0df444a360eaa60ab8c11dca51a86af692955474/Mathlib/Tactic/GCongr/Core.lean
+[grw-source]: https://github.com/leanprover-community/mathlib4/blob/0df444a360eaa60ab8c11dca51a86af692955474/Mathlib/Tactic/GRewrite/Core.lean
+[grw-elab-source]: https://github.com/leanprover-community/mathlib4/blob/0df444a360eaa60ab8c11dca51a86af692955474/Mathlib/Tactic/GRewrite/Elab.lean
+[mono-source]: https://github.com/leanprover-community/mathlib4/blob/0df444a360eaa60ab8c11dca51a86af692955474/Mathlib/Tactic/Monotonicity/Basic.lean
+[rolling-gcongr]: https://leanprover-community.github.io/mathlib4_docs/Mathlib/Tactic/GCongr/Core.html#Mathlib.Tactic.GCongr.gconvert


### PR DESCRIPTION
## Summary

Upper cost predicates and measure bind lacked the congruence rules needed for compositional inequality rewriting. Register the two existing upper-cost monotonicity lemmas and add a pointwise measure-bind companion with explicit measurability assumptions. Simplify callers in Fischlin cost accounting, the cost model, and resumption observations.

Add 57 ordinary-import examples and two checked registration diagnostics covering `gcongr`, `grw`, occurrence selection, `rel`, `mono`, equality congruence, and custom relations. Broader registrations remain local experiments. The [investigation report](https://github.com/Verified-zkEVM/VCVio/blob/fb2b3a960df430454596ac9ee0aaf7b1f934762b/docs/reading/generalized-relation-automation.md) records the pinned implementation analysis, adoption decisions, failure boundaries, and elaboration measurements; the agent guides document the supported interfaces.

The existing almost-everywhere measure API and public cost-lemma signatures are preserved. Shared assumption scopes reduce the touched files' explicit PMF/SPMF counts without changing theorem requirements or parameter ordering. There are no dependency, heartbeat, linter, exposure, or axiom-baseline changes.

The resumption proof exposes the pointwise induction goal while retaining both measurability obligations. Equal cost bounds use `simpa only`; the cost-model expectation proof uses the existing support-aware WP rule. Only three declarations enter the global congruence registry.

## Verification

- `./scripts/validate.sh --lint --test --axioms` passed: all proof-library builds, warning budgets, generated umbrellas, boundary checks, style/environment linters, tests, documentation checks, and the axiom sweep.
- The axiom sweep checked 18,153 declarations across 567 proof modules; no new axiom or `sorry` taint.
- `lake build VCVioTest.Tactic.GeneralizedRelationsExperiments` and explicit style lint of both new modules passed after the final kernel-measurability gap guard.
- `bash scripts/check-pmf-boundary.sh --ratchet HEAD`, documentation/fragment checks, and `git diff --check` passed.
- Eight public signature checks matched the base revision across the assumption-scope edits. The report includes module wall times and synchronous heartbeat comparisons; generalized rewriting is an interface improvement, not a general speedup claim.

## Checklist

- [x] New Lean files have the standard header, module docstring, and plain `public section`.
- [x] Generated umbrella modules are current; exposure and axiom baselines are unchanged.
- [x] No disabled linters, deprecated aliases, or native FFI test executables added.
- [x] Relevant agent documentation is updated and its checks pass.
- [x] Tactic gates include terminal entries, dated gap families, and explicit residual-goal/hypothesis checks for interactive normalization. Before/after proof-body counts are listed above.
