### PR TITLE
feat(EvalDist): add measure-based laws for independent draws

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -46,6 +46,7 @@ public import ToMathlib.MeasureTheory.DiscreteInstances
 public import ToMathlib.MeasureTheory.MeasurableSpace.Except
 public import ToMathlib.MeasureTheory.MeasurableSpace.Option
 public import ToMathlib.MeasureTheory.Measure.Coupling
+public import ToMathlib.MeasureTheory.Measure.IndependentDraws
 public import ToMathlib.MeasureTheory.Measure.Monotone
 public import ToMathlib.MeasureTheory.Measure.Option
 public import ToMathlib.MeasureTheory.Measure.Subprobability

--- a/ToMathlib/MeasureTheory/Measure/IndependentDraws.lean
+++ b/ToMathlib/MeasureTheory/Measure/IndependentDraws.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import Mathlib.MeasureTheory.Measure.Prod
+
+/-!
+# Interchanging independent measure-valued draws
+
+Joint measurability of a continuation lets independent s-finite draws commute under
+Giry bind. No normalization of the measures is required, so the laws also apply to
+subprobability measures and continuations with missing mass.
+-/
+
+public section
+
+open MeasureTheory Function
+
+namespace MeasureTheory.Measure
+
+variable {α β γ δ : Type*} [MeasurableSpace α] [MeasurableSpace β]
+  [MeasurableSpace γ] [MeasurableSpace δ]
+
+/-- Integrating a jointly measurable measure-valued continuation gives a measurable family. -/
+theorem measurable_bind_prod_right (ν : Measure β) [SFinite ν]
+    {f : α → β → Measure γ} (hf : Measurable (uncurry f)) :
+    Measurable fun a => ν.bind (f a) := by
+  apply measurable_of_measurable_coe
+  intro s hs
+  have hfa (a : α) : Measurable (f a) :=
+    hf.comp (measurable_const.prodMk measurable_id)
+  have heq : (fun a => (ν.bind (f a)) s) = fun a => ∫⁻ b, f a b s ∂ν :=
+    funext fun a => bind_apply hs (hfa a).aemeasurable
+  rw [heq]
+  exact Measurable.lintegral_prod_right (f := fun a b => f a b s)
+    ((measurable_coe hs).comp hf)
+
+/-- Two independent s-finite draws commute before a jointly measurable continuation. -/
+theorem bind_bind_swap (μ : Measure α) (ν : Measure β) [SFinite μ] [SFinite ν]
+    {f : α → β → Measure γ} (hf : Measurable (uncurry f)) :
+    μ.bind (fun a => ν.bind (f a)) = ν.bind (fun b => μ.bind (fun a => f a b)) := by
+  have hfa (a : α) : Measurable (f a) :=
+    hf.comp (measurable_const.prodMk measurable_id)
+  have hfb (b : β) : Measurable fun a => f a b :=
+    hf.comp (measurable_id.prodMk measurable_const)
+  have hswap : Measurable (uncurry fun b a => f a b) := hf.comp measurable_swap
+  ext s hs
+  rw [bind_apply hs (measurable_bind_prod_right ν hf).aemeasurable,
+    bind_apply hs (measurable_bind_prod_right μ hswap).aemeasurable]
+  simp_rw [bind_apply hs (hfa _).aemeasurable, bind_apply hs (hfb _).aemeasurable]
+  exact lintegral_lintegral_swap ((measurable_coe hs).comp hf).aemeasurable
+
+/-- Move the third independent draw before the first two, preserving continuation order. -/
+theorem bind_bind_bind_rotate (μ : Measure α) (ν : Measure β) (ρ : Measure γ)
+    [SFinite μ] [SFinite ν] [SFinite ρ] {f : α → β → γ → Measure δ}
+    (hf : Measurable fun p : α × β × γ => f p.1 p.2.1 p.2.2) :
+    μ.bind (fun a => ν.bind (fun b => ρ.bind (f a b))) =
+      ρ.bind (fun c => μ.bind (fun a => ν.bind (fun b => f a b c))) := by
+  calc
+    _ = μ.bind (fun a => ρ.bind (fun c => ν.bind (fun b => f a b c))) := by
+      apply bind_congr_right
+      exact Filter.Eventually.of_forall fun a =>
+        bind_bind_swap ν ρ (hf.comp (measurable_const.prodMk measurable_id))
+    _ = _ := by
+      apply bind_bind_swap μ ρ
+      exact measurable_bind_prod_right ν
+        (hf.comp (measurable_fst.fst.prodMk (measurable_snd.prodMk measurable_fst.snd)))
+
+end MeasureTheory.Measure

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -140,6 +140,7 @@ public import VCVio.EvalDist.Defs.AlternativeMonad
 public import VCVio.EvalDist.Defs.Basic
 public import VCVio.EvalDist.Defs.Instances
 public import VCVio.EvalDist.Defs.Measure
+public import VCVio.EvalDist.Defs.Measure.Core
 public import VCVio.EvalDist.Defs.NeverFails
 public import VCVio.EvalDist.Defs.Semantics
 public import VCVio.EvalDist.Defs.Support
@@ -162,6 +163,7 @@ public import VCVio.EvalDist.MeasureTVDist
 public import VCVio.EvalDist.Monad.Basic
 public import VCVio.EvalDist.Monad.Disagreement
 public import VCVio.EvalDist.Monad.Map
+public import VCVio.EvalDist.Monad.Measure
 public import VCVio.EvalDist.Monad.Seq
 public import VCVio.EvalDist.Option
 public import VCVio.EvalDist.PFunctor

--- a/VCVio/EvalDist/Defs/Measure.lean
+++ b/VCVio/EvalDist/Defs/Measure.lean
@@ -6,14 +6,15 @@ Authors: Devon Tuma
 module
 
 public import VCVio.EvalDist.Defs.Support
+public import VCVio.EvalDist.Defs.Measure.Core
 public import ToMathlib.MeasureTheory.Measure.Option
-public import ToMathlib.MeasureTheory.Measure.Subprobability
 public import ToMathlib.Probability.ProbabilityMassFunction.Measure
 
 /-!
-# Measure-valued evaluation semantics
+# Measure-valued evaluation and discrete compatibility
 
-This module defines the primary probability boundary for VCVio computations. An
+This module reexports `VCVio.EvalDist.Defs.Measure.Core` and supplies the discrete
+compatibility adapters. An
 `EvalDistSemantics m` interprets `m α` as a Mathlib `Measure α` with total mass at most one.
 Missing mass represents failure or nontermination. In particular, the output distribution itself
 does not introduce an `Option` outcome.
@@ -32,112 +33,6 @@ specialization.
 open MeasureTheory
 
 universe u v
-
-/-- A measure-valued subprobability semantics for a type constructor. -/
-class EvalDistSemantics (m : Type u → Type v) where
-  /-- Interpret a computation as its measure of successful outputs. -/
-  denote : {α : Type u} → [MeasurableSpace α] → m α → Measure α
-  /-- Successful output mass is at most one. -/
-  apply_univ_le_one : ∀ {α : Type u} [MeasurableSpace α] (mx : m α),
-    denote mx Set.univ ≤ 1
-
-/-- The measure of successful outputs produced by `mx`. -/
-@[reducible, inline]
-noncomputable def evalDist {m : Type u → Type v} [EvalDistSemantics m]
-    {α : Type u} [MeasurableSpace α] (mx : m α) : Measure α :=
-  EvalDistSemantics.denote mx
-
-/-- Evaluation-measure notation. -/
-notation "𝒟[" mx "]" => evalDist mx
-
-@[simp]
-theorem evalDist_apply_univ_le_one {m : Type u → Type v} [EvalDistSemantics m]
-    {α : Type u} [MeasurableSpace α] (mx : m α) : 𝒟[mx] Set.univ ≤ 1 :=
-  EvalDistSemantics.apply_univ_le_one mx
-
-/-- Every computation denotation is a subprobability measure. -/
-instance evalDist.instIsSubprobabilityMeasure {m : Type u → Type v} [EvalDistSemantics m]
-    {α : Type u} [MeasurableSpace α] (mx : m α) : IsSubprobabilityMeasure 𝒟[mx] :=
-  ⟨evalDist_apply_univ_le_one mx⟩
-
-/-- A measure-valued semantics respects `pure` and measurable `bind` in the Giry monad. -/
-class LawfulEvalDistSemantics (m : Type u → Type v) [Monad m]
-    [EvalDistSemantics m] : Prop where
-  /-- `pure` denotes a Dirac measure. -/
-  denote_pure {α : Type u} [MeasurableSpace α] (x : α) :
-    𝒟[(pure x : m α)] = Measure.dirac x
-  /-- Monadic bind denotes Giry bind whenever its measure-valued continuation is measurable. -/
-  denote_bind {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
-      (mx : m α) (f : α → m β) (hf : Measurable fun x => 𝒟[f x]) :
-    𝒟[mx >>= f] = Measure.bind 𝒟[mx] fun x => 𝒟[f x]
-
-@[simp]
-theorem evalDist_pure {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
-    [LawfulEvalDistSemantics m] {α : Type u} [MeasurableSpace α] (x : α) :
-    𝒟[(pure x : m α)] = Measure.dirac x :=
-  LawfulEvalDistSemantics.denote_pure x
-
-theorem evalDist_bind {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
-    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
-    (mx : m α) (f : α → m β) (hf : Measurable fun x => 𝒟[f x]) :
-    𝒟[mx >>= f] = Measure.bind 𝒟[mx] fun x => 𝒟[f x] :=
-  LawfulEvalDistSemantics.denote_bind mx f hf
-
-/-- On a discrete source type, every measure-valued continuation is measurable. -/
-theorem evalDist_bind_of_discrete {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
-    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α]
-    [DiscreteMeasurableSpace α] [MeasurableSpace β] (mx : m α) (f : α → m β) :
-    𝒟[mx >>= f] = Measure.bind 𝒟[mx] fun x => 𝒟[f x] :=
-  evalDist_bind mx f Measurable.of_discrete
-
-/-- `Functor.map` along a measurable function denotes the pushforward measure. -/
-theorem evalDist_map {m : Type u → Type v} [Monad m] [LawfulMonad m] [EvalDistSemantics m]
-    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
-    (mx : m α) {f : α → β} (hf : Measurable f) : 𝒟[f <$> mx] = 𝒟[mx].map f := by
-  have hd : Measurable fun x => 𝒟[(pure (f x) : m β)] := by
-    simp only [evalDist_pure]
-    exact Measure.measurable_dirac.comp hf
-  rw [map_eq_bind_pure_comp, evalDist_bind mx (pure ∘ f) hd]
-  simp only [Function.comp_apply, evalDist_pure]
-  exact Measure.bind_dirac_eq_map 𝒟[mx] hf
-
-/-- On a discrete source type, every `Functor.map` denotes a pushforward. -/
-theorem evalDist_map_of_discrete {m : Type u → Type v} [Monad m] [LawfulMonad m]
-    [EvalDistSemantics m] [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α]
-    [DiscreteMeasurableSpace α] [MeasurableSpace β] (mx : m α) (f : α → β) :
-    𝒟[f <$> mx] = 𝒟[mx].map f :=
-  evalDist_map mx Measurable.of_discrete
-
-/-- A constant continuation scales the continuation's measure by the success mass
-(`Measure.bind_const`); the measure form of `probOutput_bind_const`. -/
-@[simp]
-theorem evalDist_bind_const {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
-    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
-    (mx : m α) (my : m β) : 𝒟[mx >>= fun _ => my] = 𝒟[mx] Set.univ • 𝒟[my] := by
-  rw [evalDist_bind mx (fun _ => my) measurable_const, Measure.bind_const]
-
-/-- A constant map denotes the success mass at a point (`Measure.map_const`); the measure form
-of `probOutput_map_const`. -/
-@[simp]
-theorem evalDist_map_const {m : Type u → Type v} [Monad m] [LawfulMonad m] [EvalDistSemantics m]
-    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
-    (mx : m α) (c : β) : 𝒟[(fun _ => c) <$> mx] = 𝒟[mx] Set.univ • Measure.dirac c := by
-  rw [evalDist_map mx measurable_const, Measure.map_const]
-
-/-- Tower property on the measure side: the `∫⁻` twin of `expectedValue_bind`. -/
-theorem lintegral_evalDist_bind {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
-    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [DiscreteMeasurableSpace α]
-    [MeasurableSpace β] (mx : m α) (f : α → m β) {g : β → ENNReal} (hg : Measurable g) :
-    ∫⁻ y, g y ∂𝒟[mx >>= f] = ∫⁻ x, ∫⁻ y, g y ∂𝒟[f x] ∂𝒟[mx] := by
-  rw [evalDist_bind_of_discrete mx f,
-    Measure.lintegral_bind Measurable.of_discrete.aemeasurable hg.aemeasurable]
-
-/-- Change of variables on the measure side: the `∫⁻` twin of `expectedValue_map`. -/
-theorem lintegral_evalDist_map {m : Type u → Type v} [Monad m] [LawfulMonad m]
-    [EvalDistSemantics m] [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α]
-    [MeasurableSpace β] (mx : m α) {f : α → β} (hf : Measurable f) {g : β → ENNReal}
-    (hg : Measurable g) : ∫⁻ y, g y ∂𝒟[f <$> mx] = ∫⁻ x, g (f x) ∂𝒟[mx] := by
-  rw [evalDist_map mx hf, lintegral_map hg hf]
 
 namespace SPMF
 
@@ -198,7 +93,7 @@ theorem toMeasure_apply_univ : p.toMeasure Set.univ = ∑' x, p x := by
 Failure mass is determined by the successful masses, so dropping the explicit `none` outcome does
 not lose information. -/
 theorem toMeasure_injective [MeasurableSingletonClass α] :
-    Function.Injective (SPMF.toMeasure : SPMF α → Measure α) := by
+    Function.Injective (toMeasure (α := α)) := by
   intro p q hpq
   apply SPMF.ext
   intro x

--- a/VCVio/EvalDist/Defs/Measure/Core.lean
+++ b/VCVio/EvalDist/Defs/Measure/Core.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import ToMathlib.MeasureTheory.Measure.Subprobability
+
+/-!
+# Measure-valued evaluation and its composition laws
+
+`EvalDistSemantics` denotes successful outputs by subprobability measures.
+`LawfulEvalDistSemantics` supplies the Dirac and measurable-bind equations.
+Measurable spaces and continuations are explicit; discrete source spaces discharge
+continuation measurability without constraining the result space.
+-/
+
+public section
+
+open MeasureTheory
+
+universe u v
+
+/-- A measure-valued subprobability semantics for a type constructor. -/
+class EvalDistSemantics (m : Type u → Type v) where
+  /-- Interpret a computation as its measure of successful outputs. -/
+  denote : {α : Type u} → [MeasurableSpace α] → m α → Measure α
+  /-- Successful output mass is at most one. -/
+  apply_univ_le_one : ∀ {α : Type u} [MeasurableSpace α] (mx : m α),
+    denote mx Set.univ ≤ 1
+
+/-- The measure of successful outputs produced by `mx`. -/
+@[expose, reducible, inline]
+noncomputable def evalDist {m : Type u → Type v} [EvalDistSemantics m]
+    {α : Type u} [MeasurableSpace α] (mx : m α) : Measure α :=
+  EvalDistSemantics.denote mx
+
+/-- Evaluation-measure notation. -/
+notation "𝒟[" mx "]" => evalDist mx
+
+@[simp]
+theorem evalDist_apply_univ_le_one {m : Type u → Type v} [EvalDistSemantics m]
+    {α : Type u} [MeasurableSpace α] (mx : m α) : 𝒟[mx] Set.univ ≤ 1 :=
+  EvalDistSemantics.apply_univ_le_one mx
+
+/-- Every computation denotation is a subprobability measure. -/
+instance evalDist.instIsSubprobabilityMeasure {m : Type u → Type v} [EvalDistSemantics m]
+    {α : Type u} [MeasurableSpace α] (mx : m α) : IsSubprobabilityMeasure 𝒟[mx] :=
+  ⟨evalDist_apply_univ_le_one mx⟩
+
+/-- A measure-valued semantics respects `pure` and measurable `bind` in the Giry monad. -/
+class LawfulEvalDistSemantics (m : Type u → Type v) [Monad m]
+    [EvalDistSemantics m] : Prop where
+  /-- `pure` denotes a Dirac measure. -/
+  denote_pure {α : Type u} [MeasurableSpace α] (x : α) :
+    𝒟[(pure x : m α)] = Measure.dirac x
+  /-- Monadic bind denotes Giry bind whenever its measure-valued continuation is measurable. -/
+  denote_bind {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
+      (mx : m α) (f : α → m β) (hf : Measurable fun x => 𝒟[f x]) :
+    𝒟[mx >>= f] = Measure.bind 𝒟[mx] fun x => 𝒟[f x]
+
+@[simp]
+theorem evalDist_pure {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] {α : Type u} [MeasurableSpace α] (x : α) :
+    𝒟[(pure x : m α)] = Measure.dirac x :=
+  LawfulEvalDistSemantics.denote_pure x
+
+theorem evalDist_bind {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
+    (mx : m α) (f : α → m β) (hf : Measurable fun x => 𝒟[f x]) :
+    𝒟[mx >>= f] = Measure.bind 𝒟[mx] fun x => 𝒟[f x] :=
+  LawfulEvalDistSemantics.denote_bind mx f hf
+
+/-- On a discrete source type, every measure-valued continuation is measurable. -/
+theorem evalDist_bind_of_discrete {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α]
+    [DiscreteMeasurableSpace α] [MeasurableSpace β] (mx : m α) (f : α → m β) :
+    𝒟[mx >>= f] = Measure.bind 𝒟[mx] fun x => 𝒟[f x] :=
+  evalDist_bind mx f Measurable.of_discrete
+
+/-- `Functor.map` along a measurable function denotes the pushforward measure. -/
+theorem evalDist_map {m : Type u → Type v} [Monad m] [LawfulMonad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
+    (mx : m α) {f : α → β} (hf : Measurable f) : 𝒟[f <$> mx] = 𝒟[mx].map f := by
+  have hd : Measurable fun x => 𝒟[(pure (f x) : m β)] := by
+    simp only [evalDist_pure]
+    exact Measure.measurable_dirac.comp hf
+  rw [map_eq_bind_pure_comp, evalDist_bind mx (pure ∘ f) hd]
+  simp only [Function.comp_apply, evalDist_pure]
+  exact Measure.bind_dirac_eq_map 𝒟[mx] hf
+
+/-- On a discrete source type, every `Functor.map` denotes a pushforward. -/
+theorem evalDist_map_of_discrete {m : Type u → Type v} [Monad m] [LawfulMonad m]
+    [EvalDistSemantics m] [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α]
+    [DiscreteMeasurableSpace α] [MeasurableSpace β] (mx : m α) (f : α → β) :
+    𝒟[f <$> mx] = 𝒟[mx].map f :=
+  evalDist_map mx Measurable.of_discrete
+
+/-- A constant continuation scales the continuation's measure by the success mass
+(`Measure.bind_const`); the measure form of `probOutput_bind_const`. -/
+@[simp]
+theorem evalDist_bind_const {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
+    (mx : m α) (my : m β) : 𝒟[mx >>= fun _ => my] = 𝒟[mx] Set.univ • 𝒟[my] := by
+  rw [evalDist_bind mx (fun _ => my) measurable_const, Measure.bind_const]
+
+/-- A constant map denotes the success mass at a point (`Measure.map_const`); the measure form
+of `probOutput_map_const`. -/
+@[simp]
+theorem evalDist_map_const {m : Type u → Type v} [Monad m] [LawfulMonad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [MeasurableSpace β]
+    (mx : m α) (c : β) : 𝒟[(fun _ => c) <$> mx] = 𝒟[mx] Set.univ • Measure.dirac c := by
+  rw [evalDist_map mx measurable_const, Measure.map_const]
+
+/-- Tower property on the measure side: the `∫⁻` twin of `expectedValue_bind`. -/
+theorem lintegral_evalDist_bind {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α] [DiscreteMeasurableSpace α]
+    [MeasurableSpace β] (mx : m α) (f : α → m β) {g : β → ENNReal} (hg : Measurable g) :
+    ∫⁻ y, g y ∂𝒟[mx >>= f] = ∫⁻ x, ∫⁻ y, g y ∂𝒟[f x] ∂𝒟[mx] := by
+  rw [evalDist_bind_of_discrete mx f,
+    Measure.lintegral_bind Measurable.of_discrete.aemeasurable hg.aemeasurable]
+
+/-- Change of variables on the measure side: the `∫⁻` twin of `expectedValue_map`. -/
+theorem lintegral_evalDist_map {m : Type u → Type v} [Monad m] [LawfulMonad m]
+    [EvalDistSemantics m] [LawfulEvalDistSemantics m] {α β : Type u} [MeasurableSpace α]
+    [MeasurableSpace β] (mx : m α) {f : α → β} (hf : Measurable f) {g : β → ENNReal}
+    (hg : Measurable g) : ∫⁻ y, g y ∂𝒟[f <$> mx] = ∫⁻ x, g (f x) ∂𝒟[mx] := by
+  rw [evalDist_map mx hf, lintegral_map hg hf]

--- a/VCVio/EvalDist/Monad/Measure.lean
+++ b/VCVio/EvalDist/Monad/Measure.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.EvalDist.Defs.Measure.Core
+public import ToMathlib.MeasureTheory.Measure.IndependentDraws
+
+/-!
+# Independent draws under measure-valued evaluation
+
+The Giry composition laws transport measure-level independence to computation syntax.
+The general interchange theorem requires joint measurability; the three-draw law
+specializes to discrete intermediate results and leaves the final result space arbitrary.
+-/
+
+public section
+
+open MeasureTheory Function
+
+universe u v
+
+variable {m : Type u → Type v} [Monad m] [EvalDistSemantics m]
+  [LawfulEvalDistSemantics m] {α β γ δ : Type u}
+  [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ] [MeasurableSpace δ]
+
+/-- Independent computations commute under a jointly measurable denoted continuation. -/
+theorem evalDist_bind_bind_swap (mx : m α) (my : m β) (f : α → β → m γ)
+    (hf : Measurable fun p : α × β => 𝒟[f p.1 p.2]) :
+    𝒟[mx >>= fun a => my >>= fun b => f a b] =
+      𝒟[my >>= fun b => mx >>= fun a => f a b] := by
+  have hfa (a : α) : Measurable fun b => 𝒟[f a b] :=
+    hf.comp (measurable_const.prodMk measurable_id)
+  have hfb (b : β) : Measurable fun a => 𝒟[f a b] :=
+    hf.comp (measurable_id.prodMk measurable_const)
+  have hleft : Measurable fun a => 𝒟[my >>= f a] := by
+    simp_rw [evalDist_bind my _ (hfa _)]
+    exact Measure.measurable_bind_prod_right 𝒟[my] hf
+  have hright : Measurable fun b => 𝒟[mx >>= fun a => f a b] := by
+    simp_rw [evalDist_bind mx _ (hfb _)]
+    exact Measure.measurable_bind_prod_right 𝒟[mx] (hf.comp measurable_swap)
+  rw [evalDist_bind mx _ hleft, evalDist_bind my _ hright]
+  simp_rw [evalDist_bind my _ (hfa _), evalDist_bind mx _ (hfb _)]
+  exact Measure.bind_bind_swap _ _ hf
+
+/-- Move the third independent discrete draw to the front of a computation. -/
+theorem evalDist_bind_bind_bind_rotate [DiscreteMeasurableSpace α]
+    [DiscreteMeasurableSpace β] [DiscreteMeasurableSpace γ]
+    (mx : m α) (my : m β) (mz : m γ) (f : α → β → γ → m δ)
+    (hf : Measurable fun p : α × β × γ => 𝒟[f p.1 p.2.1 p.2.2]) :
+    𝒟[mx >>= fun a => my >>= fun b => mz >>= fun c => f a b c] =
+      𝒟[mz >>= fun c => mx >>= fun a => my >>= fun b => f a b c] := by
+  simp only [evalDist_bind_of_discrete]
+  exact Measure.bind_bind_bind_rotate _ _ _ hf

--- a/VCVio/EvalDist/PFunctorMeasure.lean
+++ b/VCVio/EvalDist/PFunctorMeasure.lean
@@ -13,8 +13,8 @@ public import VCVio.EvalDist.PFunctorMeasure.Core
 # Primary and discrete compatibility for free-program measure semantics
 
 The dependency-light native fold lives in `VCVio.EvalDist.PFunctorMeasure.Core`. This module
-installs that fold as VCVio's primary `EvalDistSemantics` when an `IsMeasureSpec` is available and
-connects it to the legacy discrete `IsProbabilitySpec` evaluator.
+reexports the fold's primary `EvalDistSemantics` and connects it to the legacy discrete
+`IsProbabilitySpec` evaluator.
 
 ## Main statements
 
@@ -40,55 +40,7 @@ namespace FreeM
 variable {P : PFunctor.{uA, u}} [∀ a, MeasurableSpace (P.B a)] [P.IsMeasureSpec]
   {α β : Type u}
 
-/-- Every free program denotes a subprobability measure, even before a measurability invariant is
-available for its continuations. `Measure.bind_apply_le` gives exactly the one-sided bound needed
-here; measurability is only needed to strengthen this to a probability-measure equality. -/
-theorem denote_apply_univ_le_one [MeasurableSpace α] (program : FreeM P α) :
-    denote program Set.univ ≤ 1 := by
-  induction program with
-  | pure _ => simp
-  | lift_bind a cont ih =>
-      refine (Measure.bind_apply_le _ MeasurableSet.univ).trans ?_
-      calc
-        (∫⁻ b, denote (cont b) Set.univ ∂IsMeasureSpec.toMeasure a) ≤
-            ∫⁻ _b, 1 ∂IsMeasureSpec.toMeasure a := lintegral_mono ih
-        _ = 1 := by simp
-
-/-- The direct free-monad fold supplies the primary measure semantics whenever an
-`IsMeasureSpec` is available. Its priority is above the generic finite-distribution adapter, so
-installing a measure specification makes `𝒟[…]` unfold to `denote`; computations that only have
-the legacy probability specification continue to use the adapter. -/
-noncomputable instance (priority := 20) instEvalDistSemanticsFreeM :
-    EvalDistSemantics (FreeM P) where
-  denote := denote
-  apply_univ_le_one := denote_apply_univ_le_one
-
-/-- With a measure specification in scope, primary notation is definitionally the direct
-free-monad measure fold. `𝒟[…]` is the public head: this is a transport lemma, not a simp rule,
-so the `𝒟`-keyed laws below and in `Defs.Measure` are the ones `simp` uses. -/
-theorem evalDist_eq_denote [MeasurableSpace α] (program : FreeM P α) :
-    𝒟[program] = denote program := rfl
-
-/-- A one-operation program denotes its configured answer measure. -/
-@[simp]
-theorem evalDist_lift (a : P.A) :
-    𝒟[(FreeM.lift a : FreeM P (P.B a))] = IsMeasureSpec.toMeasure a :=
-  denote_lift a
-
-/-- An operation followed by a continuation denotes the Giry bind of its answer measure with
-the denotation of the continuation. -/
-theorem evalDist_liftBind [MeasurableSpace α] (a : P.A) (cont : P.B a → FreeM P α) :
-    𝒟[FreeM.liftBind a cont] = Measure.bind (IsMeasureSpec.toMeasure a) fun b => 𝒟[cont b] :=
-  rfl
-
 variable [∀ a, DiscreteMeasurableSpace (P.B a)]
-
-/-- Over a discrete-answer interface, the direct measure semantics satisfies the Giry monad
-laws. -/
-noncomputable instance (priority := 20) instLawfulEvalDistSemanticsFreeM :
-    LawfulEvalDistSemantics (FreeM P) where
-  denote_pure := denote_pure
-  denote_bind := denote_bind
 
 /-! ### Agreement with the `PMF` denotation
 

--- a/VCVio/EvalDist/PFunctorMeasure/Core.lean
+++ b/VCVio/EvalDist/PFunctorMeasure/Core.lean
@@ -6,6 +6,7 @@ Authors: Devon Tuma
 module
 
 public import PolyFun.PFunctor.Free.Basic
+public import VCVio.EvalDist.Defs.Measure.Core
 public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 public import Mathlib.MeasureTheory.Measure.Prod
 public import Mathlib.Probability.UniformOn
@@ -180,6 +181,60 @@ theorem denote_bind_bind_prod_mk_eq_prod [MeasurableSpace α] [DiscreteMeasurabl
         Measure.bind_dirac_eq_map (denote right) (by fun_prop)
     · change Measurable (Measure.dirac ∘ Prod.mk x)
       exact Measure.measurable_dirac.comp (by fun_prop))
+
+end FreeM
+
+namespace FreeM
+
+variable {P : PFunctor.{uA, u}} [∀ a, MeasurableSpace (P.B a)] [P.IsMeasureSpec]
+  {α : Type u}
+
+/-- Every free program denotes a subprobability measure, even before a measurability invariant is
+available for its continuations. `Measure.bind_apply_le` gives exactly the one-sided bound needed
+here; measurability is only needed to strengthen this to a probability-measure equality. -/
+theorem denote_apply_univ_le_one [MeasurableSpace α] (program : FreeM P α) :
+    denote program Set.univ ≤ 1 := by
+  induction program with
+  | pure _ => simp
+  | lift_bind a cont ih =>
+      refine (Measure.bind_apply_le _ MeasurableSet.univ).trans ?_
+      calc
+        (∫⁻ b, denote (cont b) Set.univ ∂IsMeasureSpec.toMeasure a) ≤
+            ∫⁻ _b, 1 ∂IsMeasureSpec.toMeasure a := lintegral_mono ih
+        _ = 1 := by simp
+
+/-- The direct free-monad fold supplies measure semantics for a measure-valued specification. -/
+noncomputable instance (priority := 20) instEvalDistSemanticsFreeM :
+    EvalDistSemantics (FreeM P) where
+  denote := denote
+  apply_univ_le_one := denote_apply_univ_le_one
+
+/-- With a measure specification in scope, primary notation is definitionally the direct
+free-monad measure fold. `𝒟[…]` is the public head: this is a transport lemma, not a simp rule,
+so the `𝒟`-keyed laws below and in `Defs.Measure` are the ones `simp` uses. -/
+theorem evalDist_eq_denote [MeasurableSpace α] (program : FreeM P α) :
+    𝒟[program] = denote program := rfl
+
+/-- A one-operation program denotes its configured answer measure. -/
+@[simp]
+theorem evalDist_lift (a : P.A) :
+    𝒟[(FreeM.lift a : FreeM P (P.B a))] = IsMeasureSpec.toMeasure a :=
+  denote_lift a
+
+/-- An operation followed by a continuation denotes the Giry bind of its answer measure with
+the denotation of the continuation. -/
+theorem evalDist_liftBind [MeasurableSpace α] (a : P.A) (cont : P.B a → FreeM P α) :
+    𝒟[FreeM.liftBind a cont] = Measure.bind (IsMeasureSpec.toMeasure a) fun b => 𝒟[cont b] :=
+  rfl
+
+variable [∀ a, DiscreteMeasurableSpace (P.B a)]
+
+/-- Over a discrete-answer interface, the direct measure semantics satisfies the Giry monad
+laws. -/
+noncomputable instance (priority := 20) instLawfulEvalDistSemanticsFreeM :
+    LawfulEvalDistSemantics (FreeM P) where
+  denote_pure := denote_pure
+  denote_bind := denote_bind
 
 end FreeM
 end PFunctor

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -8,6 +8,7 @@ public import VCVioTest.CryptoFoundations.ComputationalComplexitySoundness
 public import VCVioTest.CryptoFoundations.OracleClosure
 public import VCVioTest.CryptoFoundations.SignatureAlg
 public import VCVioTest.CryptoFoundations.SymmEncAlgMeasure
+public import VCVioTest.EvalDist.IndependentDraws
 public import VCVioTest.EvalDist.MeasureBridge
 public import VCVioTest.ForkMeasure
 public import VCVioTest.Forking.WithoutReplacement

--- a/VCVioTest/EvalDist/IndependentDraws.lean
+++ b/VCVioTest/EvalDist/IndependentDraws.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.EvalDist.Monad.Measure
+public import VCVio.EvalDist.PFunctorMeasure.Core
+public import Mathlib.Probability.Distributions.Gaussian.Real
+
+/-!
+# Measure-only independent-draw checks
+
+The imports provide direct polynomial-program measure semantics without a discrete
+distribution backend. Continuous draws and subprobability continuations exercise
+the measurable and potentially lossy forms of interchange.
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory PFunctor
+
+run_cmd do
+  let env ← Lean.getEnv
+  for name in [`PMF, `SPMF] do
+    if env.contains name then
+      throwError "measure-only imports unexpectedly include {name}"
+
+namespace VCVioTest.IndependentDraws
+
+example (μ ν ρ : Measure ℝ) [SFinite μ] [SFinite ν] [SFinite ρ] :
+    μ.bind (fun a => ν.bind (fun b => ρ.bind (fun c => Measure.dirac (a + b * c)))) =
+      ρ.bind (fun c => μ.bind (fun a => ν.bind (fun b => Measure.dirac (a + b * c)))) := by
+  apply Measure.bind_bind_bind_rotate
+  fun_prop
+
+example :
+    (gaussianReal 0 1).bind (fun a => (gaussianReal 1 2).bind
+      (fun b => Measure.dirac (a + b))) =
+      (gaussianReal 1 2).bind (fun b => (gaussianReal 0 1).bind
+        (fun a => Measure.dirac (a + b))) := by
+  apply Measure.bind_bind_swap
+  fun_prop
+
+example (μ ν : Measure ℝ) [SFinite μ] [SFinite ν] :
+    μ.bind (fun a => ν.bind (fun b => (1 / 2 : ENNReal) • Measure.dirac (a + b))) =
+      ν.bind (fun b => μ.bind (fun a => (1 / 2 : ENNReal) • Measure.dirac (a + b))) := by
+  apply Measure.bind_bind_swap
+  apply Measure.measurable_of_measurable_coe
+  intro s hs
+  change Measurable fun p : ℝ × ℝ => (1 / 2 : ENNReal) * Measure.dirac (p.1 + p.2) s
+  exact measurable_const.mul ((Measure.measurable_coe hs).comp
+    (Measure.measurable_dirac.comp (measurable_fst.add measurable_snd)))
+
+example (ν : Measure ℝ) :
+    (0 : Measure ℝ).bind (fun a => ν.bind (fun b => Measure.dirac (a + b))) = 0 := by
+  simp
+
+/-- A finite-answer interface whose semantics is a native uniform measure. -/
+@[expose, reducible] def coinSpec : PFunctor.{0, 0} := ⟨Unit, fun _ => Bool⟩
+
+instance : coinSpec.Fintype where
+  fintypeB _ := inferInstance
+
+instance : coinSpec.Inhabited where
+  inhabitedB _ := inferInstance
+
+noncomputable instance : coinSpec.IsMeasureSpec :=
+  IsMeasureSpec.uniformOfFintypeInhabited _
+
+example (mx : FreeM coinSpec Bool) (my : FreeM coinSpec (Fin 3))
+    (mz : FreeM coinSpec Unit) (f : Bool → Fin 3 → Unit → FreeM coinSpec ℝ) :
+    𝒟[mx >>= fun a => my >>= fun b => mz >>= fun c => f a b c] =
+      𝒟[mz >>= fun c => mx >>= fun a => my >>= fun b => f a b c] := by
+  apply evalDist_bind_bind_bind_rotate
+  exact Measurable.of_discrete
+
+end VCVioTest.IndependentDraws

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -9,7 +9,14 @@ Mathlib measures for closed denotations, kernels for environment/state-indexed c
 effect-preserving outcome types for transformers, and keep `Pr[...]` as the discrete compatibility
 surface. [`docs/reading/`](../reading/README.md) indexes the full design record.
 
-The primary notation is measure-valued: `𝒟[mx] : Measure α`. The finite distribution API is
+The primary notation is measure-valued: `𝒟[mx] : Measure α`. The generic classes and Giry laws
+live in `VCVio.EvalDist.Defs.Measure.Core`; the direct free-program instances live in
+`VCVio.EvalDist.PFunctorMeasure.Core`. These core modules do not import a PMF/SPMF backend.
+`VCVio.EvalDist.Monad.Measure` provides `evalDist_bind_bind_swap` for jointly measurable
+continuations and `evalDist_bind_bind_bind_rotate` for discrete intermediate results. Their
+measure-level proofs use Tonelli's theorem and preserve subprobability mass.
+
+The finite distribution API is
 explicit as `evalSPMF mx` / `𝒮[mx]`, and `Pr[...]` remains the discrete compatibility façade. One
 class connects the two: `DiscreteEvalDistCompatible m` says that integrating a measurable
 functional against `𝒟[mx]` is the façade expectation `∑' x, Pr[= x | mx] * g x`. Everything else
@@ -45,7 +52,7 @@ with `{none}` mass `Pr[⊥ | mx]`, the success mass of `bind`/`map` in `expected
 
 | Definition | Type | Notation | Defined in |
 |-----------|------|----------|------------|
-| `evalDist mx` | `Measure α` | `𝒟[mx]` | `EvalDist/Defs/Measure.lean` |
+| `evalDist mx` | `Measure α` | `𝒟[mx]` | `EvalDist/Defs/Measure/Core.lean` |
 | `evalSPMF mx` | `SPMF α` | `𝒮[mx]` | `EvalDist/Defs/Basic.lean` |
 | `probOutput mx x` | `ℝ≥0∞` | `Pr[= x \| mx]` | `EvalDist/Defs/Basic.lean` |
 | `probEvent mx p` | `ℝ≥0∞` | `Pr[p \| mx]` | `EvalDist/Defs/Basic.lean` |


### PR DESCRIPTION
Probability proof refactors need sampling-order and observation laws that survive removal of PMF/SPMF. Separate the generic measure semantics and direct free-program instances from the discrete adapters, preserving existing imports and declaration names. Add measure-level independent-draw interchange and three-draw rotation, with computation-level corollaries and explicit measurability assumptions.

The new regression module checks continuous Gaussian draws, missing-mass continuations, and native finite-answer programs. It also rejects imports containing either PMF or SPMF, so this foundation cannot silently fall back to the retiring backend.

Validation: `./scripts/validate.sh --lint --test --axioms` passed; 18,158 declarations across 570 modules, no new axiom/sorry taint. The explicit PMF/SPMF ratchet against the base also passed. No global automation attributes were added.

This is the first stage of the long-proof refactoring plan and is stacked on #686. Subsequent stages migrate the probability proof callers and extract structural invariants.
