### PR TITLE
refactor(QueryTracking): prove adaptive random-oracle bounds with measures

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -45,6 +45,7 @@ public import ToMathlib.Logic.Basic
 public import ToMathlib.MeasureTheory.DiscreteInstances
 public import ToMathlib.MeasureTheory.MeasurableSpace.Except
 public import ToMathlib.MeasureTheory.MeasurableSpace.Option
+public import ToMathlib.MeasureTheory.Measure.Bounds
 public import ToMathlib.MeasureTheory.Measure.Coupling
 public import ToMathlib.MeasureTheory.Measure.IndependentDraws
 public import ToMathlib.MeasureTheory.Measure.Monotone

--- a/ToMathlib/MeasureTheory/Measure/Bounds.lean
+++ b/ToMathlib/MeasureTheory/Measure/Bounds.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import ToMathlib.MeasureTheory.Measure.Subprobability
+public import Mathlib.Probability.UniformOn
+
+/-!
+# Event bounds for subprobability measures
+
+A measurable bad event can be charged separately from a uniform bound on the
+remaining continuations. Uniform finite sampling identifies event mass with
+normalized cardinality directly through counting measure.
+-/
+
+public section
+
+open MeasureTheory
+
+namespace MeasureTheory.Measure
+
+variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+
+/-- A bad-event bound and a uniform good-branch bound control sequential composition. -/
+theorem bind_apply_le_add_of_bad (μ : Measure α) [IsSubprobabilityMeasure μ]
+    (f : α → Measure β) (hf : Measurable f) [∀ a, IsSubprobabilityMeasure (f a)]
+    {bad : Set α} (hbad : MeasurableSet bad) {event : Set β} (hevent : MeasurableSet event)
+    {ε₁ ε₂ : ENNReal} (hbadBound : μ bad ≤ ε₁)
+    (hgood : ∀ a, a ∉ bad → f a event ≤ ε₂) :
+    μ.bind f event ≤ ε₁ + ε₂ := by
+  rw [bind_apply hevent hf.aemeasurable]
+  calc
+    _ ≤ ∫⁻ a, ε₂ + bad.indicator 1 a ∂μ := by
+      apply lintegral_mono
+      intro a
+      by_cases ha : a ∈ bad
+      · simpa [ha] using (measure_le_one (f a) event).trans
+          (le_add_self : (1 : ENNReal) ≤ ε₂ + 1)
+      · simpa [ha] using hgood a ha
+    _ = ε₂ * μ Set.univ + μ bad := by
+      rw [lintegral_add_left measurable_const, lintegral_const, lintegral_indicator_one hbad]
+    _ ≤ ε₂ + ε₁ := add_le_add
+      ((mul_le_mul' le_rfl (measure_univ_le μ)).trans_eq (mul_one ε₂)) hbadBound
+    _ = _ := add_comm _ _
+
+end MeasureTheory.Measure
+
+namespace ProbabilityTheory
+
+/-- The uniform measure of a predicate on a finite type is its normalized cardinality. -/
+theorem uniformOn_univ_apply_setOf {α : Type*} [MeasurableSpace α]
+    [MeasurableSingletonClass α] [Fintype α] (p : α → Prop) [DecidablePred p] :
+    (uniformOn Set.univ : Measure α) {x | p x} =
+      ((Finset.univ.filter p).card : ENNReal) / Fintype.card α := by
+  rw [uniformOn_univ]
+  have hset : {x | p x} = (↑(Finset.univ.filter p) : Set α) := by ext; simp
+  rw [hset, Measure.count_apply_finset]
+
+end ProbabilityTheory

--- a/VCVio/CryptoFoundations/MerkleTree/MultiExtractability/OnlineBound.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/MultiExtractability/OnlineBound.lean
@@ -31,7 +31,7 @@ current step would be circular.
 
 @[expose] public section
 
-open OracleSpec OracleComp
+open OracleSpec OracleComp MeasureTheory
 
 namespace MerkleTreeMultiExtractability
 
@@ -87,6 +87,223 @@ The target set may change with the accumulated log, but its cardinality must be 
 pre-query cache/log invariants. The proof treats a target hit as an unrestricted bad branch; hence
 the conclusion applies to any terminal event whose good branches satisfy the recursive/terminal
 hypotheses, without requiring the execution to expose an explicit monitoring flag. -/
+theorem measure_onlineAdaptivePrefixRunFrom_logged_le
+    [DecidableEq Query] [DecidableEq Y] [Finite Y]
+    [MeasurableSpace Y] [DiscreteMeasurableSpace Y]
+    [MeasurableSpace (R × (Query →ₒ Y).QueryCache)]
+    [EvalDistSemantics (OracleComp (Query →ₒ Y))]
+    [LawfulEvalDistSemantics (OracleComp (Query →ₒ Y))]
+    (hquery : ∀ t : Query, 𝒟[(liftM ((Query →ₒ Y).query t) : OracleComp (Query →ₒ Y) Y)] =
+      ProbabilityTheory.uniformOn Set.univ)
+    (suffix : X → (Query →ₒ Y).QueryLog → OracleComp (Query →ₒ Y) R)
+    (continuation : X → (Query →ₒ Y).QueryLog → OracleComp (Query →ₒ Y) C)
+    (win : R → Prop)
+    (hwin : MeasurableSet {z : R × (Query →ₒ Y).QueryCache | win z.1})
+    (targets : (Query →ₒ Y).QueryLog → Finset Y)
+    (Good : (Query →ₒ Y).QueryCache → (Query →ₒ Y).QueryLog → Prop)
+    (nodeBudget checkpointCount overhead : ℕ)
+    (prefixComp : OracleComp (Query →ₒ Y) X)
+    (remaining cached : ℕ)
+    (log : (Query →ₒ Y).QueryLog)
+    (hbound : IsTotalQueryBound
+      (loggedAccountingBind prefixComp log continuation) remaining)
+    (cache : (Query →ₒ Y).QueryCache)
+    (hno : ¬ CacheHasCollision cache)
+    (hcacheBound : ∃ keys : Finset Query, keys.card ≤ cached ∧
+      ∀ input, cache input ≠ none → input ∈ keys)
+    (hlogCache : ∀ entry ∈ log, cache entry.1 = some entry.2)
+    (hcacheLog : ∀ input value, cache input = some value →
+      ∃ entry ∈ log, entry.1 = input ∧ entry.2 = value)
+    (hgood : Good cache log)
+    (hgoodHit : ∀ (currentCache : (Query →ₒ Y).QueryCache)
+        (currentLog : (Query →ₒ Y).QueryLog) query response,
+      Good currentCache currentLog → currentCache query = some response →
+      (∀ input value, currentCache input = some value →
+        ∃ entry ∈ currentLog, entry.1 = input ∧ entry.2 = value) →
+      Good currentCache (currentLog ++ [⟨query, response⟩]))
+    (hgoodMiss : ∀ (currentCache : (Query →ₒ Y).QueryCache)
+        (currentLog : (Query →ₒ Y).QueryLog) query response,
+      Good currentCache currentLog → currentCache query = none →
+      ¬ CacheHasCollision (currentCache.cacheQuery query response) →
+      response ∉ targets currentLog →
+      Good (currentCache.cacheQuery query response)
+        (currentLog ++ [⟨query, response⟩]))
+    (htargetBound : ∀ (currentCached : ℕ)
+        (currentCache : (Query →ₒ Y).QueryCache)
+        (currentLog : (Query →ₒ Y).QueryLog),
+      (∃ keys : Finset Query, keys.card ≤ currentCached ∧
+        ∀ input, currentCache input ≠ none → input ∈ keys) →
+      (∀ entry ∈ currentLog, currentCache entry.1 = some entry.2) →
+      (∀ input value, currentCache input = some value →
+        ∃ entry ∈ currentLog, entry.1 = input ∧ entry.2 = value) →
+      Good currentCache currentLog →
+      (targets currentLog).card ≤
+        sharedExtractedLabelCountBound nodeBudget checkpointCount currentCached)
+    (hterminal : ∀ (x : X) (terminalRemaining terminalCached : ℕ)
+        (terminalCache : (Query →ₒ Y).QueryCache)
+        (terminalLog : (Query →ₒ Y).QueryLog),
+      IsTotalQueryBound (continuation x terminalLog) terminalRemaining →
+      ¬ CacheHasCollision terminalCache →
+      (∃ keys : Finset Query, keys.card ≤ terminalCached ∧
+        ∀ input, terminalCache input ≠ none → input ∈ keys) →
+      (∀ entry ∈ terminalLog, terminalCache entry.1 = some entry.2) →
+      (∀ input value, terminalCache input = some value →
+        ∃ entry ∈ terminalLog, entry.1 = input ∧ entry.2 = value) →
+      Good terminalCache terminalLog →
+      𝒟[(simulateQ (Query →ₒ Y).cachingOracle
+          (suffix x terminalLog)).run terminalCache] {z | win z.1} ≤
+        (multiCheckpointErrorNumerator nodeBudget checkpointCount overhead
+          terminalRemaining terminalCached : ENNReal) *
+            (Nat.card Y : ENNReal)⁻¹) :
+    𝒟[adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
+        suffix prefixComp cache log] {z | win z.1} ≤
+      (multiCheckpointErrorNumerator nodeBudget checkpointCount overhead
+        remaining cached : ENNReal) * (Nat.card Y : ENNReal)⁻¹ := by
+  let cardY := (Nat.card Y : ENNReal)
+  induction prefixComp using OracleComp.inductionOn generalizing remaining cached cache log with
+  | pure x =>
+      simpa only [adaptivePrefixRunFrom, simulateQ_pure, StateT.run_pure, pure_bind] using
+        hterminal x remaining cached cache log (by simpa using hbound)
+        hno hcacheBound hlogCache hcacheLog hgood
+  | query_bind query next ih =>
+      have hqueryBound : IsTotalQueryBound
+          ((liftM ((Query →ₒ Y).query query) : OracleComp (Query →ₒ Y) _) >>=
+            fun response =>
+            loggedAccountingBind (next response) (log ++ [⟨query, response⟩])
+              continuation) remaining := by
+        rw [← loggedAccountingBind_query_bind]
+        exact hbound
+      rw [isTotalQueryBound_query_bind_iff] at hqueryBound
+      obtain ⟨hremaining, hnext⟩ := hqueryBound
+      by_cases hhit : ∃ response, cache query = some response
+      · obtain ⟨response, hresponse⟩ := hhit
+        have hrun : adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
+            suffix ((liftM ((Query →ₒ Y).query query) :
+              OracleComp (Query →ₒ Y) _) >>= next) cache log =
+            adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
+              suffix (next response) cache (log ++ [⟨query, response⟩]) := by
+          simp only [adaptivePrefixRunFrom, OracleComp.run_simulateQ_query_bind,
+            cachingLoggingOracle.run_some hresponse, pure_bind]
+        rw [hrun]
+        have hlogCache' : ∀ entry ∈ log ++ [⟨query, response⟩],
+            cache entry.1 = some entry.2 := by
+          exact QueryCache.log_consistent_append cache log query response hresponse hlogCache
+        have hcacheLog' : ∀ input output, cache input = some output →
+            ∃ entry ∈ log ++ [⟨query, response⟩],
+              entry.1 = input ∧ entry.2 = output := by
+          exact QueryCache.cache_covered_append cache log _ hcacheLog
+        have hrec := ih response (remaining := remaining - 1) (cached := cached)
+          (hnext response) (cache := cache) (log := log ++ [⟨query, response⟩])
+          hno hcacheBound hlogCache' hcacheLog'
+          (hgoodHit cache log query response hgood hresponse hcacheLog)
+        refine hrec.trans ?_
+        apply mul_le_mul_of_nonneg_right
+        · exact_mod_cast multiCheckpointErrorNumerator_hit_le
+            nodeBudget checkpointCount overhead remaining cached
+        · exact zero_le
+      · push Not at hhit
+        have hnone : cache query = none := Option.eq_none_iff_forall_ne_some.mpr hhit
+        have hrun : adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
+            suffix ((liftM ((Query →ₒ Y).query query) :
+              OracleComp (Query →ₒ Y) _) >>= next) cache log =
+            (liftM ((Query →ₒ Y).query query) :
+              OracleComp (Query →ₒ Y) _) >>= fun response =>
+              adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
+                suffix (next response) (cache.cacheQuery query response)
+                (log ++ [⟨query, response⟩]) := by
+          simp only [adaptivePrefixRunFrom, OracleComp.run_simulateQ_query_bind,
+            cachingLoggingOracle.run_none hnone]
+          rfl
+        rw [hrun]
+        have hbad : 𝒟[(liftM ((Query →ₒ Y).query query) : OracleComp (Query →ₒ Y) _)]
+            {response | CacheHasCollision (cache.cacheQuery query response) ∨
+              response ∈ targets log} ≤
+              ((cached + sharedExtractedLabelCountBound nodeBudget checkpointCount cached : ℕ) :
+                ENNReal) * cardY⁻¹ := by
+          classical
+          let : Fintype Y := Fintype.ofFinite Y
+          have htargets := htargetBound cached cache log hcacheBound hlogCache hcacheLog hgood
+          obtain ⟨keys, hkeysCard, hkeysMem⟩ := hcacheBound
+          rw [hquery, ProbabilityTheory.uniformOn_univ_apply_setOf]
+          have hcollision := (OracleComp.card_responses_creating_cacheCollision_le
+            (t := query) hno hkeysMem).trans hkeysCard
+          have horCard :
+              (Finset.univ.filter fun response : Y =>
+                CacheHasCollision (cache.cacheQuery query response) ∨
+                  response ∈ targets log).card ≤
+                cached + sharedExtractedLabelCountBound nodeBudget checkpointCount cached := by
+            calc
+              _ ≤ (Finset.univ.filter fun response : Y =>
+                      CacheHasCollision (cache.cacheQuery query response)).card +
+                    (Finset.univ.filter fun response : Y =>
+                      response ∈ targets log).card := by
+                  refine (Finset.card_mono (b :=
+                      (Finset.univ.filter fun response : Y =>
+                        CacheHasCollision (cache.cacheQuery query response)) ∪
+                      (Finset.univ.filter fun response : Y =>
+                        response ∈ targets log)) ?_).trans
+                    (Finset.card_union_le _ _)
+                  intro response hresponse
+                  simpa using hresponse
+              _ ≤ cached + (targets log).card := by
+                  exact Nat.add_le_add hcollision (by
+                    have heq : (Finset.univ.filter fun response : Y =>
+                        response ∈ targets log) = targets log := by ext; simp
+                    exact le_of_eq (congrArg Finset.card heq))
+              _ ≤ cached + sharedExtractedLabelCountBound nodeBudget checkpointCount cached :=
+                Nat.add_le_add_left htargets cached
+          calc
+            _ ≤ ((cached + sharedExtractedLabelCountBound nodeBudget checkpointCount
+                cached : ℕ) : ENNReal) / Fintype.card Y :=
+              ENNReal.div_le_div_right (by exact_mod_cast horCard) _
+            _ = _ := by
+              rw [← Nat.card_eq_fintype_card, ENNReal.div_eq_inv_mul, mul_comm]
+        have hcontinuation : ∀ response,
+            ¬ (CacheHasCollision (cache.cacheQuery query response) ∨
+              response ∈ targets log) →
+            𝒟[adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
+                suffix (next response) (cache.cacheQuery query response)
+                (log ++ [⟨query, response⟩])] {z | win z.1} ≤
+              (multiCheckpointErrorNumerator nodeBudget checkpointCount overhead
+                (remaining - 1) (cached + 1) : ENNReal) * cardY⁻¹ := by
+          intro response hsafe
+          have hcacheBound' : ∃ keys : Finset Query, keys.card ≤ cached + 1 ∧
+              ∀ input, (cache.cacheQuery query response) input ≠ none →
+                input ∈ keys := by
+            exact QueryCache.domain_bound_cacheQuery cache query response cached hcacheBound
+          have hlogCache' : ∀ entry ∈ log ++ [⟨query, response⟩],
+              (cache.cacheQuery query response) entry.1 = some entry.2 := by
+            exact QueryCache.log_consistent_cacheQuery_append
+              cache log query response hnone hlogCache
+          have hcacheLog' : ∀ input output,
+              (cache.cacheQuery query response) input = some output →
+              ∃ entry ∈ log ++ [⟨query, response⟩],
+                entry.1 = input ∧ entry.2 = output := by
+            exact QueryCache.cache_covered_cacheQuery_append cache log query response hcacheLog
+          have hrec := ih response (remaining := remaining - 1) (cached := cached + 1)
+            (hnext response) (cache := cache.cacheQuery query response)
+            (log := log ++ [⟨query, response⟩]) (not_or.mp hsafe).1
+              hcacheBound' hlogCache' hcacheLog'
+              (hgoodMiss cache log query response hgood hnone
+                (not_or.mp hsafe).1 (not_or.mp hsafe).2)
+          exact hrec
+        have hcombined := evalDist_bind_apply_le_add_of_bad
+          (mx := (liftM ((Query →ₒ Y).query query) : OracleComp (Query →ₒ Y) Y))
+          (f := fun response : Y => adaptivePrefixRunFrom
+            (ι := Query) (Y := Y) (X := X) (R := R) suffix (next response)
+            (cache.cacheQuery query response) (log ++ [⟨query, response⟩]))
+          Measurable.of_discrete
+          (bad := {response | CacheHasCollision (cache.cacheQuery query response) ∨
+            response ∈ targets log})
+          MeasurableSet.of_discrete hwin hbad (fun response hsafe => hcontinuation response hsafe)
+        refine hcombined.trans ?_
+        rw [← add_mul]
+        apply mul_le_mul_of_nonneg_right
+        · exact_mod_cast multiCheckpointErrorNumerator_miss_le
+            nodeBudget checkpointCount overhead remaining cached hremaining
+        · exact zero_le
+
+/-- The predictable-target measure bound read through discrete probability notation. -/
 theorem probEvent_onlineAdaptivePrefixRunFrom_logged_le
     [DecidableEq Query] [DecidableEq Y] [Finite Y] [Inhabited Y]
     [IsUniformSpec (Query →ₒ Y)]
@@ -154,214 +371,24 @@ theorem probEvent_onlineAdaptivePrefixRunFrom_logged_le
         suffix prefixComp cache log] ≤
       (multiCheckpointErrorNumerator nodeBudget checkpointCount overhead
         remaining cached : ENNReal) * (Nat.card Y : ENNReal)⁻¹ := by
-  let cardY := (Nat.card Y : ENNReal)
-  induction prefixComp using OracleComp.inductionOn generalizing remaining cached cache log with
-  | pure x =>
-      simpa only [adaptivePrefixRunFrom, simulateQ_pure, StateT.run_pure, pure_bind] using
-        hterminal x remaining cached cache log (by simpa using hbound)
-        hno hcacheBound hlogCache hcacheLog hgood
-  | query_bind query next ih =>
-      have hqueryBound : IsTotalQueryBound
-          ((liftM ((Query →ₒ Y).query query) : OracleComp (Query →ₒ Y) _) >>=
-            fun response =>
-            loggedAccountingBind (next response) (log ++ [⟨query, response⟩])
-              continuation) remaining := by
-        rw [← loggedAccountingBind_query_bind]
-        exact hbound
-      rw [isTotalQueryBound_query_bind_iff] at hqueryBound
-      obtain ⟨hremaining, hnext⟩ := hqueryBound
-      by_cases hhit : ∃ response, cache query = some response
-      · obtain ⟨response, hresponse⟩ := hhit
-        have hrun : adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
-            suffix ((liftM ((Query →ₒ Y).query query) :
-              OracleComp (Query →ₒ Y) _) >>= next) cache log =
-            adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
-              suffix (next response) cache (log ++ [⟨query, response⟩]) := by
-          simp only [adaptivePrefixRunFrom, OracleComp.run_simulateQ_query_bind,
-            cachingLoggingOracle.run_some hresponse, pure_bind]
-        rw [hrun]
-        have hlogCache' : ∀ entry ∈ log ++ [⟨query, response⟩],
-            cache entry.1 = some entry.2 := by
-          intro entry hentry
-          rw [List.mem_append] at hentry
-          rcases hentry with hentry | hentry
-          · exact hlogCache entry hentry
-          · rw [List.mem_singleton] at hentry
-            subst entry
-            exact hresponse
-        have hcacheLog' : ∀ input output, cache input = some output →
-            ∃ entry ∈ log ++ [⟨query, response⟩],
-              entry.1 = input ∧ entry.2 = output := by
-          intro input output hcached
-          obtain ⟨entry, hentry, hi, ho⟩ := hcacheLog input output hcached
-          exact ⟨entry, List.mem_append_left _ hentry, hi, ho⟩
-        have hrec := ih response (remaining := remaining - 1) (cached := cached)
-          (hnext response) (cache := cache) (log := log ++ [⟨query, response⟩])
-          hno hcacheBound hlogCache' hcacheLog'
-          (hgoodHit cache log query response hgood hresponse hcacheLog)
-        refine hrec.trans ?_
-        apply mul_le_mul_of_nonneg_right
-        · exact_mod_cast multiCheckpointErrorNumerator_hit_le
-            nodeBudget checkpointCount overhead remaining cached
-        · exact zero_le
-      · push Not at hhit
-        have hnone : cache query = none := Option.eq_none_iff_forall_ne_some.mpr hhit
-        have hrun : adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
-            suffix ((liftM ((Query →ₒ Y).query query) :
-              OracleComp (Query →ₒ Y) _) >>= next) cache log =
-            (liftM ((Query →ₒ Y).query query) :
-              OracleComp (Query →ₒ Y) _) >>= fun response =>
-              adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
-                suffix (next response) (cache.cacheQuery query response)
-                (log ++ [⟨query, response⟩]) := by
-          simp only [adaptivePrefixRunFrom, OracleComp.run_simulateQ_query_bind,
-            cachingLoggingOracle.run_none hnone]
-          rfl
-        rw [hrun]
-        have hbad : Pr[fun response =>
-            CacheHasCollision (cache.cacheQuery query response) ∨
-              response ∈ targets log |
-            (liftM ((Query →ₒ Y).query query) : OracleComp (Query →ₒ Y) _)] ≤
-              ((cached + sharedExtractedLabelCountBound nodeBudget checkpointCount cached : ℕ) :
-                ENNReal) * cardY⁻¹ := by
-          classical
-          let _ : Fintype Y := OracleSpec.instFintypeRangeOfFintype query
-          have htargets := htargetBound cached cache log hcacheBound hlogCache hcacheLog hgood
-          obtain ⟨keys, hkeysCard, hkeysMem⟩ := hcacheBound
-          rw [probEvent_query]
-          have hcollision := (OracleComp.card_responses_creating_cacheCollision_le
-            (t := query) hno hkeysMem).trans hkeysCard
-          have horCard :
-              (Finset.univ.filter fun response : Y =>
-                CacheHasCollision (cache.cacheQuery query response) ∨
-                  response ∈ targets log).card ≤
-                cached + sharedExtractedLabelCountBound nodeBudget checkpointCount cached := by
-            calc
-              _ ≤ (Finset.univ.filter fun response : Y =>
-                      CacheHasCollision (cache.cacheQuery query response)).card +
-                    (Finset.univ.filter fun response : Y =>
-                      response ∈ targets log).card := by
-                  refine (Finset.card_mono (b :=
-                      (Finset.univ.filter fun response : Y =>
-                        CacheHasCollision (cache.cacheQuery query response)) ∪
-                      (Finset.univ.filter fun response : Y =>
-                        response ∈ targets log)) ?_).trans
-                    (Finset.card_union_le _ _)
-                  intro response hresponse
-                  simpa using hresponse
-              _ ≤ cached + (targets log).card := by
-                  exact Nat.add_le_add hcollision (by
-                    have heq : (Finset.univ.filter fun response : Y =>
-                        response ∈ targets log) = targets log := by ext; simp
-                    exact le_of_eq (congrArg Finset.card heq))
-              _ ≤ cached + sharedExtractedLabelCountBound nodeBudget checkpointCount cached :=
-                Nat.add_le_add_left htargets cached
-          have hcard :
-              @Fintype.card ((Query →ₒ Y).Range query)
-                  (OracleSpec.instFintypeRangeOfFintype query) = Nat.card Y := by
-            calc
-              @Fintype.card ((Query →ₒ Y).Range query)
-                  (OracleSpec.instFintypeRangeOfFintype query) =
-                  Nat.card ((Query →ₒ Y).Range query) :=
-                    (@Nat.card_eq_fintype_card ((Query →ₒ Y).Range query)
-                      (OracleSpec.instFintypeRangeOfFintype query)).symm
-              _ = Nat.card Y := Nat.card_congr (Equiv.refl Y)
-          calc
-            ((Finset.univ.filter fun response : Y =>
-                CacheHasCollision (cache.cacheQuery query response) ∨
-                  response ∈ targets log).card : ENNReal) /
-                @Fintype.card ((Query →ₒ Y).Range query)
-                  (OracleSpec.instFintypeRangeOfFintype query)
-              ≤ ((cached + sharedExtractedLabelCountBound nodeBudget checkpointCount
-                    cached : ℕ) : ENNReal) /
-                  @Fintype.card ((Query →ₒ Y).Range query)
-                    (OracleSpec.instFintypeRangeOfFintype query) :=
-                ENNReal.div_le_div_right (by exact_mod_cast horCard) _
-            _ = ((cached + sharedExtractedLabelCountBound nodeBudget checkpointCount cached : ℕ) :
-                  ENNReal) * cardY⁻¹ := by
-              rw [hcard, ENNReal.div_eq_inv_mul, mul_comm]
-        have hcontinuation : ∀ response ∈ support
-            (liftM ((Query →ₒ Y).query query) : OracleComp (Query →ₒ Y) _),
-            ¬ (CacheHasCollision (cache.cacheQuery query response) ∨
-              response ∈ targets log) →
-            Pr[fun z => win z.1 |
-              adaptivePrefixRunFrom (ι := Query) (Y := Y) (X := X) (R := R)
-                suffix (next response) (cache.cacheQuery query response)
-                (log ++ [⟨query, response⟩])] ≤
-              (multiCheckpointErrorNumerator nodeBudget checkpointCount overhead
-                (remaining - 1) (cached + 1) : ENNReal) * cardY⁻¹ := by
-          intro response _ hsafe
-          have hcacheBound' : ∃ keys : Finset Query, keys.card ≤ cached + 1 ∧
-              ∀ input, (cache.cacheQuery query response) input ≠ none →
-                input ∈ keys := by
-            obtain ⟨keys, hkeysCard, hkeysMem⟩ := hcacheBound
-            refine ⟨insert query keys, (Finset.card_insert_le query keys).trans (by omega), ?_⟩
-            intro input hinput
-            by_cases hi : input = query
-            · exact hi ▸ Finset.mem_insert_self _ _
-            · rw [QueryCache.cacheQuery_of_ne cache response hi] at hinput
-              exact Finset.mem_insert_of_mem (hkeysMem input hinput)
-          have hlogCache' : ∀ entry ∈ log ++ [⟨query, response⟩],
-              (cache.cacheQuery query response) entry.1 = some entry.2 := by
-            rintro ⟨input, output⟩ hentry
-            rw [List.mem_append] at hentry
-            rcases hentry with hentry | hentry
-            · by_cases hi : input = query
-              · subst input
-                have := hlogCache ⟨query, output⟩ hentry
-                simp [hnone] at this
-              · rw [QueryCache.cacheQuery_of_ne cache response hi]
-                exact hlogCache ⟨input, output⟩ hentry
-            · rw [List.mem_singleton] at hentry
-              have hinput : input = query := congrArg Sigma.fst hentry
-              subst input
-              have houtput : output = response := eq_of_heq (Sigma.mk.inj_iff.mp hentry).2
-              subst output
-              exact QueryCache.cacheQuery_self cache query response
-          have hcacheLog' : ∀ input output,
-              (cache.cacheQuery query response) input = some output →
-              ∃ entry ∈ log ++ [⟨query, response⟩],
-                entry.1 = input ∧ entry.2 = output := by
-            intro input output hcached
-            by_cases hi : input = query
-            · subst input
-              rw [QueryCache.cacheQuery_self] at hcached
-              obtain rfl := Option.some.inj hcached
-              exact ⟨⟨query, response⟩, by simp, rfl, rfl⟩
-            · rw [QueryCache.cacheQuery_of_ne cache response hi] at hcached
-              obtain ⟨entry, hentry, heqInput, heqOutput⟩ :=
-                hcacheLog input output hcached
-              exact ⟨entry, List.mem_append_left _ hentry, heqInput, heqOutput⟩
-          have hrec := ih response (remaining := remaining - 1) (cached := cached + 1)
-            (hnext response) (cache := cache.cacheQuery query response)
-            (log := log ++ [⟨query, response⟩]) (not_or.mp hsafe).1
-              hcacheBound' hlogCache' hcacheLog'
-              (hgoodMiss cache log query response hgood hnone
-                (not_or.mp hsafe).1 (not_or.mp hsafe).2)
-          exact hrec
-        have hcombined := probEvent_bind_le_add
-          (mx := (liftM ((Query →ₒ Y).query query) : OracleComp (Query →ₒ Y) _))
-          (my := fun response => adaptivePrefixRunFrom
-            (ι := Query) (Y := Y) (X := X) (R := R) suffix (next response)
-            (cache.cacheQuery query response) (log ++ [⟨query, response⟩]))
-          (p := fun response =>
-            ¬ (CacheHasCollision (cache.cacheQuery query response) ∨
-              response ∈ targets log))
-          (q := fun z => ¬ win z.1)
-          (ε₁ :=
-            ((cached + sharedExtractedLabelCountBound nodeBudget checkpointCount cached : ℕ) :
-                ENNReal) * cardY⁻¹)
-          (ε₂ := (multiCheckpointErrorNumerator nodeBudget checkpointCount overhead
-            (remaining - 1) (cached + 1) : ENNReal) * cardY⁻¹)
-          (by simpa only [not_not] using hbad)
-          (by simpa only [not_not] using hcontinuation)
-        simp only [not_not] at hcombined
-        refine hcombined.trans ?_
-        rw [← add_mul]
-        apply mul_le_mul_of_nonneg_right
-        · exact_mod_cast multiCheckpointErrorNumerator_miss_le
-            nodeBudget checkpointCount overhead remaining cached hremaining
-        · exact zero_le
+  classical
+  let : MeasurableSpace Y := ⊤
+  let : MeasurableSpace (R × (Query →ₒ Y).QueryCache) := ⊤
+  rw [← evalDist_apply_setOf]
+  refine measure_onlineAdaptivePrefixRunFrom_logged_le (hquery := ?_)
+    suffix continuation win MeasurableSet.of_discrete targets Good nodeBudget checkpointCount
+    overhead prefixComp remaining cached log hbound cache hno hcacheBound hlogCache hcacheLog
+    hgood hgoodHit hgoodMiss htargetBound ?_
+  · intro t
+    let : Fintype Y := Fintype.ofFinite Y
+    apply MeasureTheory.Measure.ext_of_singleton
+    intro y
+    rw [evalDist_apply_singleton, probOutput_query, ProbabilityTheory.uniformOn_univ,
+      MeasureTheory.Measure.count_singleton, one_div]
+    simp only [← Nat.card_eq_fintype_card]
+  · intro x terminalRemaining terminalCached terminalCache terminalLog hq hn hb hl hc hg
+    simpa only [evalDist_apply_setOf] using
+      hterminal x terminalRemaining terminalCached terminalCache terminalLog hq hn hb hl hc hg
 
 /-- Specialization where structural accounting does not depend on the accumulated log. -/
 theorem probEvent_onlineAdaptivePrefixRunFrom_le

--- a/VCVio/EvalDist/Monad/Measure.lean
+++ b/VCVio/EvalDist/Monad/Measure.lean
@@ -7,6 +7,7 @@ Authors: Devon Tuma
 module
 public import VCVio.EvalDist.Defs.Measure.Core
 public import ToMathlib.MeasureTheory.Measure.IndependentDraws
+public import ToMathlib.MeasureTheory.Measure.Bounds
 
 /-!
 # Independent draws under measure-valued evaluation
@@ -54,3 +55,12 @@ theorem evalDist_bind_bind_bind_rotate [DiscreteMeasurableSpace α]
       𝒟[mz >>= fun c => mx >>= fun a => my >>= fun b => f a b c] := by
   simp only [evalDist_bind_of_discrete]
   exact Measure.bind_bind_bind_rotate _ _ _ hf
+
+/-- Charge a bad intermediate event separately from uniformly bounded good continuations. -/
+theorem evalDist_bind_apply_le_add_of_bad (mx : m α) (f : α → m β)
+    (hf : Measurable fun a => 𝒟[f a]) {bad : Set α} (hbad : MeasurableSet bad)
+    {event : Set β} (hevent : MeasurableSet event) {ε₁ ε₂ : ENNReal}
+    (hbadBound : 𝒟[mx] bad ≤ ε₁) (hgood : ∀ a, a ∉ bad → 𝒟[f a] event ≤ ε₂) :
+    𝒟[mx >>= f] event ≤ ε₁ + ε₂ := by
+  rw [evalDist_bind mx f hf]
+  exact Measure.bind_apply_le_add_of_bad _ _ hf hbad hevent hbadBound hgood

--- a/VCVio/OracleComp/QueryTracking/AdaptivePrefix.lean
+++ b/VCVio/OracleComp/QueryTracking/AdaptivePrefix.lean
@@ -8,6 +8,7 @@ module
 
 public import VCVio.OracleComp.QueryTracking.CachingLoggingOracle
 public import VCVio.OracleComp.QueryTracking.Collision
+public import VCVio.EvalDist.Monad.Measure
 import VCVio.OracleComp.QueryTracking.Birthday
 
 /-!
@@ -37,7 +38,7 @@ mathematical.
 
 @[expose] public section
 
-open OracleSpec OracleComp
+open OracleSpec OracleComp MeasureTheory
 
 namespace OracleComp
 
@@ -137,6 +138,155 @@ The prefix and its abstract continuation have total query bound `remaining`. The
 hypothesis supplies the caller-specific bound once the prefix stops, under the exact cache/log
 invariants maintained by `cachingLoggingOracle`. The conclusion is valid even when the prefix
 adaptively decides when to stop and repeats cached queries. -/
+theorem measure_adaptivePrefixRunFrom_le
+    [DecidableEq ι] [DecidableEq Y] [Finite Y]
+    [MeasurableSpace Y] [DiscreteMeasurableSpace Y]
+    [MeasurableSpace (R × (ι →ₒ Y).QueryCache)]
+    [EvalDistSemantics (OracleComp (ι →ₒ Y))]
+    [LawfulEvalDistSemantics (OracleComp (ι →ₒ Y))]
+    (hquery : ∀ t : ι, 𝒟[(liftM ((ι →ₒ Y).query t) : OracleComp (ι →ₒ Y) Y)] =
+      ProbabilityTheory.uniformOn Set.univ)
+    (suffix : X → (ι →ₒ Y).QueryLog → OracleComp (ι →ₒ Y) R)
+    (continuation : X → OracleComp (ι →ₒ Y) C)
+    (win : R → Prop)
+    (hwin : MeasurableSet {z : R × (ι →ₒ Y).QueryCache | win z.1})
+    (targetCount : ℕ → ℕ) (overhead : ℕ)
+    (prefixComp : OracleComp (ι →ₒ Y) X)
+    (remaining cached : ℕ)
+    (hbound : IsTotalQueryBound (prefixComp >>= continuation) remaining)
+    (cache : (ι →ₒ Y).QueryCache)
+    (log : (ι →ₒ Y).QueryLog)
+    (hno : ¬ CacheHasCollision cache)
+    (hcacheBound : ∃ keys : Finset ι, keys.card ≤ cached ∧
+      ∀ input, cache input ≠ none → input ∈ keys)
+    (hlogCache : ∀ entry ∈ log, cache entry.1 = some entry.2)
+    (hcacheLog : ∀ input value, cache input = some value →
+      ∃ entry ∈ log, entry.1 = input ∧ entry.2 = value)
+    (hterminal : ∀ (x : X) (terminalRemaining terminalCached : ℕ)
+        (terminalCache : (ι →ₒ Y).QueryCache)
+        (terminalLog : (ι →ₒ Y).QueryLog),
+      IsTotalQueryBound (continuation x) terminalRemaining →
+      ¬ CacheHasCollision terminalCache →
+      (∃ keys : Finset ι, keys.card ≤ terminalCached ∧
+        ∀ input, terminalCache input ≠ none → input ∈ keys) →
+      (∀ entry ∈ terminalLog, terminalCache entry.1 = some entry.2) →
+      (∀ input value, terminalCache input = some value →
+        ∃ entry ∈ terminalLog, entry.1 = input ∧ entry.2 = value) →
+      𝒟[(simulateQ (ι →ₒ Y).cachingOracle
+          (suffix x terminalLog)).run terminalCache] {z | win z.1} ≤
+        ((targetCount terminalCached * (terminalRemaining + overhead) : ℕ) : ENNReal) *
+          (Nat.card Y : ENNReal)⁻¹) :
+    𝒟[adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R)
+        suffix prefixComp cache log] {z | win z.1} ≤
+      (adaptivePrefixPotential targetCount overhead remaining cached : ENNReal) *
+        (Nat.card Y : ENNReal)⁻¹ := by
+  let C := (Nat.card Y : ENNReal)
+  induction prefixComp using OracleComp.inductionOn generalizing remaining cached cache log with
+  | pure x =>
+      have hsuffix := hterminal x remaining cached cache log (by simpa using hbound)
+        hno hcacheBound hlogCache hcacheLog
+      simp only [adaptivePrefixRunFrom, simulateQ_pure, StateT.run_pure, pure_bind]
+      refine hsuffix.trans ?_
+      change ((targetCount cached * (remaining + overhead) : ℕ) : ENNReal) * C⁻¹ ≤
+        (adaptivePrefixPotential targetCount overhead remaining cached : ENNReal) * C⁻¹
+      gcongr
+      exact adaptivePrefixPotential_terminal_le targetCount overhead remaining cached
+  | query_bind t next ih =>
+      have hqueryBound : IsTotalQueryBound
+          ((liftM ((ι →ₒ Y).query t) : OracleComp (ι →ₒ Y) _) >>= fun u =>
+            next u >>= continuation) remaining := by
+        simpa only [bind_assoc] using hbound
+      rw [isTotalQueryBound_query_bind_iff] at hqueryBound
+      obtain ⟨hremaining, hnext⟩ := hqueryBound
+      by_cases hhit : ∃ value, cache t = some value
+      · obtain ⟨value, hvalue⟩ := hhit
+        have hrun : adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R) suffix
+            ((liftM ((ι →ₒ Y).query t) :
+              OracleComp (ι →ₒ Y) _) >>= next) cache log =
+            adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R)
+              suffix (next value) cache (log ++ [⟨t, value⟩]) := by
+          simp only [adaptivePrefixRunFrom, OracleComp.run_simulateQ_query_bind,
+            cachingLoggingOracle.run_some hvalue, pure_bind]
+        rw [hrun]
+        have hlogCache' : ∀ entry ∈ log ++ [⟨t, value⟩],
+            cache entry.1 = some entry.2 := by
+          exact QueryCache.log_consistent_append cache log t value hvalue hlogCache
+        have hcacheLog' : ∀ input output, cache input = some output →
+            ∃ entry ∈ log ++ [⟨t, value⟩], entry.1 = input ∧ entry.2 = output := by
+          exact QueryCache.cache_covered_append cache log _ hcacheLog
+        have hrec := ih value (remaining := remaining - 1) (cached := cached)
+          (hnext value) (cache := cache) (log := log ++ [⟨t, value⟩])
+          hno hcacheBound hlogCache' hcacheLog'
+        refine hrec.trans ?_
+        apply mul_le_mul_of_nonneg_right
+        · exact_mod_cast adaptivePrefixPotential_hit_le
+            targetCount overhead remaining cached
+        · exact zero_le
+      · push Not at hhit
+        have hnone : cache t = none := Option.eq_none_iff_forall_ne_some.mpr hhit
+        have hrun : adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R) suffix
+            ((liftM ((ι →ₒ Y).query t) :
+              OracleComp (ι →ₒ Y) _) >>= next) cache log =
+            (liftM ((ι →ₒ Y).query t) :
+              OracleComp (ι →ₒ Y) _) >>= fun value =>
+              adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R)
+                suffix (next value) (cache.cacheQuery t value)
+                (log ++ [⟨t, value⟩]) := by
+          simp only [adaptivePrefixRunFrom, OracleComp.run_simulateQ_query_bind,
+            cachingLoggingOracle.run_none hnone]
+          rfl
+        rw [hrun]
+        have hcollision : 𝒟[(liftM ((ι →ₒ Y).query t) :
+              OracleComp (ι →ₒ Y) _)] {value | CacheHasCollision (cache.cacheQuery t value)} ≤
+              (cached : ENNReal) * C⁻¹ := by
+          classical
+          let : Fintype Y := Fintype.ofFinite Y
+          obtain ⟨keys, hkeysCard, hkeysMem⟩ := hcacheBound
+          rw [hquery, ProbabilityTheory.uniformOn_univ_apply_setOf]
+          have hbad := (OracleComp.card_responses_creating_cacheCollision_le
+            (t := t) hno hkeysMem).trans hkeysCard
+          calc
+            _ ≤ (cached : ENNReal) / Fintype.card Y :=
+              ENNReal.div_le_div_right (by exact_mod_cast hbad) _
+            _ = (cached : ENNReal) * C⁻¹ := by
+              rw [← Nat.card_eq_fintype_card, ENNReal.div_eq_inv_mul, mul_comm]
+        have hcontinuation : ∀ value,
+            ¬ CacheHasCollision (cache.cacheQuery t value) →
+            𝒟[adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R)
+                suffix (next value) (cache.cacheQuery t value)
+                (log ++ [⟨t, value⟩])] {z | win z.1} ≤
+              (adaptivePrefixPotential targetCount overhead
+                (remaining - 1) (cached + 1) : ENNReal) * C⁻¹ := by
+          intro value hno'
+          have hcacheBound' : ∃ keys : Finset ι, keys.card ≤ cached + 1 ∧
+              ∀ input, (cache.cacheQuery t value) input ≠ none → input ∈ keys := by
+            exact QueryCache.domain_bound_cacheQuery cache t value cached hcacheBound
+          have hlogCache' : ∀ entry ∈ log ++ [⟨t, value⟩],
+              (cache.cacheQuery t value) entry.1 = some entry.2 := by
+            exact QueryCache.log_consistent_cacheQuery_append cache log t value hnone hlogCache
+          have hcacheLog' : ∀ input output,
+              (cache.cacheQuery t value) input = some output →
+              ∃ entry ∈ log ++ [⟨t, value⟩], entry.1 = input ∧ entry.2 = output := by
+            exact QueryCache.cache_covered_cacheQuery_append cache log t value hcacheLog
+          have hrec := ih value (remaining := remaining - 1) (cached := cached + 1)
+            (hnext value) (cache := cache.cacheQuery t value)
+            (log := log ++ [⟨t, value⟩]) hno' hcacheBound' hlogCache' hcacheLog'
+          exact hrec
+        have hcombined := evalDist_bind_apply_le_add_of_bad
+          (mx := (liftM ((ι →ₒ Y).query t) : OracleComp (ι →ₒ Y) Y))
+          (f := fun value : Y => adaptivePrefixRunFrom
+            (ι := ι) (Y := Y) (X := X) (R := R) suffix (next value)
+            (cache.cacheQuery t value) (log ++ [⟨t, value⟩]))
+          Measurable.of_discrete (bad := {value | CacheHasCollision (cache.cacheQuery t value)})
+          MeasurableSet.of_discrete hwin hcollision (fun value hsafe => hcontinuation value hsafe)
+        refine hcombined.trans ?_
+        rw [← add_mul]
+        apply mul_le_mul_of_nonneg_right
+        · exact_mod_cast adaptivePrefixPotential_miss_le
+            targetCount overhead remaining cached hremaining
+        · exact zero_le
+
+/-- The adaptive-prefix measure bound read through the discrete probability notation. -/
 theorem probEvent_adaptivePrefixRunFrom_le
     [DecidableEq ι] [DecidableEq Y] [Finite Y] [Inhabited Y]
     [IsUniformSpec (ι →ₒ Y)]
@@ -173,172 +323,22 @@ theorem probEvent_adaptivePrefixRunFrom_le
         suffix prefixComp cache log] ≤
       (adaptivePrefixPotential targetCount overhead remaining cached : ENNReal) *
         (Nat.card Y : ENNReal)⁻¹ := by
-  let C := (Nat.card Y : ENNReal)
-  induction prefixComp using OracleComp.inductionOn generalizing remaining cached cache log with
-  | pure x =>
-      have hsuffix := hterminal x remaining cached cache log (by simpa using hbound)
-        hno hcacheBound hlogCache hcacheLog
-      simp only [adaptivePrefixRunFrom, simulateQ_pure, StateT.run_pure, pure_bind]
-      refine hsuffix.trans ?_
-      change ((targetCount cached * (remaining + overhead) : ℕ) : ENNReal) * C⁻¹ ≤
-        (adaptivePrefixPotential targetCount overhead remaining cached : ENNReal) * C⁻¹
-      gcongr
-      exact adaptivePrefixPotential_terminal_le targetCount overhead remaining cached
-  | query_bind t next ih =>
-      have hqueryBound : IsTotalQueryBound
-          ((liftM ((ι →ₒ Y).query t) : OracleComp (ι →ₒ Y) _) >>= fun u =>
-            next u >>= continuation) remaining := by
-        simpa only [bind_assoc] using hbound
-      rw [isTotalQueryBound_query_bind_iff] at hqueryBound
-      obtain ⟨hremaining, hnext⟩ := hqueryBound
-      by_cases hhit : ∃ value, cache t = some value
-      · obtain ⟨value, hvalue⟩ := hhit
-        have hrun : adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R) suffix
-            ((liftM ((ι →ₒ Y).query t) :
-              OracleComp (ι →ₒ Y) _) >>= next) cache log =
-            adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R)
-              suffix (next value) cache (log ++ [⟨t, value⟩]) := by
-          simp only [adaptivePrefixRunFrom, OracleComp.run_simulateQ_query_bind,
-            cachingLoggingOracle.run_some hvalue, pure_bind]
-        rw [hrun]
-        have hlogCache' : ∀ entry ∈ log ++ [⟨t, value⟩],
-            cache entry.1 = some entry.2 := by
-          intro entry hentry
-          rw [List.mem_append] at hentry
-          rcases hentry with hentry | hentry
-          · exact hlogCache entry hentry
-          · rw [List.mem_singleton] at hentry
-            subst entry
-            exact hvalue
-        have hcacheLog' : ∀ input output, cache input = some output →
-            ∃ entry ∈ log ++ [⟨t, value⟩], entry.1 = input ∧ entry.2 = output := by
-          intro input output hcached
-          obtain ⟨entry, hentry, hi, ho⟩ := hcacheLog input output hcached
-          exact ⟨entry, List.mem_append_left _ hentry, hi, ho⟩
-        have hrec := ih value (remaining := remaining - 1) (cached := cached)
-          (hnext value) (cache := cache) (log := log ++ [⟨t, value⟩])
-          hno hcacheBound hlogCache' hcacheLog'
-        refine hrec.trans ?_
-        apply mul_le_mul_of_nonneg_right
-        · exact_mod_cast adaptivePrefixPotential_hit_le
-            targetCount overhead remaining cached
-        · exact zero_le
-      · push Not at hhit
-        have hnone : cache t = none := Option.eq_none_iff_forall_ne_some.mpr hhit
-        have hrun : adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R) suffix
-            ((liftM ((ι →ₒ Y).query t) :
-              OracleComp (ι →ₒ Y) _) >>= next) cache log =
-            (liftM ((ι →ₒ Y).query t) :
-              OracleComp (ι →ₒ Y) _) >>= fun value =>
-              adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R)
-                suffix (next value) (cache.cacheQuery t value)
-                (log ++ [⟨t, value⟩]) := by
-          simp only [adaptivePrefixRunFrom, OracleComp.run_simulateQ_query_bind,
-            cachingLoggingOracle.run_none hnone]
-          rfl
-        rw [hrun]
-        have hcollision : Pr[fun value => CacheHasCollision (cache.cacheQuery t value) |
-            (liftM ((ι →ₒ Y).query t) :
-              OracleComp (ι →ₒ Y) _)] ≤
-              (cached : ENNReal) * C⁻¹ := by
-          classical
-          obtain ⟨keys, hkeysCard, hkeysMem⟩ := hcacheBound
-          rw [probEvent_query]
-          have hbad := (OracleComp.card_responses_creating_cacheCollision_le
-            (t := t) hno hkeysMem).trans hkeysCard
-          have hcard :
-              @Fintype.card ((ι →ₒ Y).Range t)
-                  (OracleSpec.instFintypeRangeOfFintype t) = Nat.card Y := by
-            calc
-              @Fintype.card ((ι →ₒ Y).Range t)
-                  (OracleSpec.instFintypeRangeOfFintype t) =
-                  Nat.card ((ι →ₒ Y).Range t) :=
-                    (@Nat.card_eq_fintype_card ((ι →ₒ Y).Range t)
-                      (OracleSpec.instFintypeRangeOfFintype t)).symm
-              _ = Nat.card Y := Nat.card_congr (Equiv.refl Y)
-          calc
-            ((Finset.univ.filter
-                (fun value => CacheHasCollision (cache.cacheQuery t value))).card : ENNReal) /
-                @Fintype.card ((ι →ₒ Y).Range t)
-                  (OracleSpec.instFintypeRangeOfFintype t)
-              ≤ (cached : ENNReal) /
-                  @Fintype.card ((ι →ₒ Y).Range t)
-                    (OracleSpec.instFintypeRangeOfFintype t) :=
-                ENNReal.div_le_div_right (by exact_mod_cast hbad) _
-            _ = (cached : ENNReal) * C⁻¹ := by
-              rw [hcard, ENNReal.div_eq_inv_mul, mul_comm]
-        have hcontinuation : ∀ value ∈ support
-            (liftM ((ι →ₒ Y).query t) : OracleComp (ι →ₒ Y) _),
-            ¬ CacheHasCollision (cache.cacheQuery t value) →
-            Pr[fun z => win z.1 |
-              adaptivePrefixRunFrom (ι := ι) (Y := Y) (X := X) (R := R)
-                suffix (next value) (cache.cacheQuery t value)
-                (log ++ [⟨t, value⟩])] ≤
-              (adaptivePrefixPotential targetCount overhead
-                (remaining - 1) (cached + 1) : ENNReal) * C⁻¹ := by
-          intro value _ hno'
-          have hcacheBound' : ∃ keys : Finset ι, keys.card ≤ cached + 1 ∧
-              ∀ input, (cache.cacheQuery t value) input ≠ none → input ∈ keys := by
-            obtain ⟨keys, hkeysCard, hkeysMem⟩ := hcacheBound
-            refine ⟨insert t keys, (Finset.card_insert_le t keys).trans (by omega), ?_⟩
-            intro input hinput
-            by_cases hi : input = t
-            · exact hi ▸ Finset.mem_insert_self _ _
-            · rw [QueryCache.cacheQuery_of_ne cache value hi] at hinput
-              exact Finset.mem_insert_of_mem (hkeysMem input hinput)
-          have hlogCache' : ∀ entry ∈ log ++ [⟨t, value⟩],
-              (cache.cacheQuery t value) entry.1 = some entry.2 := by
-            rintro ⟨input, output⟩ hentry
-            rw [List.mem_append] at hentry
-            rcases hentry with hentry | hentry
-            · by_cases hi : input = t
-              · subst input
-                have := hlogCache ⟨t, output⟩ hentry
-                simp [hnone] at this
-              · rw [QueryCache.cacheQuery_of_ne cache value hi]
-                exact hlogCache ⟨input, output⟩ hentry
-            · rw [List.mem_singleton] at hentry
-              have hinput : input = t := congrArg Sigma.fst hentry
-              subst input
-              have houtput : output = value := eq_of_heq (Sigma.mk.inj_iff.mp hentry).2
-              subst output
-              exact QueryCache.cacheQuery_self cache t value
-          have hcacheLog' : ∀ input output,
-              (cache.cacheQuery t value) input = some output →
-              ∃ entry ∈ log ++ [⟨t, value⟩], entry.1 = input ∧ entry.2 = output := by
-            intro input output hcached
-            by_cases hi : input = t
-            · subst input
-              rw [QueryCache.cacheQuery_self] at hcached
-              obtain rfl := Option.some.inj hcached
-              exact ⟨⟨t, value⟩, by simp, rfl, rfl⟩
-            · rw [QueryCache.cacheQuery_of_ne cache value hi] at hcached
-              obtain ⟨entry, hentry, heqInput, heqOutput⟩ :=
-                hcacheLog input output hcached
-              exact ⟨entry, List.mem_append_left _ hentry, heqInput, heqOutput⟩
-          have hrec := ih value (remaining := remaining - 1) (cached := cached + 1)
-            (hnext value) (cache := cache.cacheQuery t value)
-            (log := log ++ [⟨t, value⟩]) hno' hcacheBound' hlogCache' hcacheLog'
-          exact hrec
-        have hcombined := probEvent_bind_le_add
-          (mx := (liftM ((ι →ₒ Y).query t) :
-            OracleComp (ι →ₒ Y) _))
-          (my := fun value => adaptivePrefixRunFrom
-            (ι := ι) (Y := Y) (X := X) (R := R) suffix (next value)
-            (cache.cacheQuery t value) (log ++ [⟨t, value⟩]))
-          (p := fun value => ¬ CacheHasCollision (cache.cacheQuery t value))
-          (q := fun z => ¬ win z.1)
-          (ε₁ := (cached : ENNReal) * C⁻¹)
-          (ε₂ := (adaptivePrefixPotential targetCount overhead
-            (remaining - 1) (cached + 1) : ENNReal) * C⁻¹)
-          (by simpa [not_not] using hcollision)
-          (by simpa [not_not] using hcontinuation)
-        simp only [not_not] at hcombined
-        refine hcombined.trans ?_
-        rw [← add_mul]
-        apply mul_le_mul_of_nonneg_right
-        · exact_mod_cast adaptivePrefixPotential_miss_le
-            targetCount overhead remaining cached hremaining
-        · exact zero_le
+  classical
+  let : MeasurableSpace Y := ⊤
+  let : MeasurableSpace (R × (ι →ₒ Y).QueryCache) := ⊤
+  rw [← evalDist_apply_setOf]
+  refine measure_adaptivePrefixRunFrom_le (hquery := ?_) suffix continuation win
+    MeasurableSet.of_discrete targetCount overhead prefixComp remaining cached hbound
+    cache log hno hcacheBound hlogCache hcacheLog ?_
+  · intro t
+    let : Fintype Y := Fintype.ofFinite Y
+    apply MeasureTheory.Measure.ext_of_singleton
+    intro y
+    rw [evalDist_apply_singleton, probOutput_query, ProbabilityTheory.uniformOn_univ,
+      MeasureTheory.Measure.count_singleton, one_div]
+    simp only [← Nat.card_eq_fintype_card]
+  · intro x terminalRemaining terminalCached terminalCache terminalLog hq hn hb hl hc
+    simpa only [evalDist_apply_setOf] using
+      hterminal x terminalRemaining terminalCached terminalCache terminalLog hq hn hb hl hc
 
 end OracleComp

--- a/VCVio/OracleComp/QueryTracking/Birthday.lean
+++ b/VCVio/OracleComp/QueryTracking/Birthday.lean
@@ -286,14 +286,15 @@ theorem probEvent_logCollision_le_birthday_total {α : Type}
           exact (Nat.mul_div_le (n * (n - 1)) 2).trans (by gcongr; lia))
 
 open Classical in
-omit [spec.DecidableEq] in
+omit [spec.DecidableEq] [IsUniformSpec spec] in
 /-- At a fresh query, the number of responses that would create a cache collision is at most
 the number of keys known to be populated in the current collision-free cache.
 
 The finite set `S` need only cover the populated keys; it may be a convenient external bound
 rather than the cache's exact support. This form is intended for adaptive birthday arguments,
 where `S` grows by one after each cache miss. -/
-theorem card_responses_creating_cacheCollision_le {cache₀ : QueryCache spec} {t : spec.Domain}
+theorem card_responses_creating_cacheCollision_le [spec.Fintype]
+    {cache₀ : QueryCache spec} {t : spec.Domain}
     {S : Finset spec.Domain} (hnocoll : ¬CacheHasCollision cache₀)
     (hSmem : ∀ t', cache₀ t' ≠ none → t' ∈ S) :
     (Finset.univ.filter (fun u => CacheHasCollision (cache₀.cacheQuery t u))).card ≤ S.card := by

--- a/VCVio/OracleComp/QueryTracking/CachingLoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CachingLoggingOracle.lean
@@ -249,3 +249,69 @@ theorem isPerIndexQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
     (cachingOracle.isPerIndexQueryBound_run_simulateQ h s.1)
 
 end cachingLoggingOracle
+
+/-! ## Cache and log coherence -/
+
+namespace OracleSpec.QueryCache
+variable {ι Y : Type}
+/-- Appending a response already present in the cache preserves log consistency. -/
+theorem log_consistent_append (cache : (ι →ₒ Y).QueryCache) (log : (ι →ₒ Y).QueryLog)
+    (t : ι) (value : Y) (hlookup : cache t = some value)
+    (hlog : ∀ entry ∈ log, cache entry.1 = some entry.2) :
+    ∀ entry ∈ log ++ [⟨t, value⟩], cache entry.1 = some entry.2 := by
+  intro entry hentry
+  rcases List.mem_append.mp hentry with hentry | hentry
+  · exact hlog entry hentry
+  · obtain rfl := List.mem_singleton.mp hentry
+    exact hlookup
+
+/-- Caching a fresh response and appending it preserves log consistency. -/
+theorem log_consistent_cacheQuery_append [DecidableEq ι] (cache : (ι →ₒ Y).QueryCache)
+    (log : (ι →ₒ Y).QueryLog) (t : ι) (value : Y) (hnone : cache t = none)
+    (hlog : ∀ entry ∈ log, cache entry.1 = some entry.2) :
+    ∀ entry ∈ log ++ [⟨t, value⟩], (cache.cacheQuery t value) entry.1 = some entry.2 := by
+  apply log_consistent_append _ _ t value (cacheQuery_self ..)
+  intro entry hentry
+  exact le_cacheQuery cache hnone (hlog entry hentry)
+
+/-- Appending entries preserves coverage of every cached response by the log. -/
+theorem cache_covered_append (cache : (ι →ₒ Y).QueryCache)
+    (log extra : (ι →ₒ Y).QueryLog)
+    (hlog : ∀ input output, cache input = some output →
+      ∃ entry ∈ log, entry.1 = input ∧ entry.2 = output) :
+    ∀ input output, cache input = some output →
+      ∃ entry ∈ log ++ extra, entry.1 = input ∧ entry.2 = output := by
+  intro input output hcached
+  obtain ⟨entry, hentry, hi, ho⟩ := hlog input output hcached
+  exact ⟨entry, List.mem_append_left _ hentry, hi, ho⟩
+
+/-- The extended log covers every response in an updated cache. -/
+theorem cache_covered_cacheQuery_append [DecidableEq ι] (cache : (ι →ₒ Y).QueryCache)
+    (log : (ι →ₒ Y).QueryLog) (t : ι) (value : Y)
+    (hlog : ∀ input output, cache input = some output →
+      ∃ entry ∈ log, entry.1 = input ∧ entry.2 = output) :
+    ∀ input output, (cache.cacheQuery t value) input = some output →
+      ∃ entry ∈ log ++ [⟨t, value⟩], entry.1 = input ∧ entry.2 = output := by
+  intro input output hcached
+  by_cases hi : input = t
+  · subst input
+    rw [cacheQuery_self] at hcached
+    obtain rfl := Option.some.inj hcached
+    exact ⟨⟨t, value⟩, by simp, rfl, rfl⟩
+  · rw [cacheQuery_of_ne cache value hi] at hcached
+    exact cache_covered_append cache log _ hlog input output hcached
+
+/-- Inserting one response increases a finite cache-domain bound by at most one. -/
+theorem domain_bound_cacheQuery [DecidableEq ι] (cache : (ι →ₒ Y).QueryCache) (t : ι) (value : Y)
+    (bound : ℕ) (hbound : ∃ keys : Finset ι, keys.card ≤ bound ∧
+      ∀ input, cache input ≠ none → input ∈ keys) :
+    ∃ keys : Finset ι, keys.card ≤ bound + 1 ∧
+      ∀ input, (cache.cacheQuery t value) input ≠ none → input ∈ keys := by
+  obtain ⟨keys, hcard, hmem⟩ := hbound
+  refine ⟨insert t keys, (Finset.card_insert_le t keys).trans (by omega), ?_⟩
+  intro input hinput
+  by_cases hi : input = t
+  · exact hi ▸ Finset.mem_insert_self _ _
+  · rw [cacheQuery_of_ne cache value hi] at hinput
+    exact Finset.mem_insert_of_mem (hmem input hinput)
+end OracleSpec.QueryCache

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -22,6 +22,7 @@ public import VCVioTest.MerkleTreeExtractability
 public import VCVioTest.MerkleTreeMonadic
 public import VCVioTest.MerkleTreeMultiExtractability
 public import VCVioTest.MonadProbability
+public import VCVioTest.OracleComp.AdaptiveMeasure
 public import VCVioTest.OracleComp.PreservesInv
 public import VCVioTest.OracleComp.SecurityFamily
 public import VCVioTest.PFunctorFacade

--- a/VCVioTest/OracleComp/AdaptiveMeasure.lean
+++ b/VCVioTest/OracleComp/AdaptiveMeasure.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.CryptoFoundations.MerkleTree.MultiExtractability.OnlineBound
+public import VCVio.EvalDist.PFunctorMeasure.Core
+
+/-!
+# Structural cache coherence and measure-based stopping bounds
+
+Repeated hits retain log consistency without equality on response values. A direct
+uniform measure interpretation supplies the query law of the stopping bounds.
+The dependency check traverses theorem types and proofs, including definitions,
+to prevent the measure inductions from using discrete probability facts indirectly.
+-/
+
+public section
+
+open OracleSpec OracleComp MeasureTheory
+
+run_cmd do
+  let env ← Lean.getEnv
+  let mut pending := [``OracleComp.measure_adaptivePrefixRunFrom_le,
+    ``MerkleTreeMultiExtractability.measure_onlineAdaptivePrefixRunFrom_logged_le]
+  let mut visited : Std.HashSet Lean.Name := {}
+  while let name :: rest := pending do
+    pending := rest
+    unless visited.contains name do
+      visited := visited.insert name
+      for forbidden in [`PMF, `SPMF, `evalSPMF, `probEvent, `probOutput, `expectedValue] do
+        if forbidden.isPrefixOf name then
+          throwError "measure induction depends on the discrete probability declaration {name}"
+      if let some info := env.find? name then
+        pending := info.getUsedConstantsAsSet.toList ++ pending
+
+namespace VCVioTest.AdaptiveMeasure
+
+example {Y : Type} (value : Y) :
+    ∀ entry ∈ ([⟨0, value⟩, ⟨0, value⟩] : (ℕ →ₒ Y).QueryLog),
+      ((∅ : (ℕ →ₒ Y).QueryCache).cacheQuery 0 value) entry.1 = some entry.2 := by
+  have hfirst := QueryCache.log_consistent_cacheQuery_append
+    (∅ : (ℕ →ₒ Y).QueryCache) [] 0 value rfl (by simp)
+  exact QueryCache.log_consistent_append _ [⟨0, value⟩] 0 value
+    (QueryCache.cacheQuery_self ..) hfirst
+
+example {Y : Type} (value : Y) :
+    ∃ keys : Finset ℕ, keys.card ≤ 1 ∧ ∀ input,
+      ((∅ : (ℕ →ₒ Y).QueryCache).cacheQuery 7 value) input ≠ none → input ∈ keys := by
+  exact QueryCache.domain_bound_cacheQuery ∅ 7 value 0 ⟨∅, by simp, by simp⟩
+
+noncomputable local instance : (ℕ →ₒ Bool).toPFunctor.IsMeasureSpec :=
+  PFunctor.IsMeasureSpec.uniformOfFintypeInhabited _
+
+example (t : ℕ) : 𝒟[(liftM ((ℕ →ₒ Bool).query t) : OracleComp (ℕ →ₒ Bool) Bool)] =
+    ProbabilityTheory.uniformOn Set.univ := by
+  exact PFunctor.FreeM.evalDist_lift (P := (ℕ →ₒ Bool).toPFunctor) t
+
+end VCVioTest.AdaptiveMeasure

--- a/docs/agents/query-tracking.md
+++ b/docs/agents/query-tracking.md
@@ -19,6 +19,18 @@ stopping-time argument used when an adaptive prefix and a transcript-dependent s
 lazy random function. Protocol-specific files should instantiate this theorem rather than copy its
 cache/log induction.
 
+`measure_adaptivePrefixRunFrom_le` proves this bound for any lawful measure semantics with
+uniform query measures and a measurable terminal event. Its proof uses a bad-event decomposition
+of a Lebesgue integral. The original `probEvent_adaptivePrefixRunFrom_le` is a compatibility
+corollary. The online-target counterpart is
+`MerkleTreeMultiExtractability.measure_onlineAdaptivePrefixRunFrom_logged_le`; its target set
+is evaluated on the pre-query log.
+
+The structural `QueryCache.log_consistent_append`, `log_consistent_cacheQuery_append`,
+`cache_covered_append`, `cache_covered_cacheQuery_append`, and `domain_bound_cacheQuery` lemmas
+in `CachingLoggingOracle.lean` transport cache/log hypotheses without probability assumptions
+or decidable equality on responses.
+
 ## Main Files
 
 | File | Role |


### PR DESCRIPTION
Adaptive shared-random-oracle bounds previously combined cache/log bookkeeping with discrete event-probability reasoning. This change gives both the fixed-target and predictable-target stopping bounds a measure-based proof core, with the existing probability statements retained as compatibility wrappers.

- Extract five probability-free cache/log extension lemmas and use them in both inductions.
- Add a subprobability bind bound that charges a bad intermediate event separately, plus a finite uniform-measure counting equation.
- Express query distributions explicitly as uniform measures; the new cores need neither `IsUniformSpec` nor inhabited responses.
- Check transitive dependencies of both theorem statements and proofs to prevent PMF/SPMF, point-probability, event-probability, or legacy expectation dependencies. Include native measure-query and structural cache regression examples.

Validation: `./scripts/validate.sh --lint --test --axioms` passed, including all seven proof libraries, test libraries/executables, environment linters, and no new axiom/sorry taint. The PMF boundary ceiling and ratchet checks also passed.

Stacked on #687; this PR contains the adaptive-bound stage of the measure-first long-proof refactoring plan.
