### PR TITLE
refactor(PRFTagReader): share measure-based table and observation proofs

### DIFF
--- a/Examples/PRFTagReader/DirectCoupling.lean
+++ b/Examples/PRFTagReader/DirectCoupling.lean
@@ -50,7 +50,7 @@ underlying facts in the explicit shape used by the direct coupling argument.
 
 @[expose] public section
 
-open OracleComp OracleSpec ENNReal
+open OracleComp OracleSpec ENNReal MeasureTheory ProbabilityTheory
 
 namespace PRFTagReader
 
@@ -117,16 +117,33 @@ distribution on multiple-session tables.
 This is the foundational marginalization step of the direct M_ideal/S_ideal coupling: the
 reference-slot cells of `gS` are themselves jointly uniform and independent of the off-slot
 cells, so the multiple-session sub-table is uniform whenever the single-session full table is. -/
+lemma evalDist_slotZeroSubTable_uniformSample
+    [Fintype TagId] [DecidableEq TagId]
+    [Fintype Nonce] [DecidableEq Nonce]
+    [Finite Digest] [Nonempty Digest] [SampleableType Digest]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    (hSmall : 𝒟[$ᵗ (TagId × Nonce → Digest)] = uniformOn Set.univ)
+    (hLarge : 𝒟[$ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)] = uniformOn Set.univ) :
+    𝒟[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>=
+        fun gS => pure (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS)] =
+      𝒟[$ᵗ (TagId × Nonce → Digest)] := by
+  rw [bind_pure_comp]
+  exact evalDist_map_table_comp_injective _ _ hSmall hLarge
+    (slotZeroEmbed_injective (TagId := TagId) (Nonce := Nonce)
+      (sessionsPerTag := sessionsPerTag))
+
+/-- Discrete frontend form of uniform slot-zero restriction. -/
 lemma evalSPMF_slotZeroSubTable_uniformSample
     [Fintype TagId] [DecidableEq TagId]
     [Fintype Nonce] [DecidableEq Nonce]
     [Finite Digest] [Nonempty Digest] [SampleableType Digest] :
     𝒮[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>=
         fun gS => pure (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS)] =
-      𝒮[$ᵗ (TagId × Nonce → Digest)] :=
-  evalSPMF_uniformSample_map_comp_injective (R := Digest)
-    (slotZeroEmbed_injective (TagId := TagId) (Nonce := Nonce)
-      (sessionsPerTag := sessionsPerTag))
+      𝒮[$ᵗ (TagId × Nonce → Digest)] := by
+  let : MeasurableSpace Digest := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_slotZeroSubTable_uniformSample evalDist_uniformSample evalDist_uniformSample
 
 /-! ### Reader-side cell inclusion under the embedding -/
 

--- a/Examples/PRFTagReader/DirectCoupling/Compose.lean
+++ b/Examples/PRFTagReader/DirectCoupling/Compose.lean
@@ -79,7 +79,7 @@ packaging) are thin compositions.
 
 @[expose] public section
 
-open OracleComp OracleSpec ENNReal
+open OracleComp OracleSpec ENNReal MeasureTheory ProbabilityTheory
 
 namespace PRFTagReader
 
@@ -396,39 +396,10 @@ theorem multipleIdeal_le_singleIdeal_add_bad_DC [Fintype Nonce] [Fintype Digest]
               (OracleComp.tableExtending
                 (∅ : ((TagId × Nonce) →ₒ Digest).QueryCache) gM)) adversary).run
               (UnlinkState.init, UnlinkBadState.init)] := by
-    rw [probOutput_def, probOutput_def]
-    have hlhs : (simulateQ (multipleBadQueryImpl (TagId := TagId) (Nonce := Nonce)
-          (Digest := Digest) (sessionsPerTag := sessionsPerTag)) adversary).run'
-          ((UnlinkState.init, (∅ : ((TagId × Nonce) →ₒ Digest).QueryCache)),
-            UnlinkBadState.init) =
-        (fun w : Bool × UnlinkBadState TagId Nonce Digest => w.1) <$>
-          ((fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag =>
-              (z.1, z.2.2)) <$>
-            (simulateQ (multipleBadQueryImpl (TagId := TagId) (Nonce := Nonce)
-              (Digest := Digest) (sessionsPerTag := sessionsPerTag)) adversary).run
-              ((UnlinkState.init, (∅ : ((TagId × Nonce) →ₒ Digest).QueryCache)),
-                UnlinkBadState.init)) := by
-      rw [Functor.map_map]; rfl
-    have hrhs : (do
-        let gM ← $ᵗ (TagId × Nonce → Digest)
-        (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) <$>
-          (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-            (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-            (OracleComp.tableExtending
-              (∅ : ((TagId × Nonce) →ₒ Digest).QueryCache) gM)) adversary).run
-            (UnlinkState.init, UnlinkBadState.init)) =
-        (fun w : Bool × UnlinkBadState TagId Nonce Digest => w.1) <$>
-          (do
-            let gM ← $ᵗ (TagId × Nonce → Digest)
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                (z.1, z.2.2)) <$>
-              (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (OracleComp.tableExtending
-                  (∅ : ((TagId × Nonce) →ₒ Digest).QueryCache) gM)) adversary).run
-                (UnlinkState.init, UnlinkBadState.init)) := by
-      simp only [map_bind, Functor.map_map]
-    rw [hlhs, hrhs, evalSPMF_map, evalSPMF_map, ← evalSPMF_map, hM, evalSPMF_map]
+    apply probOutput_congr rfl
+    have h := congrArg (fun d => (fun w : Bool × UnlinkBadState TagId Nonce Digest => w.1) <$> d) hM
+    simpa only [StateT.run'_eq, ← evalSPMF_map, Functor.map_map, map_bind,
+      Function.comp_def] using h
   -- M-side bad-term rewrite: factor `z.2.2.bad = (z.2.bad) ∘ (z.1, z.2.2)` and apply `hM`.
   have hMbad :
       Pr[fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag => z.2.2.bad |
@@ -468,17 +439,19 @@ theorem multipleIdeal_le_singleIdeal_add_bad_DC [Fintype Nonce] [Fintype Digest]
       𝒮[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>=
             fun gS => F (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS)] := by
     intro X F
-    have hSZ :
-        𝒮[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>=
-              fun gS => pure (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS)]
-        = 𝒮[($ᵗ (TagId × Nonce → Digest))] :=
-      evalSPMF_slotZeroSubTable_uniformSample
+    let : MeasurableSpace Digest := ⊤
+    let : MeasurableSpace X := ⊤
+    apply evalSPMF_eq_of_evalDist_eq
+    have hSZ := evalDist_slotZeroSubTable_uniformSample
+      (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+      (sessionsPerTag := sessionsPerTag)
+      evalDist_uniformSample evalDist_uniformSample
     have hR : (($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>=
             fun gS => F (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS))
         = (($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>=
             fun gS => pure (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS)) >>= F := by
       simp
-    rw [hR, evalSPMF_bind, evalSPMF_bind, hSZ]
+    rw [hR, evalDist_bind_of_discrete _ F, evalDist_bind_of_discrete _ F, hSZ]
   -- M-success bridge.
   have hbridge_succ :
       Pr[= true | do
@@ -556,51 +529,11 @@ theorem multipleIdeal_le_singleIdeal_add_bad_DC [Fintype Nonce] [Fintype Digest]
               (Digest := Digest) (sessionsPerTag := sessionsPerTag)
               (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS) gFine) adversary).run
                 (UnlinkState.init, UnlinkBadState.init)] := by
-    -- `Pr[= true | oa] = probOutput oa true`. We convert to `probEvent (· = true)` via
-    -- `probEvent_eq_eq_probOutput`, then use `probEvent_bind_congr'`.
     rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
-    refine probEvent_bind_congr' _ _ ?_
-    intro gS
-    -- Per-gS: Pr[(b = true) | (z.1) <$> coarse.run] = Pr[(b = true) | gFine←$ᵗ; (z.1) <$> Fine.run]
-    -- Push (z.1) into the inner gFine bind on the Fine side, then apply `probEvent_map` on
-    -- both sides to expose `(z.1 = true)` as a precomposition.
-    rw [probEvent_map]
-    have hrhs :
-        (do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) <$>
-              (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS) gFine) adversary).run
-                  (UnlinkState.init, UnlinkBadState.init))
-        = (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) <$>
-          (do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS) gFine) adversary).run
-                  (UnlinkState.init, UnlinkBadState.init)) := by rw [map_bind]
-    rw [hrhs, probEvent_map]
-    -- Bridge via hFineEq: replace `coarse.run` with `π <$> (gFine←$ᵗ; Fine.run)`.
-    have hbridge :
-        Pr[(fun b : Bool => b = true) ∘
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) |
-            (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-              (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-              (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS)) adversary).run
-                (UnlinkState.init, UnlinkBadState.init)] =
-        Pr[(fun b : Bool => b = true) ∘
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) |
-            (fun z => (z.1, z.2.1, {z.2.2 with cacheBad :=
-                (UnlinkBadState.init : UnlinkBadState TagId Nonce Digest).cacheBad})) <$>
-              (do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS) gFine) adversary).run
-                      (UnlinkState.init, UnlinkBadState.init))] := by
-      rw [probEvent_def, probEvent_def, ← hFineEq gS]
-    rw [hbridge, probEvent_map]
-    -- Goal: Pr[(b=true) ∘ z.1 ∘ π | gFine←$ᵗ; Fine] = Pr[(b=true) ∘ z.1 | gFine←$ᵗ; Fine].
-    -- (b=true) ∘ z.1 ∘ π = (b=true) ∘ z.1 pointwise (π preserves .1).
-    exact probEvent_congr' (fun _ _ => Iff.rfl) rfl
+    refine probEvent_bind_congr' _ _ fun gS => ?_
+    have h := probEvent_congr' (p := fun z => z.1 = true)
+      (fun _ _ => Iff.rfl) (hFineEq gS).symm
+    simpa only [← map_bind, probEvent_map, Function.comp_def] using h
   -- Apply the Fine bridge to the bad term. The bad event factors through π (cacheBad ≠ bad).
   -- Strategy: use `probEvent_bind_congr'` to reduce to a per-gS equality, then push the
   -- `(z.1, z.2.2)` map through `probEvent_map` to expose the `z.2.2.bad` predicate, then
@@ -623,59 +556,10 @@ theorem multipleIdeal_le_singleIdeal_add_bad_DC [Fintype Nonce] [Fintype Digest]
               (Digest := Digest) (sessionsPerTag := sessionsPerTag)
               (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS) gFine) adversary).run
                 (UnlinkState.init, UnlinkBadState.init)] := by
-    refine probEvent_bind_congr' _ _ ?_
-    intro gS
-    -- Per-gS goal:
-    --   Pr[bad | (z.1, z.2.2) <$> coarse.run]
-    --   = Pr[bad | gFine←$ᵗ; (z.1, z.2.2) <$> Fine.run]
-    -- Push the (z.1, z.2.2) map through `probEvent_map`:
-    rw [probEvent_map]
-    -- LHS now: Pr[bad ∘ (z.1, z.2.2) | coarse.run] = Pr[z.2.2.bad | coarse.run].
-    -- For the RHS, push the (z.1, z.2.2) map into the inner bind:
-    have hrhs :
-        (do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                (z.1, z.2.2)) <$>
-              (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS) gFine) adversary).run
-                  (UnlinkState.init, UnlinkBadState.init))
-        = (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-            (z.1, z.2.2)) <$>
-          (do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS) gFine) adversary).run
-                  (UnlinkState.init, UnlinkBadState.init)) := by rw [map_bind]
-    rw [hrhs, probEvent_map]
-    -- Goal:
-    --   Pr[bad ∘ (z.1, z.2.2) | coarse.run] = Pr[bad ∘ (z.1, z.2.2) | gFine←$ᵗ; Fine.run]
-    -- which is Pr[z.2.2.bad | coarse.run] = Pr[z.2.2.bad | gFine←$ᵗ; Fine.run]. Express this
-    -- via hFineEq: 𝒮[π <$> (gFine←$ᵗ; Fine.run)] = 𝒮[coarse.run]; the bad predicate is
-    -- π-invariant.
-    have hLHS_via_bridge :
-        Pr[(fun z : Bool × UnlinkBadState TagId Nonce Digest => z.2.bad = true) ∘
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                (z.1, z.2.2)) |
-            (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-              (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-              (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS)) adversary).run
-                (UnlinkState.init, UnlinkBadState.init)] =
-        Pr[(fun z : Bool × UnlinkBadState TagId Nonce Digest => z.2.bad = true) ∘
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                (z.1, z.2.2)) |
-            (fun z => (z.1, z.2.1, {z.2.2 with cacheBad :=
-                (UnlinkBadState.init : UnlinkBadState TagId Nonce Digest).cacheBad})) <$>
-              (do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag) gS) gFine) adversary).run
-                      (UnlinkState.init, UnlinkBadState.init))] := by
-      rw [probEvent_def, probEvent_def, ← hFineEq gS]
-    rw [hLHS_via_bridge, probEvent_map]
-    -- Goal: Pr[(bad ∘ (z.1, z.2.2)) ∘ π | gFine←$ᵗ; Fine] = Pr[bad ∘ (z.1, z.2.2) | gFine←$ᵗ; Fine]
-    -- Both events agree pointwise (π only changes cacheBad; the event reads only `.2.bad`).
-    exact probEvent_congr' (fun _ _ => Iff.rfl) rfl
+    refine probEvent_bind_congr' _ _ fun gS => ?_
+    have h := probEvent_congr' (p := fun z => z.2.2.bad = true)
+      (fun _ _ => Iff.rfl) (hFineEq gS).symm
+    simpa only [← map_bind, probEvent_map, Function.comp_def] using h
   rw [hsucc_fine, hbad_fine]
   -- **Step 5.** Apply the DC aux at `c = ∅`, `s = UnlinkState.init`, `sB = UnlinkBadState.init`.
   have haux := multipleBadEager_le_singleEager_DC_aux (sessionsPerTag := sessionsPerTag)

--- a/Examples/PRFTagReader/DirectCoupling/ReaderCase.lean
+++ b/Examples/PRFTagReader/DirectCoupling/ReaderCase.lean
@@ -192,21 +192,22 @@ lemma dcAux_reader_step [Fintype Nonce] [Fintype Digest]
     singleTableHandler_reader_run (OracleComp.tableExtending c gS) transcript s
   -- Collapse the head reader query on all three positions.
   simp only [multipleBadTableFine_run_query_bind', singleTable_run'_query_bind', map_bind]
-  have hLHS_eq :
+  have hM_eq {α : Type}
+      (observe : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) → α) :
       (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let p ← multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
             (Digest := Digest) (sessionsPerTag := sessionsPerTag)
             (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
               (OracleComp.tableExtending c gS)) gFine (Sum.inr transcript) (s, sB)
-          (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) <$>
+          observe <$>
             (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
               (Digest := Digest) (sessionsPerTag := sessionsPerTag)
               (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
                 (OracleComp.tableExtending c gS)) gFine) (k p.1)).run p.2)
       = (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
             let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) <$>
+            observe <$>
               (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
                 (Digest := Digest) (sessionsPerTag := sessionsPerTag)
                 (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
@@ -217,6 +218,7 @@ lemma dcAux_reader_step [Fintype Nonce] [Fintype Digest]
     refine bind_congr fun gS => ?_
     refine bind_congr fun gFine => ?_
     rw [hMstep gS gFine]; rfl
+  have hLHS_eq := hM_eq (fun z => z.1)
   have hRHS_eq :
       (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let p ← singleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
@@ -231,33 +233,7 @@ lemma dcAux_reader_step [Fintype Nonce] [Fintype Digest]
               (k (ReaderReply.ofBool (sAcc gS)))).run' s) := by
     refine bind_congr fun gS => ?_
     rw [hSstep gS]; rfl
-  have hBAD_eq :
-      (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-          let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-          let p ← multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-            (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-            (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-              (OracleComp.tableExtending c gS)) gFine (Sum.inr transcript) (s, sB)
-          (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-              (z.1, z.2.2)) <$>
-            (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-              (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-              (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                (OracleComp.tableExtending c gS)) gFine) (k p.1)).run p.2)
-      = (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                (z.1, z.2.2)) <$>
-              (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                  (OracleComp.tableExtending c gS)) gFine)
-                (k (ReaderReply.ofBool (mAcc gS)))).run
-                (s, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
-                  gFine transcript sB)) := by
-    refine bind_congr fun gS => ?_
-    refine bind_congr fun gFine => ?_
-    rw [hMstep gS gFine]; rfl
+  have hBAD_eq := hM_eq (fun z => (z.1, z.2.2))
   rw [probOutput_congr rfl (congrArg evalSPMF hLHS_eq),
       probOutput_congr rfl (congrArg evalSPMF hRHS_eq),
       probEvent_congr' (fun _ _ => Iff.rfl) (congrArg evalSPMF hBAD_eq)]
@@ -272,10 +248,11 @@ lemma dcAux_reader_step [Fintype Nonce] [Fintype Digest]
   -- `$ᵗ gS >>= fun gS => Mψ (tableExtending c gS)` for the continuations below; the
   -- lazification lemma rewrites `tableExtending c gS` to `idealCacheMapM cells c >>= …`.
   -- LHS continuation: absorbs the inner `$ᵗ gFine` binder.
-  have hLHS_lazify :
-      𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
+  have hM_lazify {α : Type} [MeasurableSpace α]
+      (observe : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) → α) :
+      𝒟[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
             let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) <$>
+            observe <$>
               (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
                 (Digest := Digest) (sessionsPerTag := sessionsPerTag)
                 (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
@@ -283,11 +260,10 @@ lemma dcAux_reader_step [Fintype Nonce] [Fintype Digest]
                 (k (ReaderReply.ofBool (mAcc gS)))).run
                 (s, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
                   gFine transcript sB))]
-      = 𝒮[(do let rs ← idealCacheMapM (Digest := Digest) cells c
+      = 𝒟[(do let rs ← idealCacheMapM (Digest := Digest) cells c
               let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
               let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  z.1) <$>
+              observe <$>
                 (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
                   (Digest := Digest) (sessionsPerTag := sessionsPerTag)
                   (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
@@ -298,11 +274,13 @@ lemma dcAux_reader_step [Fintype Nonce] [Fintype Digest]
                     (multiplePattern (TagId := TagId) sessionsPerTag) transcript)))).run
                   (s, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
                     gFine transcript sB))] := by
+    let : MeasurableSpace Digest := ⊤
     rw [hmAcc]
-    exact (evalSPMF_idealCacheMapM_bind_uniformTable_comp cells c
+    exact (evalDist_idealCacheMapM_bind_uniformTable_comp
+      evalDist_uniformSample evalDist_uniformSample cells c
       (fun T => do
         let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-        (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) => z.1) <$>
+        observe <$>
           (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
             (Digest := Digest) (sessionsPerTag := sessionsPerTag)
             (slotZeroSubTable (sessionsPerTag := sessionsPerTag) T) gFine)
@@ -312,6 +290,7 @@ lemma dcAux_reader_step [Fintype Nonce] [Fintype Digest]
               (multiplePattern (TagId := TagId) sessionsPerTag) transcript)))).run
             (s, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
               gFine transcript sB))).symm
+  have hLHS_lazify := evalSPMF_eq_of_evalDist_eq _ _ (hM_lazify (fun z => z.1))
   -- RHS continuation (no `gFine`).
   have hRHS_lazify :
       𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
@@ -327,56 +306,19 @@ lemma dcAux_reader_step [Fintype Nonce] [Fintype Digest]
                   (Slot := TagId × Fin sessionsPerTag)
                   (fun slot nonce => OracleComp.tableExtending rs.2 gS (slot, nonce))
                   (singlePattern (TagId := TagId) sessionsPerTag) transcript)))).run' s)] := by
+    let : MeasurableSpace Digest := ⊤
+    apply evalSPMF_eq_of_evalDist_eq
     rw [hsAcc]
-    exact (evalSPMF_idealCacheMapM_bind_uniformTable_comp cells c
+    exact (evalDist_idealCacheMapM_bind_uniformTable_comp
+      evalDist_uniformSample evalDist_uniformSample cells c
       (fun T => (simulateQ (singleTableHandler (TagId := TagId) (Nonce := Nonce)
         (Digest := Digest) (sessionsPerTag := sessionsPerTag) T)
         (k (ReaderReply.ofBool (unlinkReaderAccepts (Slot := TagId × Fin sessionsPerTag)
           (fun slot nonce => T (slot, nonce))
           (singlePattern (TagId := TagId) sessionsPerTag) transcript)))).run' s)).symm
   -- BAD continuation: same as LHS but with the `(z.1, z.2.2)` projection.
-  have hBAD_lazify :
-      𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                (z.1, z.2.2)) <$>
-              (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                  (OracleComp.tableExtending c gS)) gFine)
-                (k (ReaderReply.ofBool (mAcc gS)))).run
-                (s, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
-                  gFine transcript sB))]
-      = 𝒮[(do let rs ← idealCacheMapM (Digest := Digest) cells c
-              let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  (z.1, z.2.2)) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending rs.2 gS)) gFine)
-                  (k (ReaderReply.ofBool (unlinkReaderAccepts (Slot := TagId)
-                    (fun tag nonce => slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending rs.2 gS) (tag, nonce))
-                    (multiplePattern (TagId := TagId) sessionsPerTag) transcript)))).run
-                  (s, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
-                    gFine transcript sB))] := by
-    rw [hmAcc]
-    exact (evalSPMF_idealCacheMapM_bind_uniformTable_comp cells c
-      (fun T => do
-        let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-        (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-            (z.1, z.2.2)) <$>
-          (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-            (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-            (slotZeroSubTable (sessionsPerTag := sessionsPerTag) T) gFine)
-            (k (ReaderReply.ofBool (unlinkReaderAccepts (Slot := TagId)
-              (fun tag nonce => slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                T (tag, nonce))
-              (multiplePattern (TagId := TagId) sessionsPerTag) transcript)))).run
-            (s, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
-              gFine transcript sB))).symm
+  let : MeasurableSpace (Bool × UnlinkBadState TagId Nonce Digest) := ⊤
+  have hBAD_lazify := evalSPMF_eq_of_evalDist_eq _ _ (hM_lazify (fun z => (z.1, z.2.2)))
   -- Rewrite all three terms to their lazified forms.
   rw [probOutput_congr rfl hLHS_lazify, probOutput_congr rfl hRHS_lazify,
       probEvent_congr' (fun _ _ => Iff.rfl) hBAD_lazify]

--- a/Examples/PRFTagReader/DirectCoupling/Swap.lean
+++ b/Examples/PRFTagReader/DirectCoupling/Swap.lean
@@ -35,7 +35,7 @@ distribution over a uniform table draw.
 
 @[expose] public section
 
-open OracleComp OracleSpec ENNReal
+open OracleComp OracleSpec ENNReal MeasureTheory ProbabilityTheory
 
 namespace PRFTagReader
 
@@ -113,11 +113,14 @@ post-composing with `cellSwap a b` (which is a bijection on the domain) yields t
 distribution as drawing `gS` directly. The key measure-preserving step underlying the
 swap-bridge: averaging any continuation `F` over a uniform `gS` is invariant under
 `gS ↦ gS ∘ cellSwap a b`. -/
-lemma evalSPMF_uniformSample_comp_cellSwap [Fintype Nonce]
+lemma evalDist_uniformSample_comp_cellSwap [Fintype Nonce]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    (hTable : 𝒟[$ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)] = uniformOn Set.univ)
     (a b : (TagId × Fin sessionsPerTag) × Nonce) :
-    𝒮[(fun gS : (TagId × Fin sessionsPerTag) × Nonce → Digest =>
+    𝒟[(fun gS : (TagId × Fin sessionsPerTag) × Nonce → Digest =>
         gS ∘ cellSwap a b) <$> ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest))] =
-      𝒮[$ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)] := by
+      𝒟[$ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)] := by
   classical
   -- `g ↦ g ∘ cellSwap a b` is a bijection on `(D → R)`: its inverse is `g ↦ g ∘ cellSwap a b`
   -- (since cellSwap is an involution).
@@ -133,21 +136,33 @@ lemma evalSPMF_uniformSample_comp_cellSwap [Fintype Nonce]
       refine ⟨h ∘ cellSwap a b, ?_⟩
       funext x
       simp [Function.comp, cellSwap_involution]
-  exact evalSPMF_map_bijective_uniform_cross
-    (α := (TagId × Fin sessionsPerTag) × Nonce → Digest)
-    (β := (TagId × Fin sessionsPerTag) × Nonce → Digest)
-    (fun gS => gS ∘ cellSwap a b) hbij
+  rw [evalDist_map_of_discrete, hTable]
+  exact uniformOn_univ_map_equiv (Equiv.ofBijective _ hbij)
+
+omit [Nonempty TagId] [SampleableType Nonce] [DecidableEq Digest] [NeZero sessionsPerTag] in
+/-- Discrete frontend form of the measure-preserving table permutation. -/
+lemma evalSPMF_uniformSample_comp_cellSwap [Fintype Nonce]
+    (a b : (TagId × Fin sessionsPerTag) × Nonce) :
+    𝒮[(fun gS : (TagId × Fin sessionsPerTag) × Nonce → Digest =>
+        gS ∘ cellSwap a b) <$> ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest))] =
+      𝒮[$ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)] := by
+  let : MeasurableSpace Digest := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_uniformSample_comp_cellSwap evalDist_uniformSample a b
 
 omit [Nonempty TagId] [SampleableType Nonce] [DecidableEq Digest] [NeZero sessionsPerTag] in
 /-- **Bind-level measure-preservation via `cellSwap`.** For any continuation
 `F : (table) → ProbComp α`, drawing a uniform `gS` and applying `F` to `gS` has the same
 distribution as drawing a uniform `gS` and applying `F` to `gS ∘ cellSwap a b`. Direct
 consequence of `evalSPMF_uniformSample_comp_cellSwap` combined with `map_bind`. -/
-lemma evalSPMF_uniformSample_bind_cellSwap [Fintype Nonce]
-    {α : Type} (a b : (TagId × Fin sessionsPerTag) × Nonce)
+lemma evalDist_uniformSample_bind_cellSwap [Fintype Nonce]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    (hTable : 𝒟[$ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)] = uniformOn Set.univ)
+    {α : Type} [MeasurableSpace α] (a b : (TagId × Fin sessionsPerTag) × Nonce)
     (F : ((TagId × Fin sessionsPerTag) × Nonce → Digest) → ProbComp α) :
-    𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest); F gS)] =
-      𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest);
+    𝒟[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest); F gS)] =
+      𝒟[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest);
             F (gS ∘ cellSwap a b))] := by
   classical
   have hMapBind :
@@ -156,9 +171,22 @@ lemma evalSPMF_uniformSample_bind_cellSwap [Fintype Nonce]
       (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest);
           F (gS ∘ cellSwap a b)) := by
     simp [map_eq_bind_pure_comp, bind_assoc, Function.comp]
-  rw [← hMapBind, evalSPMF_bind, evalSPMF_bind,
-      evalSPMF_uniformSample_comp_cellSwap (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
-        (sessionsPerTag := sessionsPerTag) a b]
+  rw [← hMapBind, evalDist_bind_of_discrete _ F, evalDist_bind_of_discrete _ F,
+      evalDist_uniformSample_comp_cellSwap (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+        (sessionsPerTag := sessionsPerTag) hTable a b]
+
+omit [Nonempty TagId] [SampleableType Nonce] [DecidableEq Digest] [NeZero sessionsPerTag] in
+/-- Discrete frontend form of the measure-preserving table permutation. -/
+lemma evalSPMF_uniformSample_bind_cellSwap [Fintype Nonce]
+    {α : Type} (a b : (TagId × Fin sessionsPerTag) × Nonce)
+    (F : ((TagId × Fin sessionsPerTag) × Nonce → Digest) → ProbComp α) :
+    𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest); F gS)] =
+      𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest);
+            F (gS ∘ cellSwap a b))] := by
+  let : MeasurableSpace Digest := ⊤
+  let : MeasurableSpace α := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_uniformSample_bind_cellSwap evalDist_uniformSample a b F
 
 /-! ### Multiset-invariance of `singleTableHandler` under cell-value swap
 
@@ -382,7 +410,10 @@ POINTWISE equality between the rewritten LHS body and the RHS body, because:
 * `((tag, 0), n)`: both tables cache `u`.
 * `((tag, slotK), n)`: T_L(gS ∘ φ) exposes `gS((tag, 0), n)` (φ swaps these); T_R(gS) exposes
   `gS((tag, 0), n)` (uncached by `hc0`). -/
-lemma singleTableHandler_cache_swap_eq [Fintype Nonce]
+lemma evalDist_singleTableHandler_cache_swap_eq [Fintype Nonce]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    (hTable : 𝒟[$ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)] = uniformOn Set.univ)
     (s : UnlinkState TagId)
     (c : (((TagId × Fin sessionsPerTag) × Nonce) →ₒ Digest).QueryCache)
     (tag : TagId) (slotK : Fin sessionsPerTag) (hslotK : slotK ≠ 0)
@@ -392,12 +423,12 @@ lemma singleTableHandler_cache_swap_eq [Fintype Nonce]
     (hc0 : c ((tag, (0 : Fin sessionsPerTag)), n) = none)
     (hAdv : slotK.val < s.sessionsUsed tag)
     (oa : OracleComp (UnlinkOracleSpec TagId Nonce Digest) Bool) :
-    𝒮[do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
+    𝒟[do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
          (simulateQ (singleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
             (sessionsPerTag := sessionsPerTag)
             (OracleComp.tableExtending
               (c.cacheQuery ((tag, (0 : Fin sessionsPerTag)), n) u) gS)) oa).run' s]
-    = 𝒮[do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
+    = 𝒟[do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
            (simulateQ (singleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
               (sessionsPerTag := sessionsPerTag)
               (OracleComp.tableExtending
@@ -409,11 +440,12 @@ lemma singleTableHandler_cache_swap_eq [Fintype Nonce]
   -- swap-invariance lemma.
   set φ : (TagId × Fin sessionsPerTag) × Nonce → (TagId × Fin sessionsPerTag) × Nonce :=
     cellSwap ((tag, (0 : Fin sessionsPerTag)), n) ((tag, slotK), n) with hφ
-  -- Step 1: apply `evalSPMF_uniformSample_bind_cellSwap` to rewrite LHS with `gS ↦ gS ∘ φ`.
-  rw [evalSPMF_uniformSample_bind_cellSwap (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
-        (sessionsPerTag := sessionsPerTag) ((tag, (0 : Fin sessionsPerTag)), n) ((tag, slotK), n)]
+  -- Step 1: apply `evalDist_uniformSample_bind_cellSwap` to rewrite LHS with `gS ↦ gS ∘ φ`.
+  rw [evalDist_uniformSample_bind_cellSwap (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+        (sessionsPerTag := sessionsPerTag) hTable
+        ((tag, (0 : Fin sessionsPerTag)), n) ((tag, slotK), n)]
   -- Step 2: pointwise — show the bodies are equal as functions of gS.
-  refine congrArg evalSPMF (bind_congr fun gS => ?_)
+  refine congrArg evalDist (bind_congr fun gS => ?_)
   -- For each fixed `gS`, apply the swap-invariance lemma with the two tables.
   apply singleTableHandler_simulateQ_swap_invariant tag slotK hslotK n oa s hAdv
   · -- heq: agreement off the swap pair.
@@ -449,6 +481,33 @@ lemma singleTableHandler_cache_swap_eq [Fintype Nonce]
     have : φ ((tag, slotK), n) = ((tag, (0 : Fin sessionsPerTag)), n) := by
       rw [hφ, cellSwap_right]
     rw [this]
+
+omit [Nonempty TagId] in
+/-- Discrete frontend form of the measure-preserving table permutation. -/
+lemma singleTableHandler_cache_swap_eq [Fintype Nonce]
+    (s : UnlinkState TagId)
+    (c : (((TagId × Fin sessionsPerTag) × Nonce) →ₒ Digest).QueryCache)
+    (tag : TagId) (slotK : Fin sessionsPerTag) (hslotK : slotK ≠ 0)
+    (n : Nonce) (u : Digest)
+    (hcInv : ∀ tag' : TagId, ∀ sid' : Fin sessionsPerTag, sid' ≠ 0 →
+        ∀ n' : Nonce, c ((tag', sid'), n') = none)
+    (hc0 : c ((tag, (0 : Fin sessionsPerTag)), n) = none)
+    (hAdv : slotK.val < s.sessionsUsed tag)
+    (oa : OracleComp (UnlinkOracleSpec TagId Nonce Digest) Bool) :
+    𝒮[do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
+         (simulateQ (singleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+            (sessionsPerTag := sessionsPerTag)
+            (OracleComp.tableExtending
+              (c.cacheQuery ((tag, (0 : Fin sessionsPerTag)), n) u) gS)) oa).run' s]
+    = 𝒮[do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
+           (simulateQ (singleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+              (sessionsPerTag := sessionsPerTag)
+              (OracleComp.tableExtending
+                (c.cacheQuery ((tag, slotK), n) u) gS)) oa).run' s] := by
+  let : MeasurableSpace Digest := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_singleTableHandler_cache_swap_eq evalDist_uniformSample
+    s c tag slotK hslotK n u hcInv hc0 hAdv oa
 
 end UnlinkReduction
 

--- a/Examples/PRFTagReader/DirectCoupling/TagSlotPositive.lean
+++ b/Examples/PRFTagReader/DirectCoupling/TagSlotPositive.lean
@@ -202,15 +202,15 @@ lemma dcAux_tag_slotPositive [Fintype Nonce] [Fintype Digest]
   -- Unfold head queries on both sides.
   simp only [multipleBadTableFine_run_query_bind', singleTable_run'_query_bind', map_bind]
   -- Phase B-1: rewrite each of LHS, RHS, BAD so the head step exposes the inner `n ← $ᵗ`.
-  have hLHS_eq :
+  have hM_eq {α : Type}
+      (observe : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) → α) :
       (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let p ← multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
             (Digest := Digest) (sessionsPerTag := sessionsPerTag)
             (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
               (OracleComp.tableExtending c gS)) gFine (Sum.inl tag) (s, sB)
-          (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-              z.1) <$>
+          observe <$>
             (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
               (Digest := Digest) (sessionsPerTag := sessionsPerTag)
               (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
@@ -218,8 +218,7 @@ lemma dcAux_tag_slotPositive [Fintype Nonce] [Fintype Digest]
       = (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
             let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
             let n ← $ᵗ Nonce
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                z.1) <$>
+            observe <$>
               (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
                 (Digest := Digest) (sessionsPerTag := sessionsPerTag)
                 (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
@@ -235,6 +234,7 @@ lemma dcAux_tag_slotPositive [Fintype Nonce] [Fintype Digest]
     refine bind_congr fun gFine => ?_
     rw [hMstep gS gFine]
     exact bind_assoc ..
+  have hLHS_eq := hM_eq (fun z => z.1)
   have hRHS_eq :
       (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let p ← singleTableHandler (TagId := TagId) (Nonce := Nonce)
@@ -253,39 +253,7 @@ lemma dcAux_tag_slotPositive [Fintype Nonce] [Fintype Digest]
     refine bind_congr fun gS => ?_
     rw [hSstep gS]
     exact bind_assoc ..
-  have hBAD_eq :
-      (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-          let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-          let p ← multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-            (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-            (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-              (OracleComp.tableExtending c gS)) gFine (Sum.inl tag) (s, sB)
-          (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-              (z.1, z.2.2)) <$>
-            (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-              (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-              (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                (OracleComp.tableExtending c gS)) gFine) (k p.1)).run p.2)
-      = (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            let n ← $ᵗ Nonce
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                (z.1, z.2.2)) <$>
-              (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                  (OracleComp.tableExtending c gS)) gFine)
-                (k (some (⟨n, OracleComp.tableExtending c gS
-                    ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                    TagTranscript Nonce Digest)))).run
-                (advM, multipleBadAdvance tag sB
-                  (some (⟨n, OracleComp.tableExtending c gS
-                    ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                    TagTranscript Nonce Digest)))) := by
-    refine bind_congr fun gS => ?_
-    refine bind_congr fun gFine => ?_
-    rw [hMstep gS gFine]
-    exact bind_assoc ..
+  have hBAD_eq := hM_eq (fun z => (z.1, z.2.2))
   rw [hLHS_eq, hRHS_eq, hBAD_eq]
   -- Phase B-2: commute outer `$ᵗ gS`, `$ᵗ gFine` past inner `$ᵗ Nonce` at the `𝒮[·]`
   -- level so `n` is outermost. Identical structure to slot-zero (M-side LHS/BAD have the
@@ -323,114 +291,10 @@ lemma dcAux_tag_slotPositive [Fintype Nonce] [Fintype Digest]
                     (some (⟨n, OracleComp.tableExtending c gS
                       ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
                       TagTranscript Nonce Digest))))] := by
-    -- Step (i): swap inner `gFine ← $ᵗ` past `n ← $ᵗ Nonce` under outer `gS`.
-    have hStep1 : ∀ gS : (TagId × Fin sessionsPerTag) × Nonce → Digest,
-        𝒮[(do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  z.1) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let n ← $ᵗ Nonce
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    z.1) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] := fun gS =>
-      evalSPMF_bind_bind_swap
-        ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) ($ᵗ Nonce) _
-    have hPart1 :
-        𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  z.1) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                let n ← $ᵗ Nonce
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    z.1) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] := by
-      rw [evalSPMF_bind, evalSPMF_bind]
-      refine congrArg _ (funext fun gS => ?_)
-      exact hStep1 gS
-    -- Step (ii): swap outermost `gS` past `n`.
-    have hStep2 :
-        𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  z.1) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let n ← $ᵗ Nonce
-                let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    z.1) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] :=
-      evalSPMF_bind_bind_swap
-        ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) ($ᵗ Nonce) _
-    exact hPart1.trans hStep2
-  -- RHS commute: single `evalSPMF_bind_bind_swap` (no gFine binder).
+    let : MeasurableSpace Digest := ⊤
+    let : MeasurableSpace Nonce := ⊤
+    apply evalSPMF_eq_of_evalDist_eq
+    exact evalDist_bind_bind_bind_rotate _ _ _ _ .of_discrete
   have hRHS_comm :
       𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
             let n ← $ᵗ Nonce
@@ -481,112 +345,11 @@ lemma dcAux_tag_slotPositive [Fintype Nonce] [Fintype Digest]
                     (some (⟨n, OracleComp.tableExtending c gS
                       ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
                       TagTranscript Nonce Digest))))] := by
-    -- Same two-step commute as hLHS_comm but with the (z.1, z.2.2) projection.
-    have hStep1B : ∀ gS : (TagId × Fin sessionsPerTag) × Nonce → Digest,
-        𝒮[(do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  (z.1, z.2.2)) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let n ← $ᵗ Nonce
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    (z.1, z.2.2)) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] := fun gS =>
-      evalSPMF_bind_bind_swap
-        ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) ($ᵗ Nonce) _
-    have hPart1B :
-        𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  (z.1, z.2.2)) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                let n ← $ᵗ Nonce
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    (z.1, z.2.2)) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] := by
-      rw [evalSPMF_bind, evalSPMF_bind]
-      refine congrArg _ (funext fun gS => ?_)
-      exact hStep1B gS
-    have hStep2B :
-        𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  (z.1, z.2.2)) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let n ← $ᵗ Nonce
-                let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    (z.1, z.2.2)) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] :=
-      evalSPMF_bind_bind_swap
-        ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) ($ᵗ Nonce) _
-    exact hPart1B.trans hStep2B
+    let : MeasurableSpace Digest := ⊤
+    let : MeasurableSpace Nonce := ⊤
+    let : MeasurableSpace (Bool × UnlinkBadState TagId Nonce Digest) := ⊤
+    apply evalSPMF_eq_of_evalDist_eq
+    exact evalDist_bind_bind_bind_rotate _ _ _ _ .of_discrete
   rw [probOutput_congr rfl hLHS_comm,
       probOutput_congr rfl hRHS_comm,
       probEvent_congr' (fun _ _ => Iff.rfl) hBAD_comm]

--- a/Examples/PRFTagReader/DirectCoupling/TagSlotZero.lean
+++ b/Examples/PRFTagReader/DirectCoupling/TagSlotZero.lean
@@ -212,15 +212,15 @@ lemma dcAux_tag_slotZero [Fintype Nonce] [Fintype Digest]
   simp only [multipleBadTableFine_run_query_bind', singleTable_run'_query_bind', map_bind]
   -- LHS: rewrite `gS ← $ᵗ; gFine ← $ᵗ; step >>= ...` into
   -- `gS ← $ᵗ; gFine ← $ᵗ; n ← $ᵗ Nonce; ...`.
-  have hLHS_eq :
+  have hM_eq {α : Type}
+      (observe : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) → α) :
       (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let p ← multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
             (Digest := Digest) (sessionsPerTag := sessionsPerTag)
             (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
               (OracleComp.tableExtending c gS)) gFine (Sum.inl tag) (s, sB)
-          (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-              z.1) <$>
+          observe <$>
             (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
               (Digest := Digest) (sessionsPerTag := sessionsPerTag)
               (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
@@ -228,8 +228,7 @@ lemma dcAux_tag_slotZero [Fintype Nonce] [Fintype Digest]
       = (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
             let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
             let n ← $ᵗ Nonce
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                z.1) <$>
+            observe <$>
               (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
                 (Digest := Digest) (sessionsPerTag := sessionsPerTag)
                 (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
@@ -245,6 +244,7 @@ lemma dcAux_tag_slotZero [Fintype Nonce] [Fintype Digest]
     refine bind_congr fun gFine => ?_
     rw [hMstep_with_bad gS gFine]
     exact bind_assoc ..
+  have hLHS_eq := hM_eq (fun z => z.1)
   have hRHS_eq :
       (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
           let p ← singleTableHandler (TagId := TagId) (Nonce := Nonce)
@@ -264,39 +264,7 @@ lemma dcAux_tag_slotZero [Fintype Nonce] [Fintype Digest]
     refine bind_congr fun gS => ?_
     rw [hSstep gS]
     exact bind_assoc ..
-  have hBAD_eq :
-      (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-          let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-          let p ← multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-            (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-            (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-              (OracleComp.tableExtending c gS)) gFine (Sum.inl tag) (s, sB)
-          (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-              (z.1, z.2.2)) <$>
-            (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-              (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-              (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                (OracleComp.tableExtending c gS)) gFine) (k p.1)).run p.2)
-      = (do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-            let n ← $ᵗ Nonce
-            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                (z.1, z.2.2)) <$>
-              (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                  (OracleComp.tableExtending c gS)) gFine)
-                (k (some (⟨n, OracleComp.tableExtending c gS
-                    ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                    TagTranscript Nonce Digest)))).run
-                (advM, multipleBadAdvance tag sB
-                  (some (⟨n, OracleComp.tableExtending c gS
-                    ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                    TagTranscript Nonce Digest)))) := by
-    refine bind_congr fun gS => ?_
-    refine bind_congr fun gFine => ?_
-    rw [hMstep_with_bad gS gFine]
-    exact bind_assoc ..
+  have hBAD_eq := hM_eq (fun z => (z.1, z.2.2))
   rw [hLHS_eq, hRHS_eq, hBAD_eq]
   -- Phase B. Commute outer `$ᵗ gS`, `$ᵗ gFine` past inner `$ᵗ Nonce` at the `𝒮[·]` level
   -- so the shared nonce draw is outermost. We push `n` out one binder at a time.
@@ -333,116 +301,10 @@ lemma dcAux_tag_slotZero [Fintype Nonce] [Fintype Digest]
                     (some (⟨n, OracleComp.tableExtending c gS
                       ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
                       TagTranscript Nonce Digest))))] := by
-    -- Two-step commute: (i) swap inner `gFine ← $ᵗ` past `n ← $ᵗ Nonce` so the body
-    -- becomes `gS; n; gFine; F`; (ii) swap outermost `gS` past `n` so `n` is outermost.
-    -- Step (i): inside `gS`, swap `gFine` and `n`.
-    have hStep1 : ∀ gS : (TagId × Fin sessionsPerTag) × Nonce → Digest,
-        𝒮[(do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  z.1) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let n ← $ᵗ Nonce
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    z.1) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] := fun gS =>
-      evalSPMF_bind_bind_swap
-        ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) ($ᵗ Nonce) _
-    -- Use hStep1 to rewrite under outer `gS ← $ᵗ`.
-    have hPart1 :
-        𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  z.1) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                let n ← $ᵗ Nonce
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    z.1) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] := by
-      rw [evalSPMF_bind, evalSPMF_bind]
-      refine congrArg _ (funext fun gS => ?_)
-      exact hStep1 gS
-    -- Step (ii): swap outer `gS` and `n`.
-    have hStep2 :
-        𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  z.1) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let n ← $ᵗ Nonce
-                let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    z.1) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] :=
-      evalSPMF_bind_bind_swap
-        ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) ($ᵗ Nonce) _
-    exact hPart1.trans hStep2
+    let : MeasurableSpace Digest := ⊤
+    let : MeasurableSpace Nonce := ⊤
+    apply evalSPMF_eq_of_evalDist_eq
+    exact evalDist_bind_bind_bind_rotate _ _ _ _ .of_discrete
   have hRHS_comm :
       𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
             let n ← $ᵗ Nonce
@@ -495,111 +357,11 @@ lemma dcAux_tag_slotZero [Fintype Nonce] [Fintype Digest]
                     (some (⟨n, OracleComp.tableExtending c gS
                       ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
                       TagTranscript Nonce Digest))))] := by
-    have hStep1B : ∀ gS : (TagId × Fin sessionsPerTag) × Nonce → Digest,
-        𝒮[(do let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  (z.1, z.2.2)) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let n ← $ᵗ Nonce
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    (z.1, z.2.2)) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] := fun gS =>
-      evalSPMF_bind_bind_swap
-        ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) ($ᵗ Nonce) _
-    have hPart1B :
-        𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  (z.1, z.2.2)) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                let n ← $ᵗ Nonce
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    (z.1, z.2.2)) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] := by
-      rw [evalSPMF_bind, evalSPMF_bind]
-      refine congrArg _ (funext fun gS => ?_)
-      exact hStep1B gS
-    have hStep2B :
-        𝒮[(do let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              let n ← $ᵗ Nonce
-              let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-              (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                  (z.1, z.2.2)) <$>
-                (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                  (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                  (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                    (OracleComp.tableExtending c gS)) gFine)
-                  (k (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest)))).run
-                  (advM, multipleBadAdvance tag sB
-                    (some (⟨n, OracleComp.tableExtending c gS
-                      ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                      TagTranscript Nonce Digest))))]
-        = 𝒮[(do let n ← $ᵗ Nonce
-                let gS ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                let gFine ← $ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)
-                (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
-                    (z.1, z.2.2)) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag)
-                    (slotZeroSubTable (sessionsPerTag := sessionsPerTag)
-                      (OracleComp.tableExtending c gS)) gFine)
-                    (k (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest)))).run
-                    (advM, multipleBadAdvance tag sB
-                      (some (⟨n, OracleComp.tableExtending c gS
-                        ((tag, (0 : Fin sessionsPerTag)), n)⟩ :
-                        TagTranscript Nonce Digest))))] :=
-      evalSPMF_bind_bind_swap
-        ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) ($ᵗ Nonce) _
-    exact hPart1B.trans hStep2B
+    let : MeasurableSpace Digest := ⊤
+    let : MeasurableSpace Nonce := ⊤
+    let : MeasurableSpace (Bool × UnlinkBadState TagId Nonce Digest) := ⊤
+    apply evalSPMF_eq_of_evalDist_eq
+    exact evalDist_bind_bind_bind_rotate _ _ _ _ .of_discrete
   rw [probOutput_congr rfl hLHS_comm,
       probOutput_congr rfl hRHS_comm,
       probEvent_congr' (fun _ _ => Iff.rfl) hBAD_comm]

--- a/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
+++ b/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
@@ -23,12 +23,13 @@ module hosts:
 * the per-step uniform-table bound `probEvent_cacheBadReader_uniformSample_le` on
   `cacheBadReader` at a freshly sampled fine table;
 * the eager equivalence
-  `evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending` lifting the lazy-vs-eager
-  equivalence to the instrumented handler;
+  `evalDist_simulateQ_multipleBadQueryImpl_run_eq_tableExtending` for the instrumented
+  handler, retaining its bad-state observation;
 * the Fine→original bridges
-  `evalSPMF_simulateQ_multipleBadTableHandler_cacheBad_irrelevant` and
-  `evalSPMF_simulateQ_multipleBadTableHandlerFine_forget_cacheBad_eq`, showing the `cacheBad`
-  field is invisible to the original handler and marginalizes away from the Fine handler.
+  `simulateQ_multipleBadTableHandler_cacheBad_irrelevant` and
+  `evalDist_simulateQ_multipleBadTableHandlerFine_forget_cacheBad`, showing the `cacheBad`
+  field is invisible to the original handler. Sampling an auxiliary fine table contributes
+  exactly its success mass to the projected measure.
 
 These shared definitions and bridges supply the eager-table instrumentation consumed by the
 direct-coupling headline in `DirectCoupling.Compose`.
@@ -36,7 +37,7 @@ direct-coupling headline in `DirectCoupling.Compose`.
 
 @[expose] public section
 
-open OracleComp OracleSpec ENNReal
+open OracleComp OracleSpec ENNReal MeasureTheory ProbabilityTheory
 
 namespace PRFTagReader
 
@@ -503,36 +504,43 @@ overlaying the cache `c`, and running the deterministic instrumented table handl
 Proved by induction on the adversary, generalized over the state. It mirrors
 `evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending`, threading the bad-world
 component (which `multipleBadAdvance` advances deterministically from the realized transcript). -/
-lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
+lemma evalDist_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
     [Fintype Nonce] [Finite Digest]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [MeasurableSpace (Bool × UnlinkBadState TagId Nonce Digest)]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    (hDigest : 𝒟[$ᵗ Digest] = uniformOn Set.univ)
+    (hTable : 𝒟[$ᵗ (TagId × Nonce → Digest)] = uniformOn Set.univ)
     (oa : UnlinkAdversary TagId Nonce Digest)
     (s : UnlinkState TagId) (c : ((TagId × Nonce) →ₒ Digest).QueryCache)
     (sB : UnlinkBadState TagId Nonce Digest) :
-    𝒮[(fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag => (z.1, z.2.2)) <$>
+    𝒟[(fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag => (z.1, z.2.2)) <$>
         (simulateQ (multipleBadQueryImpl (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
         (sessionsPerTag := sessionsPerTag)) oa).run ((s, c), sB)] =
-      𝒮[do let g ← $ᵗ (TagId × Nonce → Digest);
+      𝒟[do let g ← $ᵗ (TagId × Nonce → Digest);
             (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
                 (z.1, z.2.2)) <$>
               (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
                 (Digest := Digest) (sessionsPerTag := sessionsPerTag)
                 (OracleComp.tableExtending c g)) oa).run (s, sB)] := by
   classical
+  let : MeasurableSpace Nonce := ⊤
+  have : Nonempty Digest := ⟨(SampleableType.selectElem (β := Digest)).defaultResult⟩
   induction oa using OracleComp.inductionOn generalizing s c sB with
   | pure b =>
     simp only [simulateQ_pure, StateT.run_pure, map_pure]
-    refine (evalSPMF_ext fun x => ?_).symm
-    rw [probOutput_bind_const, probFailure_uniformSample, tsub_zero, one_mul]
+    rw [evalDist_bind_const, hTable]
+    simp
   | query_bind t f ih =>
     rw [multipleBad_run_query_bind', map_bind]
-    have hrhs : 𝒮[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
+    have hrhs : 𝒟[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
           (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
               (z.1, z.2.2)) <$>
             (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
               (Digest := Digest) (sessionsPerTag := sessionsPerTag)
               (OracleComp.tableExtending c g))
               (liftM (OracleSpec.query t) >>= f)).run (s, sB)]
-        = 𝒮[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
+        = 𝒟[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
             (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
               (sessionsPerTag := sessionsPerTag) (OracleComp.tableExtending c g) t (s, sB))
               >>= fun p =>
@@ -572,10 +580,10 @@ lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
                     ((advU, r.2), multipleBadAdvance tag sB
                       (some (⟨nonce, r.1⟩ : TagTranscript Nonce Digest)))) := by
           simp only [bind_assoc, pure_bind]
-        refine (congrArg evalSPMF hlhs_norm).trans ?_
+        refine (congrArg evalDist hlhs_norm).trans ?_
         -- per-nonce eager equivalence under the inner idealCacheStep
         have hlhs_inner : ∀ (n : Nonce),
-            𝒮[idealCacheStep c (tag, n) >>= fun r =>
+            𝒟[idealCacheStep c (tag, n) >>= fun r =>
                 (fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag =>
                     (z.1, z.2.2)) <$>
                   (simulateQ (multipleBadQueryImpl (TagId := TagId) (Nonce := Nonce)
@@ -583,7 +591,7 @@ lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
                   (f (some (⟨n, r.1⟩ : TagTranscript Nonce Digest)))).run
                     ((advU, r.2), multipleBadAdvance tag sB
                       (some (⟨n, r.1⟩ : TagTranscript Nonce Digest)))]
-            = 𝒮[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
+            = 𝒟[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
                   (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
                       (z.1, z.2.2)) <$>
                     (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
@@ -605,8 +613,9 @@ lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
                 (advU, multipleBadAdvance tag sB
                   (some (⟨n, g' (tag, n)⟩ : TagTranscript Nonce Digest)))
             with hMψ
-          refine Eq.trans ?_ (evalSPMF_idealCacheStep_bind_uniformTable_comp c (tag, n) Mψ)
-          refine evalSPMF_bind_congr_of_support _ _ _ fun r hr => ?_
+          refine Eq.trans ?_
+            (evalDist_idealCacheStep_bind_uniformTable_comp hDigest hTable c (tag, n) Mψ)
+          refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun r hr => ?_
           rw [ih (some (⟨n, r.1⟩ : TagTranscript Nonce Digest)) advU r.2
             (multipleBadAdvance tag sB (some (⟨n, r.1⟩ : TagTranscript Nonce Digest)))]
           refine congrArg _ (congrArg _ (funext fun g => ?_))
@@ -644,15 +653,15 @@ lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
                 multipleBadAdvance tag sB r.1))) >>= _ = _
           rw [multipleTableHandler_tag_run_of_lt _ tag s hslot, ← hadvU]
           simp only [unlinkOracleSpec_range_inl, bind_assoc, pure_bind]
-        refine Eq.trans ?_ (congrArg evalSPMF hrhs_swap).symm
-        rw [evalSPMF_bind_bind_swap ($ᵗ (TagId × Nonce → Digest)) ($ᵗ Nonce)]
-        refine evalSPMF_bind_congr_of_support _ _ _ fun n _ => ?_
+        refine Eq.trans ?_ (congrArg evalDist hrhs_swap).symm
+        rw [evalDist_bind_bind_swap ($ᵗ (TagId × Nonce → Digest)) ($ᵗ Nonce) _ .of_discrete]
+        refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun n _ => ?_
         exact hlhs_inner n
       · -- tag query, slot exhausted
         rw [multipleBadQueryImpl_tag_run tag ((s, c), sB)]
         dsimp only
         rw [multipleIdealQueryImpl_tag_run_of_not_lt tag s c hslot]
-        change 𝒮[(fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag =>
+        change 𝒟[(fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag =>
             (z.1, z.2.2)) <$>
             (simulateQ (multipleBadQueryImpl (TagId := TagId) (Nonce := Nonce)
               (Digest := Digest) (sessionsPerTag := sessionsPerTag)) (f none)).run
@@ -688,7 +697,7 @@ lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
                   (f (ReaderReply.ofBool (decide (∃ d ∈ rs.1, d = transcript.auth))))).run
                   ((s, rs.2), sB)) := by
         simp only [bind_assoc]; rfl
-      refine (congrArg evalSPMF hlhs_norm).trans ?_
+      refine (congrArg evalDist hlhs_norm).trans ?_
       -- eager equivalence under idealCacheMapM
       set Mψ : (TagId × Nonce → Digest) → ProbComp (Bool × UnlinkBadState TagId Nonce Digest) :=
         fun g' =>
@@ -700,24 +709,24 @@ lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
             (s, sB)
         with hMψ
       have hstep1 :
-          𝒮[idealCacheMapM cells c >>= fun rs =>
+          𝒟[idealCacheMapM cells c >>= fun rs =>
               (fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag =>
                   (z.1, z.2.2)) <$>
                 (simulateQ (multipleBadQueryImpl (TagId := TagId) (Nonce := Nonce)
                 (Digest := Digest) (sessionsPerTag := sessionsPerTag))
                 (f (ReaderReply.ofBool (decide (∃ d ∈ rs.1, d = transcript.auth))))).run
                 ((s, rs.2), sB)]
-          = 𝒮[idealCacheMapM cells c >>= fun rs =>
+          = 𝒟[idealCacheMapM cells c >>= fun rs =>
               ($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
                 Mψ (OracleComp.tableExtending rs.2 g)] := by
-        refine evalSPMF_bind_congr_of_support _ _ _ fun rs hrs => ?_
+        refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun rs hrs => ?_
         rw [ih (ReaderReply.ofBool (decide (∃ d ∈ rs.1, d = transcript.auth))) s rs.2 sB]
         refine congrArg _ (congrArg _ (funext fun g => ?_))
         rw [hMψ]
         simp only [idealCacheMapM_support cells c rs hrs g]
-      rw [hstep1, evalSPMF_idealCacheMapM_bind_uniformTable_comp cells c Mψ]
+      rw [hstep1, evalDist_idealCacheMapM_bind_uniformTable_comp hDigest hTable cells c Mψ]
       -- RHS: collapse the table-handler reader query
-      refine (evalSPMF_bind_congr_of_support _ _ _ fun g _ => ?_).symm
+      refine (OracleComp.evalDist_bind_congr_of_support _ _ _ fun g _ => ?_).symm
       have hrhs_reader : (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
           (Digest := Digest) (sessionsPerTag := sessionsPerTag)
           (OracleComp.tableExtending c g) (Sum.inr transcript) (s, sB))
@@ -750,6 +759,28 @@ lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
           exact ⟨transcript.auth, ⟨tag, hd⟩, Eq.refl transcript.auth⟩
       rw [← hAccept]
       simp only [unlinkOracleSpec_range_inr, pure_bind]
+
+omit [Nonempty TagId] in
+/-- Discrete frontend form of the joint measure observation identity. -/
+lemma evalSPMF_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
+    [Fintype Nonce] [Finite Digest]
+    (oa : UnlinkAdversary TagId Nonce Digest)
+    (s : UnlinkState TagId) (c : ((TagId × Nonce) →ₒ Digest).QueryCache)
+    (sB : UnlinkBadState TagId Nonce Digest) :
+    𝒮[(fun z : Bool × MultipleBadState TagId Nonce Digest sessionsPerTag => (z.1, z.2.2)) <$>
+        (simulateQ (multipleBadQueryImpl (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+        (sessionsPerTag := sessionsPerTag)) oa).run ((s, c), sB)] =
+      𝒮[do let g ← $ᵗ (TagId × Nonce → Digest);
+            (fun z : Bool × (UnlinkState TagId × UnlinkBadState TagId Nonce Digest) =>
+                (z.1, z.2.2)) <$>
+              (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
+                (Digest := Digest) (sessionsPerTag := sessionsPerTag)
+                (OracleComp.tableExtending c g)) oa).run (s, sB)] := by
+  let : MeasurableSpace Digest := ⊤
+  let : MeasurableSpace (Bool × UnlinkBadState TagId Nonce Digest) := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_simulateQ_multipleBadQueryImpl_run_eq_tableExtending
+    evalDist_uniformSample evalDist_uniformSample oa s c sB
 
 /-! ### Fine→original eager-table bridge
 
@@ -833,42 +864,42 @@ omit [Nonempty TagId] [SampleableType Digest] [NeZero sessionsPerTag] in
 that differ only in `cacheBad` produce identical original-handler-run distributions after the
 projection `with cacheBad := cb`. The original handler never reads or writes `cacheBad`, so the
 field is invisible to the run. -/
-lemma evalSPMF_simulateQ_multipleBadTableHandler_cacheBad_irrelevant
+lemma simulateQ_multipleBadTableHandler_cacheBad_irrelevant
     {α : Type} (g : TagId × Nonce → Digest)
     (oa : OracleComp (UnlinkOracleSpec TagId Nonce Digest) α)
     (s : UnlinkState TagId) (sB sB' : UnlinkBadState TagId Nonce Digest) (cb : Bool)
     (hSU : sB.sessionsUsed = sB'.sessionsUsed)
     (hR : sB.responses = sB'.responses) (hB : sB.bad = sB'.bad) :
-    𝒮[(fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
+    ((fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
         (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
-          (sessionsPerTag := sessionsPerTag) g) oa).run (s, sB)]
-      = 𝒮[(fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
+          (sessionsPerTag := sessionsPerTag) g) oa).run (s, sB))
+      = ((fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
         (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
-          (sessionsPerTag := sessionsPerTag) g) oa).run (s, sB')] := by
+          (sessionsPerTag := sessionsPerTag) g) oa).run (s, sB')) := by
   induction oa using OracleComp.inductionOn generalizing s sB sB' with
   | pure b =>
     simp only [simulateQ_pure, StateT.run_pure, map_pure]
-    congr 2
+    congr 1
     cases sB; cases sB'
     simp_all
   | query_bind t f ih =>
     rw [multipleBadTable_run_query_bind', multipleBadTable_run_query_bind', map_bind, map_bind]
     cases t with
     | inl tag =>
-      change 𝒮[((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+      change (((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
               (sessionsPerTag := sessionsPerTag) g (Sum.inl tag)) s >>= fun r =>
                 pure (r.1, r.2, multipleBadAdvance tag sB r.1)) >>= fun a =>
             (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
               (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) (f a.1)).run a.2]
-          = 𝒮[((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+                (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) (f a.1)).run a.2)
+          = (((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
               (sessionsPerTag := sessionsPerTag) g (Sum.inl tag)) s >>= fun r =>
                 pure (r.1, r.2, multipleBadAdvance tag sB' r.1)) >>= fun a =>
             (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
               (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) (f a.1)).run a.2]
+                (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) (f a.1)).run a.2)
       rw [bind_assoc, bind_assoc]
-      refine evalSPMF_bind_congr_of_support _ _ _ fun r _ => ?_
+      refine bind_congr fun r => ?_
       rw [pure_bind, pure_bind]
       have hAdv_SU : (multipleBadAdvance tag sB r.1).sessionsUsed
           = (multipleBadAdvance tag sB' r.1).sessionsUsed := by
@@ -894,22 +925,39 @@ lemma evalSPMF_simulateQ_multipleBadTableHandler_cacheBad_irrelevant
       exact ih r.1 r.2 (multipleBadAdvance tag sB r.1) (multipleBadAdvance tag sB' r.1)
         hAdv_SU hAdv_R hAdv_B
     | inr transcript =>
-      change 𝒮[((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+      change (((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
               (sessionsPerTag := sessionsPerTag) g (Sum.inr transcript)) s >>= fun r =>
                 pure (r.1, r.2, sB)) >>= fun a =>
             (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
               (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) (f a.1)).run a.2]
-          = 𝒮[((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+                (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) (f a.1)).run a.2)
+          = (((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
               (sessionsPerTag := sessionsPerTag) g (Sum.inr transcript)) s >>= fun r =>
                 pure (r.1, r.2, sB')) >>= fun a =>
             (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
               (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-                (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) (f a.1)).run a.2]
+                (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) (f a.1)).run a.2)
       rw [bind_assoc, bind_assoc]
-      refine evalSPMF_bind_congr_of_support _ _ _ fun r _ => ?_
+      refine bind_congr fun r => ?_
       rw [pure_bind, pure_bind]
       exact ih r.1 r.2 sB sB' hSU hR hB
+
+omit [Nonempty TagId] [SampleableType Digest] [NeZero sessionsPerTag] in
+/-- Discrete observation of the structural projection equality. -/
+lemma evalSPMF_simulateQ_multipleBadTableHandler_cacheBad_irrelevant
+    {α : Type} (g : TagId × Nonce → Digest)
+    (oa : OracleComp (UnlinkOracleSpec TagId Nonce Digest) α)
+    (s : UnlinkState TagId) (sB sB' : UnlinkBadState TagId Nonce Digest) (cb : Bool)
+    (hSU : sB.sessionsUsed = sB'.sessionsUsed)
+    (hR : sB.responses = sB'.responses) (hB : sB.bad = sB'.bad) :
+    𝒮[(fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
+        (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+          (sessionsPerTag := sessionsPerTag) g) oa).run (s, sB)]
+      = 𝒮[(fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
+        (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+          (sessionsPerTag := sessionsPerTag) g) oa).run (s, sB')] := by
+  exact congrArg evalSPMF
+    (simulateQ_multipleBadTableHandler_cacheBad_irrelevant g oa s sB sB' cb hSU hR hB)
 
 omit [Nonempty TagId] [SampleableType Digest] in
 /-- **Pointwise-in-`gFine` Fine→original projection equality.** For every fixed `gFine` and
@@ -917,6 +965,59 @@ every overwrite value `cb`, projecting `cacheBad := cb` on the Fine-run distribu
 same distribution as projecting `cacheBad := cb` on the original-run distribution. The workhorse
 of the headline bridge: parametrized over `cb` (rather than `p.2.cacheBad`) so the induction can
 pass through query-bind steps where the post-state's `cacheBad` differs from the pre-state's. -/
+lemma simulateQ_multipleBadTableHandlerFine_forget_cacheBad_pointwise_eq
+    (g : TagId × Nonce → Digest)
+    (gFine : ((TagId × Fin sessionsPerTag) × Nonce) → Digest)
+    {α : Type} (oa : OracleComp (UnlinkOracleSpec TagId Nonce Digest) α)
+    (p : UnlinkState TagId × UnlinkBadState TagId Nonce Digest) (cb : Bool) :
+    ((fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
+          (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
+            (Digest := Digest) (sessionsPerTag := sessionsPerTag) g gFine) oa).run p)
+      = ((fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
+          (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
+            (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) oa).run p) := by
+  induction oa using OracleComp.inductionOn generalizing p with
+  | pure b =>
+    simp only [simulateQ_pure, StateT.run_pure, map_pure]
+  | query_bind t f ih =>
+    rw [multipleBadTableFine_run_query_bind', multipleBadTable_run_query_bind', map_bind, map_bind]
+    cases t with
+    | inl tag =>
+      -- Tag branch: handlers are byte-identical; bind_congr + ih.
+      refine bind_congr fun q => ?_
+      exact ih q.1 q.2
+    | inr transcript =>
+      -- Reader branch: handlers differ only in cacheBad of post-state.
+      -- Unfold both handler-step calls to expose the shared inner `multipleTableHandler` bind.
+      change (((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+            (sessionsPerTag := sessionsPerTag) g (Sum.inr transcript)) p.1 >>= fun r =>
+              pure (r.1, r.2,
+                multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
+                  gFine transcript p.2)) >>= fun a =>
+                (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
+                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
+                    (Digest := Digest) (sessionsPerTag := sessionsPerTag) g gFine)
+                    (f a.1)).run a.2)
+            = (((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
+            (sessionsPerTag := sessionsPerTag) g (Sum.inr transcript)) p.1 >>= fun r =>
+              pure (r.1, r.2, p.2)) >>= fun a =>
+                (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
+                  (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
+                    (Digest := Digest) (sessionsPerTag := sessionsPerTag) g)
+                    (f a.1)).run a.2)
+      rw [bind_assoc, bind_assoc]
+      refine bind_congr fun r => ?_
+      rw [pure_bind, pure_bind]
+      -- Apply IH on the LHS to convert Fine to Original on a perturbed bad state,
+      -- then apply cacheBad-irrelevance to align that to the RHS bad state.
+      rw [ih r.1 (r.2, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
+        gFine transcript p.2)]
+      exact simulateQ_multipleBadTableHandler_cacheBad_irrelevant g (f r.1) r.2
+        (multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag) gFine transcript p.2)
+        p.2 cb rfl rfl rfl
+
+omit [Nonempty TagId] [SampleableType Digest] in
+/-- Discrete observation of the structural projection equality. -/
 lemma evalSPMF_simulateQ_multipleBadTableHandlerFine_forget_cacheBad_pointwise_eq
     (g : TagId × Nonce → Digest)
     (gFine : ((TagId × Fin sessionsPerTag) × Nonce) → Digest)
@@ -928,45 +1029,54 @@ lemma evalSPMF_simulateQ_multipleBadTableHandlerFine_forget_cacheBad_pointwise_e
       = 𝒮[(fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
           (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
             (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) oa).run p] := by
-  induction oa using OracleComp.inductionOn generalizing p with
-  | pure b =>
-    simp only [simulateQ_pure, StateT.run_pure, map_pure]
-  | query_bind t f ih =>
-    rw [multipleBadTableFine_run_query_bind', multipleBadTable_run_query_bind', map_bind, map_bind]
-    cases t with
-    | inl tag =>
-      -- Tag branch: handlers are byte-identical; bind_congr + ih.
-      refine evalSPMF_bind_congr_of_support _ _ _ fun q _ => ?_
-      exact ih q.1 q.2
-    | inr transcript =>
-      -- Reader branch: handlers differ only in cacheBad of post-state.
-      -- Unfold both handler-step calls to expose the shared inner `multipleTableHandler` bind.
-      change 𝒮[((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
-            (sessionsPerTag := sessionsPerTag) g (Sum.inr transcript)) p.1 >>= fun r =>
-              pure (r.1, r.2,
-                multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
-                  gFine transcript p.2)) >>= fun a =>
-                (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
-                  (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag) g gFine)
-                    (f a.1)).run a.2]
-            = 𝒮[((multipleTableHandler (TagId := TagId) (Nonce := Nonce) (Digest := Digest)
-            (sessionsPerTag := sessionsPerTag) g (Sum.inr transcript)) p.1 >>= fun r =>
-              pure (r.1, r.2, p.2)) >>= fun a =>
-                (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := cb})) <$>
-                  (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-                    (Digest := Digest) (sessionsPerTag := sessionsPerTag) g)
-                    (f a.1)).run a.2]
-      rw [bind_assoc, bind_assoc]
-      refine evalSPMF_bind_congr_of_support _ _ _ fun r _ => ?_
-      rw [pure_bind, pure_bind]
-      -- Apply IH on the LHS to convert Fine to Original on a perturbed bad state,
-      -- then apply cacheBad-irrelevance to align that to the RHS bad state.
-      rw [ih r.1 (r.2, multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag)
-        gFine transcript p.2)]
-      exact evalSPMF_simulateQ_multipleBadTableHandler_cacheBad_irrelevant g (f r.1) r.2
-        (multipleBadReaderAdvance (sessionsPerTag := sessionsPerTag) gFine transcript p.2)
-        p.2 cb rfl rfl rfl
+  exact congrArg evalSPMF
+    (simulateQ_multipleBadTableHandlerFine_forget_cacheBad_pointwise_eq g gFine oa p cb)
+
+omit [Nonempty TagId] [SampleableType Digest] in
+/-- Forgetting the fine handler's additional flag recovers the original computation. -/
+lemma simulateQ_multipleBadTableHandlerFine_forget_cacheBad_eq
+    (g : TagId × Nonce → Digest)
+    (gFine : ((TagId × Fin sessionsPerTag) × Nonce) → Digest)
+    {α : Type} (oa : OracleComp (UnlinkOracleSpec TagId Nonce Digest) α)
+    (p : UnlinkState TagId × UnlinkBadState TagId Nonce Digest) :
+    (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := p.2.cacheBad})) <$>
+        (simulateQ (multipleBadTableHandlerFine (sessionsPerTag := sessionsPerTag) g gFine)
+          oa).run p =
+      (simulateQ (multipleBadTableHandler (sessionsPerTag := sessionsPerTag) g) oa).run p := by
+  rw [simulateQ_multipleBadTableHandlerFine_forget_cacheBad_pointwise_eq]
+  let run := (simulateQ (multipleBadTableHandler (sessionsPerTag := sessionsPerTag) g) oa).run p
+  change (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := p.2.cacheBad})) <$> run = run
+  calc
+    _ = id <$> run := by
+      simp only [map_eq_pure_bind]
+      apply bind_congr_of_forall_mem_support
+      intro z hz
+      have hcb := multipleBadTableHandler_run_cacheBad_const g oa p z hz
+      have hrecord : ({z.2.2 with cacheBad := p.2.cacheBad} :
+          UnlinkBadState TagId Nonce Digest) = z.2.2 := by
+        rw [← hcb]
+      simp only [hrecord, id_eq]
+    _ = run := id_map run
+
+omit [Nonempty TagId] [SampleableType Digest] in
+/-- Sampling an auxiliary fine table only contributes its success mass to the original
+handler's observation measure. The sampler need not be uniform or lossless. -/
+lemma evalDist_simulateQ_multipleBadTableHandlerFine_forget_cacheBad
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    [MeasurableSpace (((TagId × Fin sessionsPerTag) × Nonce) → Digest)]
+    {α : Type} [MeasurableSpace (α × UnlinkState TagId × UnlinkBadState TagId Nonce Digest)]
+    (sampleFine : ProbComp (((TagId × Fin sessionsPerTag) × Nonce) → Digest))
+    (g : TagId × Nonce → Digest)
+    (oa : OracleComp (UnlinkOracleSpec TagId Nonce Digest) α)
+    (p : UnlinkState TagId × UnlinkBadState TagId Nonce Digest) :
+    𝒟[(fun z => (z.1, z.2.1, {z.2.2 with cacheBad := p.2.cacheBad})) <$>
+      (do let gFine ← sampleFine
+          (simulateQ (multipleBadTableHandlerFine (sessionsPerTag := sessionsPerTag) g gFine)
+            oa).run p)] =
+      𝒟[sampleFine] Set.univ •
+        𝒟[(simulateQ (multipleBadTableHandler (sessionsPerTag := sessionsPerTag) g) oa).run p] := by
+  simp_rw [map_bind, simulateQ_multipleBadTableHandlerFine_forget_cacheBad_eq]
+  exact evalDist_bind_const _ _
 
 omit [Nonempty TagId] [SampleableType Digest] in
 /-- **Fine→original eager-table bridge.** Marginalizing the Fine-run output distribution over a
@@ -975,8 +1085,8 @@ the original-run output distribution exactly.
 
 The proof composes the pointwise-in-`gFine` projection equality
 (`…_forget_cacheBad_pointwise_eq`) with the constancy of `cacheBad` along original-handler runs
-(`multipleBadTableHandler_run_cacheBad_const`), then collapses the outer `gFine` binder via
-`probOutput_bind_const` (uniform sample doesn't fail). -/
+(`multipleBadTableHandler_run_cacheBad_const`), then applies `evalDist_bind_const` and the
+uniform sampler's unit mass. -/
 lemma evalSPMF_simulateQ_multipleBadTableHandlerFine_forget_cacheBad_eq
     [SampleableType (((TagId × Fin sessionsPerTag) × Nonce) → Digest)]
     (g : TagId × Nonce → Digest) {α : Type}
@@ -988,48 +1098,11 @@ lemma evalSPMF_simulateQ_multipleBadTableHandlerFine_forget_cacheBad_eq
                 (Digest := Digest) (sessionsPerTag := sessionsPerTag) g gFine) oa).run p)]
       = 𝒮[(simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
                 (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) oa).run p] := by
-  classical
-  -- Push the projection map under the outer bind.
-  rw [map_bind]
-  -- Per-point distribution equality by extensional probOutput, on every output `x`.
-  refine evalSPMF_ext fun x => ?_
-  -- Step 1: the per-gFine projected Fine-run distribution equals the projected Original-run
-  -- distribution pointwise in gFine (via the pointwise lemma); collapse the constant gFine
-  -- bind with `probOutput_bind_of_const` and `probFailure_uniformSample = 0`.
-  have hpointwise : ∀ gFine ∈ support
-      ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)),
-      Pr[= x | (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := p.2.cacheBad})) <$>
-        (simulateQ (multipleBadTableHandlerFine (TagId := TagId) (Nonce := Nonce)
-          (Digest := Digest) (sessionsPerTag := sessionsPerTag) g gFine) oa).run p] =
-      Pr[= x | (fun z => (z.1, z.2.1, {z.2.2 with cacheBad := p.2.cacheBad})) <$>
-        (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-          (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) oa).run p] := by
-    intro gFine _
-    rw [probOutput_def, probOutput_def,
-      evalSPMF_simulateQ_multipleBadTableHandlerFine_forget_cacheBad_pointwise_eq
-        g gFine oa p p.2.cacheBad]
-  rw [probOutput_bind_of_const _ hpointwise, probFailure_uniformSample, tsub_zero, one_mul]
-  -- Step 2: π acts as identity on the support of the original run (since cacheBad is constant).
-  rw [probOutput_map_eq_tsum_subtype_ite]
-  rw [show Pr[= x | (simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-          (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) oa).run p]
-        = Pr[= x |
-            (id <$> ((simulateQ (multipleBadTableHandler (TagId := TagId) (Nonce := Nonce)
-              (Digest := Digest) (sessionsPerTag := sessionsPerTag) g) oa).run p))]
-      from by rw [id_map]]
-  rw [probOutput_map_eq_tsum_subtype_ite]
-  -- The two subtype-sums agree pointwise since π acts as identity on the support.
-  have hcb := multipleBadTableHandler_run_cacheBad_const (sessionsPerTag := sessionsPerTag) g oa p
-  refine tsum_congr fun z => ?_
-  have hz := hcb z.val z.property
-  have hrec : ((z.val.1, z.val.2.1,
-        ({z.val.2.2 with cacheBad := p.2.cacheBad} : UnlinkBadState TagId Nonce Digest)) :
-        α × UnlinkState TagId × UnlinkBadState TagId Nonce Digest) = z.val := by
-    have heq : ({z.val.2.2 with cacheBad := p.2.cacheBad} : UnlinkBadState TagId Nonce Digest)
-        = z.val.2.2 := by
-      conv_lhs => rw [← hz]
-    rw [heq]
-  rw [hrec, id_eq]
+  let : MeasurableSpace (((TagId × Fin sessionsPerTag) × Nonce) → Digest) := ⊤
+  let : MeasurableSpace (α × UnlinkState TagId × UnlinkBadState TagId Nonce Digest) := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  rw [evalDist_simulateQ_multipleBadTableHandlerFine_forget_cacheBad, evalDist_uniformSample]
+  simp
 
 end UnlinkReduction
 

--- a/Examples/PRFTagReader/Table.lean
+++ b/Examples/PRFTagReader/Table.lean
@@ -7,6 +7,9 @@ Authors: Oleksandr Vovkotrub
 module
 
 public import Examples.PRFTagReader.PRFReductions
+public import VCVio.EvalDist.Monad.UniformTable
+public import VCVio.OracleComp.EvalDist.Measure
+public import VCVio.OracleComp.Constructions.SampleableType.MeasureCompatibility
 
 /-!
 # PRF Tag/Reader Protocol — Composed-Handler Eager-Table Equivalence
@@ -14,10 +17,10 @@ public import Examples.PRFTagReader.PRFReductions
 The eager-table reformulation of the composed ideal handlers, in four parts:
 
 * the reader table-iteration lemma `idealCacheMapM`;
-* the composed multiple-world eager-table equivalence
-  `evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending`;
-* the composed single-world eager-table equivalence
-  `evalSPMF_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending`;
+* the composed multiple-world measure equivalence
+  `evalDist_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending`;
+* the composed single-world measure equivalence
+  `evalDist_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending`;
 * the eager-form success probabilities `probOutput_*_run'_eq_tableSample`
   and the `projectTable` helper that bridges the two table types.
 
@@ -28,7 +31,7 @@ the eager-table reformulation).
 
 @[expose] public section
 
-open OracleComp OracleSpec ENNReal
+open OracleComp OracleSpec ENNReal MeasureTheory ProbabilityTheory
 
 namespace PRFTagReader
 
@@ -43,11 +46,10 @@ variable {TagId Nonce Digest K : Type}
 /-! ### Composed-handler eager-table equivalence
 
 The composed ideal handler `multipleIdealQueryImpl` embeds the lazy random oracle inside a
-stateful handler over `UnlinkOracleSpec`. The lemma below lifts the top-level lazy-vs-eager-table
-equivalence (`OracleComp.evalSPMF_simulateQ_randomOracle_run'_eq_tableExtending`) to this composed
-handler: running `multipleIdealQueryImpl` from `(s, c)` has the same output distribution as
-sampling a full random-oracle table `g`, overlaying the cache `c`, and running the *real*
-multiple-session handler `multipleTableHandler` deterministically against that table.
+stateful handler over `UnlinkOracleSpec`. Structural induction and native uniform-table
+resampling show that running it from `(s, c)` has the same measure as sampling a full table `g`,
+overlaying the cache `c`, and running `multipleTableHandler` against that table. Uniformity of
+the digest and table samplers is explicit in the measure theorem.
 
 This is the multiple-world half of the eager-sampling reformulation. -/
 
@@ -148,10 +150,61 @@ lemma multipleTableHandler_reader_run (g : TagId × Nonce → Digest)
   rw [QueryImpl.add_apply_inr]; rfl
 
 omit [DecidableEq Digest] in
+/-- A lazy cache step followed by an eager table draw preserves the continuation measure. -/
+lemma evalDist_idealCacheStep_bind_uniformTable_comp {D : Type} [DecidableEq D] [Finite D]
+    [Finite Digest] [SampleableType (D → Digest)]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    {β : Type} [MeasurableSpace β]
+    (hDigest : 𝒟[$ᵗ Digest] = uniformOn Set.univ)
+    (hTable : 𝒟[$ᵗ (D → Digest)] = uniformOn Set.univ)
+    (c : (D →ₒ Digest).QueryCache) (d : D) (cont : (D → Digest) → ProbComp β) :
+    𝒟[do let r ← idealCacheStep (Digest := Digest) c d
+          let g ← $ᵗ (D → Digest)
+          cont (OracleComp.tableExtending r.2 g)] =
+      𝒟[do let g ← $ᵗ (D → Digest); cont (OracleComp.tableExtending c g)] := by
+  classical
+  have : Nonempty Digest := ⟨(SampleableType.selectElem (β := Digest)).defaultResult⟩
+  unfold idealCacheStep
+  rcases hc : c d with _ | u
+  · simp only [bind_assoc, pure_bind]
+    have heq : ∀ u g,
+        OracleComp.tableExtending (c.cacheQuery d u) g =
+          OracleComp.tableExtending c (Function.update g d u) := by
+      intro u g
+      rw [OracleComp.tableExtending_cacheQuery,
+        OracleComp.tableExtending_update_of_none c g hc u]
+    simp_rw [heq]
+    exact evalDist_bind_bind_update _ _ hDigest hTable d
+      (fun g => cont (OracleComp.tableExtending c g))
+  · simp only [pure_bind]
+
+omit [DecidableEq Digest] in
+/-- The eager table absorbs a list of lazy cache lookups, including repeated cells. -/
+lemma evalDist_idealCacheMapM_bind_uniformTable_comp {D : Type} [DecidableEq D] [Finite D]
+    [Finite Digest] [SampleableType (D → Digest)]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    {β : Type} [MeasurableSpace β]
+    (hDigest : 𝒟[$ᵗ Digest] = uniformOn Set.univ)
+    (hTable : 𝒟[$ᵗ (D → Digest)] = uniformOn Set.univ)
+    (cells : List D) (c : (D →ₒ Digest).QueryCache) (cont : (D → Digest) → ProbComp β) :
+    𝒟[do let r ← idealCacheMapM (Digest := Digest) cells c
+          let g ← $ᵗ (D → Digest)
+          cont (OracleComp.tableExtending r.2 g)] =
+      𝒟[do let g ← $ᵗ (D → Digest); cont (OracleComp.tableExtending c g)] := by
+  induction cells generalizing c with
+  | nil => simp only [idealCacheMapM, pure_bind]
+  | cons d ds ih =>
+    simp only [idealCacheMapM, bind_assoc, pure_bind]
+    refine Eq.trans ?_ (evalDist_idealCacheStep_bind_uniformTable_comp hDigest hTable c d cont)
+    exact OracleComp.evalDist_bind_congr_of_support _ _ _ (fun r _ => ih r.2)
+
+omit [DecidableEq Digest] in
 /-- **Cache-branch eager-table step.** A single lazy-random-oracle lookup `idealCacheStep` at a
 domain point `d`, followed by sampling a full random-oracle table for the remaining computation,
 has the same output distribution as directly sampling the table: the fresh on-demand draw of a
-cache miss is absorbed by `OracleComp.evalSPMF_uniformSample_bind_update_map`.
+cache miss is absorbed by `evalDist_bind_bind_update`.
 
 This is the per-query workhorse for an eager-sampling reformulation of the composed ideal handler:
 it reconciles the lazy cache step with the up-front table draw, generalized over an arbitrary
@@ -163,25 +216,12 @@ lemma evalSPMF_idealCacheStep_bind_uniformTable {D : Type} [DecidableEq D] [Fini
           let g ← $ᵗ (D → Digest);
           pure (ψ (OracleComp.tableExtending r.2 g))] =
       𝒮[do let g ← $ᵗ (D → Digest); pure (ψ (OracleComp.tableExtending c g))] := by
-  classical
-  have : Nonempty Digest := ⟨(SampleableType.selectElem (β := Digest)).defaultResult⟩
-  unfold idealCacheStep
-  rcases hc : c d with _ | u
-  · dsimp only
-    rw [show (($ᵗ Digest) >>= fun u => pure (u, c.cacheQuery d u)) >>=
-              (fun r => ($ᵗ (D → Digest)) >>= fun g =>
-                pure (ψ (OracleComp.tableExtending r.2 g)))
-          = ($ᵗ Digest) >>= fun u => ($ᵗ (D → Digest)) >>= fun g =>
-              pure ((fun g' => ψ (OracleComp.tableExtending c g')) (Function.update g d u))
-        from by
-          rw [bind_assoc]; refine bind_congr fun u => ?_
-          rw [pure_bind]; refine bind_congr fun g => ?_
-          rw [OracleComp.tableExtending_cacheQuery,
-            OracleComp.tableExtending_update_of_none c g hc u]]
-    exact OracleComp.evalSPMF_uniformSample_bind_update_map (R := Digest) d
-      (fun g' => ψ (OracleComp.tableExtending c g'))
-  · dsimp only
-    rw [pure_bind]
+  let : MeasurableSpace Digest := ⊤
+  let : MeasurableSpace β := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_idealCacheStep_bind_uniformTable_comp
+    evalDist_uniformSample evalDist_uniformSample c d (fun g => pure (ψ g))
+
 
 omit [DecidableEq Digest] in
 /-- **Single-cell extraction at the bind level.** Drawing a uniform function table `g : D → R` and
@@ -199,39 +239,12 @@ lemma evalSPMF_uniformSample_bind_cell_extract {D R : Type}
     (cont : (D → R) → R → ProbComp β) :
     𝒮[do let g ← $ᵗ (D → R); cont g (g t)] =
       𝒮[do let u ← $ᵗ R; let g ← $ᵗ (D → R); cont (Function.update g t u) u] := by
-  classical
-  -- Factor both sides through a `pure (g, g t)` / `pure (Function.update g t u, u)` pair, then
-  -- apply `evalSPMF_uniformSample_bind_update_map` on the inner pure layer.
-  have hLeq :
-      (do let g ← $ᵗ (D → R); cont g (g t))
-        = ((do let g ← $ᵗ (D → R); pure (g, g t)) >>= fun p : (D → R) × R => cont p.1 p.2) := by
-    simp
-  have hReq :
-      (do let u ← $ᵗ R; let g ← $ᵗ (D → R); cont (Function.update g t u) u)
-        = ((do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (Function.update g t u, u))
-            >>= fun p : (D → R) × R => cont p.1 p.2) := by
-    simp
-  rw [hLeq, hReq]
-  have hpureEq : ∀ (g : D → R) (u : R),
-      (Function.update g t u, u)
-        = ((fun g' : D → R => (g', g' t)) (Function.update g t u)) := fun _ _ => by simp
-  have hcore :
-      𝒮[do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (Function.update g t u, u)]
-        = 𝒮[do let g ← $ᵗ (D → R); pure (g, g t)] := by
-    have hrw :
-        (do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (Function.update g t u, u))
-          = (do let u ← $ᵗ R; let g ← $ᵗ (D → R);
-                pure ((fun g' : D → R => (g', g' t)) (Function.update g t u))) :=
-      bind_congr fun u => bind_congr fun g => by rw [hpureEq g u]
-    rw [hrw]
-    exact OracleComp.evalSPMF_uniformSample_bind_update_map (R := R) t (fun g' => (g', g' t))
-  -- Lift `hcore` through the outer continuation `fun p => cont p.1 p.2`.
-  refine evalSPMF_ext fun y => ?_
-  rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
-  refine tsum_congr fun p => ?_
-  rw [show Pr[= p | (do let g ← $ᵗ (D → R); pure (g, g t))]
-        = Pr[= p | (do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (Function.update g t u, u))]
-      from probOutput_congr rfl hcore.symm]
+  let : MeasurableSpace R := ⊤
+  let : MeasurableSpace β := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_bind_cell_extract ($ᵗ R) ($ᵗ (D → R))
+    evalDist_uniformSample evalDist_uniformSample t cont
+
 
 /-! #### Reader table-iteration lemma
 
@@ -420,28 +433,12 @@ lemma evalSPMF_idealCacheMapM_bind_uniformTable {D : Type} [DecidableEq D] [Fini
           let g ← $ᵗ (D → Digest);
           pure (ψ (OracleComp.tableExtending r.2 g))] =
       𝒮[do let g ← $ᵗ (D → Digest); pure (ψ (OracleComp.tableExtending c g))] := by
-  induction l generalizing c with
-  | nil =>
-    simp only [idealCacheMapM, pure_bind]
-  | cons d ds ih =>
-    simp only [idealCacheMapM]
-    have hreassoc :
-        (idealCacheStep c d >>= fun r =>
-            idealCacheMapM ds r.2 >>= fun rs =>
-              pure (r.1 :: rs.1, rs.2)) >>= (fun r =>
-          ($ᵗ (D → Digest)) >>= fun g => pure (ψ (OracleComp.tableExtending r.2 g)))
-        = idealCacheStep c d >>= fun r =>
-            idealCacheMapM ds r.2 >>= fun rs =>
-              ($ᵗ (D → Digest)) >>= fun g =>
-                pure (ψ (OracleComp.tableExtending rs.2 g)) := by
-      rw [bind_assoc]; refine bind_congr fun r => ?_
-      rw [bind_assoc]; refine bind_congr fun rs => ?_
-      rw [pure_bind]
-    rw [hreassoc]
-    refine Eq.trans ?_ (evalSPMF_idealCacheStep_bind_uniformTable c d ψ)
-    rw [evalSPMF_bind, evalSPMF_bind]
-    refine congrArg (fun h => 𝒮[idealCacheStep c d] >>= h) ?_
-    exact funext fun r => ih r.2
+  let : MeasurableSpace Digest := ⊤
+  let : MeasurableSpace β := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_idealCacheMapM_bind_uniformTable_comp
+    evalDist_uniformSample evalDist_uniformSample l c (fun g => pure (ψ g))
+
 
 omit [DecidableEq Digest] in
 /-- Computation-valued form of `evalSPMF_idealCacheStep_bind_uniformTable`: the continuation `Mψ`
@@ -453,20 +450,12 @@ lemma evalSPMF_idealCacheStep_bind_uniformTable_comp {D : Type} [DecidableEq D] 
           let g ← $ᵗ (D → Digest);
           Mψ (OracleComp.tableExtending r.2 g)] =
       𝒮[do let g ← $ᵗ (D → Digest); Mψ (OracleComp.tableExtending c g)] := by
-  have hbase := evalSPMF_idealCacheStep_bind_uniformTable c d Mψ
-  have hL : (idealCacheStep c d >>= fun r =>
-              ($ᵗ (D → Digest)) >>= fun g => Mψ (OracleComp.tableExtending r.2 g))
-      = (idealCacheStep c d >>= fun r =>
-            ($ᵗ (D → Digest)) >>= fun g =>
-            pure (Mψ (OracleComp.tableExtending r.2 g))) >>= id := by simp
-  have hR : (($ᵗ (D → Digest)) >>= fun g => Mψ (OracleComp.tableExtending c g))
-      = (($ᵗ (D → Digest)) >>= fun g =>
-            pure (Mψ (OracleComp.tableExtending c g))) >>= id := by simp
-  rw [hL, hR, evalSPMF_bind (mx := idealCacheStep c d >>= fun r =>
-        ($ᵗ (D → Digest)) >>= fun g => pure (Mψ (OracleComp.tableExtending r.2 g))),
-    evalSPMF_bind (mx := ($ᵗ (D → Digest)) >>= fun g =>
-        pure (Mψ (OracleComp.tableExtending c g)))]
-  exact congrArg (fun h => h >>= fun c' => 𝒮[id c']) hbase
+  let : MeasurableSpace Digest := ⊤
+  let : MeasurableSpace β := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_idealCacheStep_bind_uniformTable_comp
+    evalDist_uniformSample evalDist_uniformSample c d Mψ
+
 
 omit [DecidableEq Digest] in
 /-- Computation-valued form of `evalSPMF_idealCacheMapM_bind_uniformTable`. -/
@@ -477,20 +466,12 @@ lemma evalSPMF_idealCacheMapM_bind_uniformTable_comp {D : Type} [DecidableEq D] 
           let g ← $ᵗ (D → Digest);
           Mψ (OracleComp.tableExtending r.2 g)] =
       𝒮[do let g ← $ᵗ (D → Digest); Mψ (OracleComp.tableExtending c g)] := by
-  have hbase := evalSPMF_idealCacheMapM_bind_uniformTable l c Mψ
-  have hL : (idealCacheMapM l c >>= fun r =>
-              ($ᵗ (D → Digest)) >>= fun g => Mψ (OracleComp.tableExtending r.2 g))
-      = (idealCacheMapM l c >>= fun r =>
-            ($ᵗ (D → Digest)) >>= fun g =>
-            pure (Mψ (OracleComp.tableExtending r.2 g))) >>= id := by simp
-  have hR : (($ᵗ (D → Digest)) >>= fun g => Mψ (OracleComp.tableExtending c g))
-      = (($ᵗ (D → Digest)) >>= fun g =>
-            pure (Mψ (OracleComp.tableExtending c g))) >>= id := by simp
-  rw [hL, hR, evalSPMF_bind (mx := idealCacheMapM l c >>= fun r =>
-        ($ᵗ (D → Digest)) >>= fun g => pure (Mψ (OracleComp.tableExtending r.2 g))),
-    evalSPMF_bind (mx := ($ᵗ (D → Digest)) >>= fun g =>
-        pure (Mψ (OracleComp.tableExtending c g)))]
-  exact congrArg (fun h => h >>= fun c' => 𝒮[id c']) hbase
+  let : MeasurableSpace Digest := ⊤
+  let : MeasurableSpace β := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_idealCacheMapM_bind_uniformTable_comp
+    evalDist_uniformSample evalDist_uniformSample l c Mψ
+
 
 /-- Distribution-level bind congruence: if two continuations agree (in distribution) on every
 output in the support of the head computation, the full binds have equal distributions. -/
@@ -498,9 +479,12 @@ lemma evalSPMF_bind_congr_of_support {α β : Type}
     (mx : ProbComp α) (my my' : α → ProbComp β)
     (h : ∀ a ∈ support mx, 𝒮[my a] = 𝒮[my' a]) :
     𝒮[mx >>= my] = 𝒮[mx >>= my'] := by
-  refine evalSPMF_ext fun y => ?_
-  refine probOutput_bind_congr fun a ha => ?_
-  rw [probOutput_def, probOutput_def, h a ha]
+  let : MeasurableSpace β := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  apply OracleComp.evalDist_bind_congr_of_support
+  intro a ha
+  exact evalDist_eq_of_evalSPMF_eq _ _ (h a ha)
+
 
 /-! #### Composed multiple-world eager-table equivalence
 
@@ -517,26 +501,33 @@ omit [Nonempty TagId] in
 /-- **Step A, multiple world.** Running the composed multiple-session ideal handler
 from state `(s, c)` has the same output distribution as sampling a full random-oracle table `g`,
 overlaying the cache `c`, and running the deterministic real multiple-session table handler. -/
-lemma evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
+lemma evalDist_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
     [Fintype Nonce] [Finite Digest]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    (hDigest : 𝒟[$ᵗ Digest] = uniformOn Set.univ)
+    (hTable : 𝒟[$ᵗ (TagId × Nonce → Digest)] = uniformOn Set.univ)
     (oa : UnlinkAdversary TagId Nonce Digest)
     (s : UnlinkState TagId) (c : ((TagId × Nonce) →ₒ Digest).QueryCache) :
-    𝒮[(simulateQ (multipleIdealQueryImpl (sessionsPerTag := sessionsPerTag)) oa).run' (s, c)] =
-      𝒮[do let g ← $ᵗ (TagId × Nonce → Digest);
+    𝒟[(simulateQ (multipleIdealQueryImpl (sessionsPerTag := sessionsPerTag)) oa).run' (s, c)] =
+      𝒟[do let g ← $ᵗ (TagId × Nonce → Digest);
             (simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag)
               (OracleComp.tableExtending c g)) oa).run' s] := by
+  classical
+  let : MeasurableSpace Nonce := ⊤
+  have : Nonempty Digest := ⟨(SampleableType.selectElem (β := Digest)).defaultResult⟩
   induction oa using OracleComp.inductionOn generalizing s c with
   | pure b =>
     simp only [simulateQ_pure, StateT.run'_eq, StateT.run_pure, map_pure]
-    refine (evalSPMF_ext fun x => ?_).symm
-    rw [probOutput_bind_const, probFailure_uniformSample, tsub_zero, one_mul]
+    rw [evalDist_bind_const, hTable]
+    simp
   | query_bind t f ih =>
     rw [multipleIdeal_run'_query_bind']
-    have hrhs : 𝒮[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
+    have hrhs : 𝒟[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
           (simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag)
               (OracleComp.tableExtending c g))
             (liftM (OracleSpec.query t) >>= f)).run' s]
-        = 𝒮[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
+        = 𝒟[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
             (multipleTableHandler (sessionsPerTag := sessionsPerTag)
               (OracleComp.tableExtending c g) t s) >>= fun p =>
               (simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag)
@@ -563,13 +554,13 @@ lemma evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
           rw [bind_assoc]; refine bind_congr fun nonce => ?_
           rw [bind_assoc]; refine bind_congr fun r => ?_
           rw [pure_bind]
-        refine (congrArg evalSPMF hlhs_reassoc).trans ?_
+        refine (congrArg evalDist hlhs_reassoc).trans ?_
         -- per-nonce eager equivalence under the inner idealCacheStep
         have hlhs_inner : ∀ (n : Nonce),
-            𝒮[idealCacheStep c (tag, n) >>= fun r =>
+            𝒟[idealCacheStep c (tag, n) >>= fun r =>
               (simulateQ (multipleIdealQueryImpl (sessionsPerTag := sessionsPerTag))
                 (f (some (⟨n, r.1⟩ : TagTranscript Nonce Digest)))).run' (adv, r.2)]
-            = 𝒮[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
+            = 𝒟[($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
                   (simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag)
                     (OracleComp.tableExtending c g))
                     (f (some (⟨n, OracleComp.tableExtending c g (tag, n)⟩ :
@@ -578,8 +569,9 @@ lemma evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
           set Mψ : (TagId × Nonce → Digest) → ProbComp Bool := fun g' =>
             (simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag) g')
               (f (some (⟨n, g' (tag, n)⟩ : TagTranscript Nonce Digest)))).run' adv with hMψ
-          refine Eq.trans ?_ (evalSPMF_idealCacheStep_bind_uniformTable_comp c (tag, n) Mψ)
-          refine evalSPMF_bind_congr_of_support _ _ _ fun r hr => ?_
+          refine Eq.trans ?_
+            (evalDist_idealCacheStep_bind_uniformTable_comp hDigest hTable c (tag, n) Mψ)
+          refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun r hr => ?_
           rw [ih (some (⟨n, r.1⟩ : TagTranscript Nonce Digest)) adv r.2]
           refine congrArg _ (congrArg _ (funext fun g => ?_))
           have hcell : OracleComp.tableExtending r.2 g (tag, n) = r.1 := by
@@ -605,13 +597,13 @@ lemma evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
           refine bind_congr fun g => ?_
           rw [bind_assoc]; refine bind_congr fun n => ?_
           rw [pure_bind]
-        refine Eq.trans ?_ (congrArg evalSPMF hrhs_swap).symm
-        rw [evalSPMF_bind_bind_swap ($ᵗ (TagId × Nonce → Digest)) ($ᵗ Nonce)]
-        refine evalSPMF_bind_congr_of_support _ _ _ fun n _ => ?_
+        refine Eq.trans ?_ (congrArg evalDist hrhs_swap).symm
+        rw [evalDist_bind_bind_swap ($ᵗ (TagId × Nonce → Digest)) ($ᵗ Nonce) _ .of_discrete]
+        refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun n _ => ?_
         exact hlhs_inner n
       · -- tag query, slot exhausted
         rw [multipleIdealQueryImpl_tag_run_of_not_lt tag s c hslot]
-        change 𝒮[(simulateQ (multipleIdealQueryImpl (sessionsPerTag := sessionsPerTag))
+        change 𝒟[(simulateQ (multipleIdealQueryImpl (sessionsPerTag := sessionsPerTag))
           (f none)).run' (s, c)] = _
         rw [ih none s c]
         refine congrArg _ (congrArg _ (funext fun g => ?_))
@@ -633,30 +625,30 @@ lemma evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
                 (s, rs.2)) := by
         rw [bind_assoc]; refine bind_congr fun rs => ?_
         rw [pure_bind]
-      refine (congrArg evalSPMF hlhs_reassoc).trans ?_
+      refine (congrArg evalDist hlhs_reassoc).trans ?_
       -- eager equivalence under idealCacheMapM
       set Mψ : (TagId × Nonce → Digest) → ProbComp Bool := fun g' =>
         (simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag) g')
           (f (ReaderReply.ofBool (decide (∃ d ∈ cells.map g', d = transcript.auth))))).run' s
         with hMψ
       have hstep1 :
-          𝒮[idealCacheMapM cells c >>= fun rs =>
+          𝒟[idealCacheMapM cells c >>= fun rs =>
               (simulateQ (multipleIdealQueryImpl (sessionsPerTag := sessionsPerTag))
                 (f (ReaderReply.ofBool (decide (∃ d ∈ rs.1, d = transcript.auth))))).run'
                 (s, rs.2)]
-          = 𝒮[idealCacheMapM cells c >>= fun rs =>
+          = 𝒟[idealCacheMapM cells c >>= fun rs =>
               ($ᵗ (TagId × Nonce → Digest)) >>= fun g =>
                 Mψ (OracleComp.tableExtending rs.2 g)] := by
-        refine evalSPMF_bind_congr_of_support _ _ _ fun rs hrs => ?_
+        refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun rs hrs => ?_
         rw [ih (ReaderReply.ofBool (decide (∃ d ∈ rs.1, d = transcript.auth))) s rs.2]
         refine congrArg _ (congrArg _ (funext fun g => ?_))
         rw [hMψ]
         simp only [idealCacheMapM_support cells c rs hrs g]
-      rw [hstep1, evalSPMF_idealCacheMapM_bind_uniformTable_comp cells c Mψ]
+      rw [hstep1, evalDist_idealCacheMapM_bind_uniformTable_comp hDigest hTable cells c Mψ]
       -- RHS: collapse the table-handler reader query
-      refine (evalSPMF_bind_congr_of_support _ _ _ fun g _ => ?_).symm
+      refine (OracleComp.evalDist_bind_congr_of_support _ _ _ fun g _ => ?_).symm
       rw [multipleTableHandler_reader_run _ transcript s]
-      change 𝒮[(simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag)
+      change 𝒟[(simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag)
           (OracleComp.tableExtending c g))
           (f (ReaderReply.ofBool (unlinkReaderAccepts (Slot := TagId)
             (fun tag nonce => OracleComp.tableExtending c g (tag, nonce))
@@ -681,6 +673,21 @@ lemma evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
           exact ⟨transcript.auth, ⟨tag, hd⟩, Eq.refl transcript.auth⟩
       beta_reduce
       rw [hAccept]
+
+omit [Nonempty TagId] in
+/-- Discrete frontend form of the measure-based eager-table identity. -/
+lemma evalSPMF_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
+    [Fintype Nonce] [Finite Digest]
+    (oa : UnlinkAdversary TagId Nonce Digest)
+    (s : UnlinkState TagId) (c : ((TagId × Nonce) →ₒ Digest).QueryCache) :
+    𝒮[(simulateQ (multipleIdealQueryImpl (sessionsPerTag := sessionsPerTag)) oa).run' (s, c)] =
+      𝒮[do let g ← $ᵗ (TagId × Nonce → Digest);
+            (simulateQ (multipleTableHandler (sessionsPerTag := sessionsPerTag)
+              (OracleComp.tableExtending c g)) oa).run' s] := by
+  let : MeasurableSpace Digest := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_simulateQ_multipleIdealQueryImpl_run'_eq_tableExtending
+    evalDist_uniformSample evalDist_uniformSample oa s c
 
 /-! #### Composed single-world eager-table equivalence
 
@@ -779,25 +786,32 @@ omit [Nonempty TagId] [NeZero sessionsPerTag] in
 /-- **Step A, single world.** Running the composed single-session ideal handler
 from state `(s, c)` has the same output distribution as sampling a full random-oracle table `g`,
 overlaying the cache `c`, and running the deterministic real single-session table handler. -/
-lemma evalSPMF_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
+lemma evalDist_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
     [Fintype Nonce] [Finite Digest]
+    [MeasurableSpace Digest] [MeasurableSingletonClass Digest]
+    [EvalDistSemantics ProbComp] [LawfulEvalDistSemantics ProbComp]
+    (hDigest : 𝒟[$ᵗ Digest] = uniformOn Set.univ)
+    (hTable : 𝒟[$ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)] = uniformOn Set.univ)
     (oa : UnlinkAdversary TagId Nonce Digest)
     (s : UnlinkState TagId)
     (c : (((TagId × Fin sessionsPerTag) × Nonce) →ₒ Digest).QueryCache) :
-    𝒮[(simulateQ (singleIdealQueryImpl (sessionsPerTag := sessionsPerTag)) oa).run' (s, c)] =
-      𝒮[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
+    𝒟[(simulateQ (singleIdealQueryImpl (sessionsPerTag := sessionsPerTag)) oa).run' (s, c)] =
+      𝒟[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
             (simulateQ (singleTableHandler (OracleComp.tableExtending c g)) oa).run' s] := by
+  classical
+  let : MeasurableSpace Nonce := ⊤
+  have : Nonempty Digest := ⟨(SampleableType.selectElem (β := Digest)).defaultResult⟩
   induction oa using OracleComp.inductionOn generalizing s c with
   | pure b =>
     simp only [simulateQ_pure, StateT.run'_eq, StateT.run_pure, map_pure]
-    refine (evalSPMF_ext fun x => ?_).symm
-    rw [probOutput_bind_const, probFailure_uniformSample, tsub_zero, one_mul]
+    rw [evalDist_bind_const, hTable]
+    simp
   | query_bind t f ih =>
     rw [singleIdeal_run'_query_bind']
-    have hrhs : 𝒮[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
+    have hrhs : 𝒟[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
           (simulateQ (singleTableHandler (OracleComp.tableExtending c g))
             (liftM (OracleSpec.query t) >>= f)).run' s]
-        = 𝒮[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
+        = 𝒟[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
             (singleTableHandler (OracleComp.tableExtending c g) t s) >>= fun p =>
               (simulateQ (singleTableHandler (OracleComp.tableExtending c g))
                 (f p.1)).run' p.2] := by
@@ -823,12 +837,12 @@ lemma evalSPMF_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
           rw [bind_assoc]; refine bind_congr fun nonce => ?_
           rw [bind_assoc]; refine bind_congr fun r => ?_
           rw [pure_bind]
-        refine (congrArg evalSPMF hlhs_reassoc).trans ?_
+        refine (congrArg evalDist hlhs_reassoc).trans ?_
         have hlhs_inner : ∀ (n : Nonce),
-            𝒮[idealCacheStep c ((tag, sid), n) >>= fun r =>
+            𝒟[idealCacheStep c ((tag, sid), n) >>= fun r =>
               (simulateQ (singleIdealQueryImpl (sessionsPerTag := sessionsPerTag))
                 (f (some (⟨n, r.1⟩ : TagTranscript Nonce Digest)))).run' (adv, r.2)]
-            = 𝒮[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
+            = 𝒟[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
                   (simulateQ (singleTableHandler (OracleComp.tableExtending c g))
                     (f (some (⟨n, OracleComp.tableExtending c g ((tag, sid), n)⟩ :
                       TagTranscript Nonce Digest)))).run' adv] := by
@@ -836,8 +850,9 @@ lemma evalSPMF_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
           set Mψ : ((TagId × Fin sessionsPerTag) × Nonce → Digest) → ProbComp Bool := fun g' =>
             (simulateQ (singleTableHandler g')
               (f (some (⟨n, g' ((tag, sid), n)⟩ : TagTranscript Nonce Digest)))).run' adv with hMψ
-          refine Eq.trans ?_ (evalSPMF_idealCacheStep_bind_uniformTable_comp c ((tag, sid), n) Mψ)
-          refine evalSPMF_bind_congr_of_support _ _ _ fun r hr => ?_
+          refine Eq.trans ?_
+            (evalDist_idealCacheStep_bind_uniformTable_comp hDigest hTable c ((tag, sid), n) Mψ)
+          refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun r hr => ?_
           rw [ih (some (⟨n, r.1⟩ : TagTranscript Nonce Digest)) adv r.2]
           refine congrArg _ (congrArg _ (funext fun g => ?_))
           have hcell : OracleComp.tableExtending r.2 g ((tag, sid), n) = r.1 := by
@@ -861,13 +876,13 @@ lemma evalSPMF_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
           refine bind_congr fun g => ?_
           rw [bind_assoc]; refine bind_congr fun n => ?_
           rw [pure_bind]
-        refine Eq.trans ?_ (congrArg evalSPMF hrhs_swap).symm
-        rw [evalSPMF_bind_bind_swap ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest))
-          ($ᵗ Nonce)]
-        refine evalSPMF_bind_congr_of_support _ _ _ fun n _ => ?_
+        refine Eq.trans ?_ (congrArg evalDist hrhs_swap).symm
+        rw [evalDist_bind_bind_swap ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest))
+          ($ᵗ Nonce) _ .of_discrete]
+        refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun n _ => ?_
         exact hlhs_inner n
       · rw [singleIdealQueryImpl_tag_run_of_not_lt tag s c hslot]
-        change 𝒮[(simulateQ (singleIdealQueryImpl (sessionsPerTag := sessionsPerTag))
+        change 𝒟[(simulateQ (singleIdealQueryImpl (sessionsPerTag := sessionsPerTag))
           (f none)).run' (s, c)] = _
         rw [ih none s c]
         refine congrArg _ (congrArg _ (funext fun g => ?_))
@@ -888,28 +903,28 @@ lemma evalSPMF_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
                 (s, rs.2)) := by
         rw [bind_assoc]; refine bind_congr fun rs => ?_
         rw [pure_bind]
-      refine (congrArg evalSPMF hlhs_reassoc).trans ?_
+      refine (congrArg evalDist hlhs_reassoc).trans ?_
       set Mψ : ((TagId × Fin sessionsPerTag) × Nonce → Digest) → ProbComp Bool := fun g' =>
         (simulateQ (singleTableHandler g')
           (f (ReaderReply.ofBool (decide (∃ d ∈ cells.map g', d = transcript.auth))))).run' s
         with hMψ
       have hstep1 :
-          𝒮[idealCacheMapM cells c >>= fun rs =>
+          𝒟[idealCacheMapM cells c >>= fun rs =>
               (simulateQ (singleIdealQueryImpl (sessionsPerTag := sessionsPerTag))
                 (f (ReaderReply.ofBool (decide (∃ d ∈ rs.1, d = transcript.auth))))).run'
                 (s, rs.2)]
-          = 𝒮[idealCacheMapM cells c >>= fun rs =>
+          = 𝒟[idealCacheMapM cells c >>= fun rs =>
               ($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
                 Mψ (OracleComp.tableExtending rs.2 g)] := by
-        refine evalSPMF_bind_congr_of_support _ _ _ fun rs hrs => ?_
+        refine OracleComp.evalDist_bind_congr_of_support _ _ _ fun rs hrs => ?_
         rw [ih (ReaderReply.ofBool (decide (∃ d ∈ rs.1, d = transcript.auth))) s rs.2]
         refine congrArg _ (congrArg _ (funext fun g => ?_))
         rw [hMψ]
         simp only [idealCacheMapM_support cells c rs hrs g]
-      rw [hstep1, evalSPMF_idealCacheMapM_bind_uniformTable_comp cells c Mψ]
-      refine (evalSPMF_bind_congr_of_support _ _ _ fun g _ => ?_).symm
+      rw [hstep1, evalDist_idealCacheMapM_bind_uniformTable_comp hDigest hTable cells c Mψ]
+      refine (OracleComp.evalDist_bind_congr_of_support _ _ _ fun g _ => ?_).symm
       rw [singleTableHandler_reader_run _ transcript s]
-      change 𝒮[(simulateQ (singleTableHandler (OracleComp.tableExtending c g))
+      change 𝒟[(simulateQ (singleTableHandler (OracleComp.tableExtending c g))
           (f (ReaderReply.ofBool (unlinkReaderAccepts (Slot := TagId × Fin sessionsPerTag)
             (fun slot nonce => OracleComp.tableExtending c g (slot, nonce))
             (singlePattern sessionsPerTag) transcript)))).run' s] = _
@@ -932,6 +947,21 @@ lemma evalSPMF_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
           exact ⟨transcript.auth, ⟨(tag, sid), hd⟩, Eq.refl transcript.auth⟩
       beta_reduce
       rw [hAccept]
+
+omit [Nonempty TagId] [NeZero sessionsPerTag] in
+/-- Discrete frontend form of the measure-based eager-table identity. -/
+lemma evalSPMF_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
+    [Fintype Nonce] [Finite Digest]
+    (oa : UnlinkAdversary TagId Nonce Digest)
+    (s : UnlinkState TagId)
+    (c : (((TagId × Fin sessionsPerTag) × Nonce) →ₒ Digest).QueryCache) :
+    𝒮[(simulateQ (singleIdealQueryImpl (sessionsPerTag := sessionsPerTag)) oa).run' (s, c)] =
+      𝒮[($ᵗ ((TagId × Fin sessionsPerTag) × Nonce → Digest)) >>= fun g =>
+            (simulateQ (singleTableHandler (OracleComp.tableExtending c g)) oa).run' s] := by
+  let : MeasurableSpace Digest := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_simulateQ_singleIdealQueryImpl_run'_eq_tableExtending
+    evalDist_uniformSample evalDist_uniformSample oa s c
 
 /-! #### Eager-form success probabilities
 

--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -52,6 +52,7 @@ public import ToMathlib.MeasureTheory.Measure.Monotone
 public import ToMathlib.MeasureTheory.Measure.Option
 public import ToMathlib.MeasureTheory.Measure.Subprobability
 public import ToMathlib.MeasureTheory.Measure.TotalVariation
+public import ToMathlib.MeasureTheory.Measure.UniformTable
 public import ToMathlib.OrderEnrichedCategory
 public import ToMathlib.Probability.Divergence.Renyi
 public import ToMathlib.Probability.Divergence.RenyiDiscrete

--- a/ToMathlib/MeasureTheory/Measure/UniformTable.lean
+++ b/ToMathlib/MeasureTheory/Measure/UniformTable.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma, Quang Dao
+-/
+
+module
+public import ToMathlib.MeasureTheory.Measure.Bounds
+public import ToMathlib.Probability.UniformOn
+public import Mathlib.MeasureTheory.Integral.Lebesgue.Countable
+
+/-!
+# Uniform table resampling
+
+Finite uniform measures are normalized counting measures. Independently resampling one
+coordinate of a uniform table preserves its joint distribution. These laws work directly
+with measures and can be used below any computation or random-oracle semantics.
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory
+
+namespace ProbabilityTheory
+
+/-- Integrate a continuation against a finite uniform measure. -/
+theorem uniformOn_univ_bind_apply {α β : Type*} [Fintype α] [MeasurableSpace α]
+    [MeasurableSingletonClass α] [MeasurableSpace β] (f : α → Measure β)
+    (s : Set β) (hs : MeasurableSet s) :
+    ((uniformOn Set.univ : Measure α).bind f) s =
+      ∑ a, (Fintype.card α : ENNReal)⁻¹ * f a s := by
+  rw [Measure.bind_apply hs Measurable.of_discrete.aemeasurable, lintegral_fintype]
+  simp [uniformOn_univ, mul_comm]
+
+/-- Replace one cell of a uniform table by an independent uniform value. -/
+theorem uniformOn_univ_bind_map_update {D R : Type*} [Finite D] [DecidableEq D]
+    [Finite R] [Nonempty R] [MeasurableSpace R] [MeasurableSingletonClass R] (t : D) :
+    (uniformOn Set.univ : Measure R).bind (fun u =>
+      (uniformOn Set.univ : Measure (D → R)).map (fun g => Function.update g t u)) =
+      uniformOn Set.univ := by
+  classical
+  let : Fintype D := Fintype.ofFinite D
+  let : Fintype R := Fintype.ofFinite R
+  apply Measure.ext_of_singleton
+  intro h
+  rw [uniformOn_univ_bind_apply _ _ (MeasurableSet.singleton h)]
+  have hinner : ∀ u : R,
+      ((uniformOn Set.univ : Measure (D → R)).map (fun g => Function.update g t u)) {h}
+        = if u = h t then
+            (Fintype.card R : ENNReal) * (Fintype.card (D → R) : ENNReal)⁻¹ else 0 := by
+    intro u
+    rw [Measure.map_apply .of_discrete (MeasurableSet.singleton h)]
+    change (uniformOn Set.univ : Measure (D → R)) {g | Function.update g t u = h} = _
+    rw [show {g | Function.update g t u = h} = {g | h = Function.update g t u} by
+      ext; exact eq_comm]
+    rw [uniformOn_univ_apply_setOf]
+    have hcard :
+        ((Finset.univ.filter fun g : D → R => h = Function.update g t u).card : ENNReal)
+          = if u = h t then (Fintype.card R : ENNReal) else 0 := by
+      by_cases hu : u = h t
+      · have hset : (Finset.univ.filter fun g : D → R => h = Function.update g t u)
+            = Finset.univ.image (fun r : R => Function.update h t r) := by
+          ext g
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_image]
+          constructor
+          · intro hg
+            exact ⟨g t, by subst hg; simp⟩
+          · rintro ⟨r, rfl⟩
+            subst hu; simp
+        rw [hset, Finset.card_image_of_injective _
+          (fun r₁ r₂ hr => by simpa using congrFun hr t), Finset.card_univ, if_pos hu]
+      · rw [if_neg hu, Nat.cast_eq_zero, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+        rintro g - rfl
+        simp at hu
+    rw [hcard, ENNReal.div_eq_inv_mul, mul_ite, mul_zero, mul_comm]
+  simp_rw [hinner, mul_ite, mul_zero]
+  rw [Finset.sum_ite_eq' Finset.univ (h t), if_pos (Finset.mem_univ _),
+    ← mul_assoc, ENNReal.inv_mul_cancel (by simp [Fintype.card_ne_zero])
+      (ENNReal.natCast_ne_top _), one_mul]
+  simp [uniformOn_univ]
+
+/-- A bijection transports a finite uniform measure to the uniform measure on its codomain. -/
+theorem uniformOn_univ_map_equiv {α β : Type*} [Finite α] [Finite β]
+    [MeasurableSpace α] [MeasurableSingletonClass α]
+    [MeasurableSpace β] [MeasurableSingletonClass β] (e : α ≃ β) :
+    (uniformOn Set.univ : Measure α).map e = (uniformOn Set.univ : Measure β) := by
+  classical
+  let : Fintype α := Fintype.ofFinite α
+  let : Fintype β := Fintype.ofFinite β
+  apply Measure.ext_of_singleton
+  intro y
+  rw [Measure.map_apply .of_discrete (MeasurableSet.singleton y)]
+  have hpreimage : e ⁻¹' {y} = {e.symm y} := by
+    ext x
+    simp only [Set.mem_preimage, Set.mem_singleton_iff, ← e.eq_symm_apply]
+  rw [hpreimage]
+  simp [uniformOn_univ, Fintype.card_congr e]
+
+/-- Restrict a uniform table to an injectively indexed family of cells. -/
+theorem uniformOn_univ_map_comp_injective {A B R : Type*} [Finite A] [Finite B] [Finite R]
+    [Nonempty R] [MeasurableSpace R] [MeasurableSingletonClass R]
+    {e : A → B} (he : Function.Injective e) :
+    (uniformOn Set.univ : Measure (B → R)).map (fun g => g ∘ e) =
+      (uniformOn Set.univ : Measure (A → R)) := by
+  classical
+  let : Fintype A := Fintype.ofFinite A
+  let : Fintype B := Fintype.ofFinite B
+  let : Fintype R := Fintype.ofFinite R
+  let C := {b : B // b ∉ Set.range e}
+  let φ : (B → R) ≃ (A → R) × (C → R) :=
+    (Equiv.arrowCongr ((Equiv.Set.sumCompl (Set.range e)).symm.trans
+      ((Equiv.ofInjective e he).symm.sumCongr (Equiv.refl C))) (Equiv.refl R)).trans
+      (Equiv.sumArrowEquivProdArrow _ _ _)
+  have hφ1 : ∀ g : B → R, (φ g).1 = g ∘ e := fun g => funext fun a => by
+    simp [φ, Equiv.sumArrowEquivProdArrow, Equiv.ofInjective]
+  calc
+    _ = ((uniformOn Set.univ : Measure (B → R)).map φ).map Prod.fst := by
+      rw [Measure.map_map .of_discrete .of_discrete]
+      simp only [Function.comp_def, hφ1]
+    _ = (uniformOn Set.univ : Measure ((A → R) × (C → R))).map Prod.fst := by
+      rw [uniformOn_univ_map_equiv]
+    _ = _ := by rw [uniformOn_univ_prod, Measure.map_fst_prod, measure_univ, one_smul]
+
+end ProbabilityTheory

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -165,6 +165,7 @@ public import VCVio.EvalDist.Monad.Disagreement
 public import VCVio.EvalDist.Monad.Map
 public import VCVio.EvalDist.Monad.Measure
 public import VCVio.EvalDist.Monad.Seq
+public import VCVio.EvalDist.Monad.UniformTable
 public import VCVio.EvalDist.Option
 public import VCVio.EvalDist.PFunctor
 public import VCVio.EvalDist.PFunctorMeasure
@@ -195,8 +196,10 @@ public import VCVio.OracleComp.Constructions.Fork
 public import VCVio.OracleComp.Constructions.GenerateSeed
 public import VCVio.OracleComp.Constructions.Replicate
 public import VCVio.OracleComp.Constructions.SampleableType
+public import VCVio.OracleComp.Constructions.SampleableType.MeasureCompatibility
 public import VCVio.OracleComp.Constructions.WithoutReplacement
 public import VCVio.OracleComp.EvalDist
+public import VCVio.OracleComp.EvalDist.Measure
 public import VCVio.OracleComp.FinRatPMF
 public import VCVio.OracleComp.HasQuery.Basic
 public import VCVio.OracleComp.HasQuery.Morphism

--- a/VCVio/EvalDist/Monad/UniformTable.lean
+++ b/VCVio/EvalDist/Monad/UniformTable.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.EvalDist.Monad.Measure
+public import ToMathlib.MeasureTheory.Measure.UniformTable
+
+/-!
+# Uniform table laws for measure-valued computations
+
+Explicit uniform-measure hypotheses suffice to resample or extract table cells. The
+continuation may return any measurable result space and may lose mass. No sampling
+implementation or discrete probability representation is required.
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory
+
+variable {m : Type → Type*} [Monad m] [LawfulMonad m] [EvalDistSemantics m]
+  [LawfulEvalDistSemantics m]
+  {D R α : Type} [Finite D] [DecidableEq D] [Finite R] [Nonempty R]
+  [MeasurableSpace R] [MeasurableSingletonClass R] [MeasurableSpace α]
+
+/-- Independent uniform cell resampling preserves every subsequent observation. -/
+theorem evalDist_bind_bind_update (value : m R) (table : m (D → R))
+    (hvalue : 𝒟[value] = uniformOn Set.univ) (htable : 𝒟[table] = uniformOn Set.univ)
+    (t : D) (f : (D → R) → m α) :
+    𝒟[value >>= fun u => table >>= fun g => f (Function.update g t u)] = 𝒟[table >>= f] := by
+  have hupdate : 𝒟[value >>= fun u => (fun g => Function.update g t u) <$> table] =
+      𝒟[table] := by
+    simp_rw [evalDist_bind_of_discrete, evalDist_map_of_discrete, hvalue, htable]
+    exact uniformOn_univ_bind_map_update t
+  have hbind : (value >>= fun u => table >>= fun g => f (Function.update g t u)) =
+      (value >>= fun u => (fun g => Function.update g t u) <$> table) >>= f := by
+    simp only [bind_assoc, bind_map_left]
+  rw [hbind, evalDist_bind_of_discrete _ f, hupdate, ← evalDist_bind_of_discrete]
+
+/-- Independent uniform cell resampling preserves a pure observation of the table. -/
+theorem evalDist_bind_bind_update_map (value : m R) (table : m (D → R))
+    (hvalue : 𝒟[value] = uniformOn Set.univ) (htable : 𝒟[table] = uniformOn Set.univ)
+    (t : D) (f : (D → R) → α) :
+    𝒟[value >>= fun u => table >>= fun g => pure (f (Function.update g t u))] =
+      𝒟[table >>= fun g => pure (f g)] :=
+  evalDist_bind_bind_update value table hvalue htable t (fun g => pure (f g))
+
+/-- Expose a uniform table cell before running the continuation that reads it. -/
+theorem evalDist_bind_cell_extract (value : m R) (table : m (D → R))
+    (hvalue : 𝒟[value] = uniformOn Set.univ) (htable : 𝒟[table] = uniformOn Set.univ)
+    (t : D) (f : (D → R) → R → m α) :
+    𝒟[table >>= fun g => f g (g t)] =
+      𝒟[value >>= fun u => table >>= fun g => f (Function.update g t u) u] := by
+  simpa only [Function.update_self] using
+    (evalDist_bind_bind_update value table hvalue htable t (fun g => f g (g t))).symm
+
+/-- Reindexing a finite uniform draw by a permutation preserves every continuation measure. -/
+theorem evalDist_bind_uniform_equiv [Finite α] [MeasurableSingletonClass α]
+    {β : Type} [MeasurableSpace β] (draw : m α)
+    (hdraw : 𝒟[draw] = uniformOn Set.univ) (e : α ≃ α) (f : α → m β) :
+    𝒟[draw >>= f] = 𝒟[draw >>= fun x => f (e x)] := by
+  have hmap : 𝒟[e <$> draw] = 𝒟[draw] := by
+    rw [evalDist_map_of_discrete, hdraw, uniformOn_univ_map_equiv]
+  calc
+    _ = 𝒟[(e <$> draw) >>= f] := by
+      rw [evalDist_bind_of_discrete _ f, evalDist_bind_of_discrete _ f, hmap]
+    _ = _ := by rw [bind_map_left]
+
+/-- Independently resample two distinct table cells before observing the table. -/
+theorem evalDist_bind_bind_bind_update_two_map (value : m R) (table : m (D → R))
+    (hvalue : 𝒟[value] = uniformOn Set.univ) (htable : 𝒟[table] = uniformOn Set.univ)
+    {t₁ t₂ : D} (hne : t₁ ≠ t₂) (f : (D → R) → α) :
+    𝒟[value >>= fun u₁ => value >>= fun u₂ => table >>= fun g =>
+      pure (f (Function.update (Function.update g t₁ u₁) t₂ u₂))] =
+        𝒟[table >>= fun g => pure (f g)] := by
+  simp_rw [Function.update_comm hne]
+  trans 𝒟[value >>= fun u₁ => table >>= fun g => pure (f (Function.update g t₁ u₁))]
+  · rw [evalDist_bind_of_discrete value, evalDist_bind_of_discrete value]
+    exact Measure.bind_congr_right (Filter.Eventually.of_forall fun u₁ =>
+      evalDist_bind_bind_update_map value table hvalue htable t₂
+        (fun g => f (Function.update g t₁ u₁)))
+  · exact evalDist_bind_bind_update_map value table hvalue htable t₁ f
+
+/-- An injective table restriction preserves uniformity under explicitly calibrated draws. -/
+theorem evalDist_map_table_comp_injective {A B : Type} [Finite A] [Finite B]
+    (small : m (A → R)) (large : m (B → R))
+    (hsmall : 𝒟[small] = uniformOn Set.univ) (hlarge : 𝒟[large] = uniformOn Set.univ)
+    {e : A → B} (he : Function.Injective e) :
+    𝒟[(fun g => g ∘ e) <$> large] = 𝒟[small] := by
+  rw [evalDist_map_of_discrete, hsmall, hlarge]
+  exact uniformOn_univ_map_comp_injective he

--- a/VCVio/OracleComp/Constructions/SampleableType/MeasureCompatibility.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType/MeasureCompatibility.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.OracleComp.Constructions.SampleableType
+public import VCVio.EvalDist.Monad.Measure
+
+/-!
+# Measure compatibility for the discrete sampling frontend
+
+The uniformity certificate of `SampleableType` calibrates its compatibility evaluation
+as a uniform measure. Measure identities can then recover the existing discrete equality
+statements. Measure proof cores take their calibration hypotheses explicitly and do not
+use these adapters.
+-/
+
+public section
+
+open OracleComp OracleSpec MeasureTheory ProbabilityTheory
+
+/-- The compatibility measure of the certified uniform sampler is uniform. -/
+theorem evalDist_uniformSample {α : Type} [SampleableType α] [MeasurableSpace α]
+    [MeasurableSingletonClass α] :
+    𝒟[$ᵗ α] = uniformOn Set.univ := by
+  classical
+  let : Fintype α := Fintype.ofFinite α
+  apply Measure.ext_of_singleton
+  intro x
+  rw [evalDist_apply_singleton, probOutput_uniformSample, uniformOn_univ]
+  simp
+
+/-- Recover a discrete frontend equality from equality of its successful-output measures. -/
+theorem evalSPMF_eq_of_evalDist_eq {α : Type} [MeasurableSpace α]
+    [MeasurableSingletonClass α] (mx my : ProbComp α) (h : 𝒟[mx] = 𝒟[my]) :
+    𝒮[mx] = 𝒮[my] := by
+  apply evalSPMF_ext
+  intro x
+  simpa only [evalDist_apply_singleton] using congrArg (fun μ : Measure α => μ {x}) h
+
+/-- Equality of discrete frontend distributions preserves their successful-output measures. -/
+theorem evalDist_eq_of_evalSPMF_eq {α : Type} [MeasurableSpace α]
+    (mx my : ProbComp α) (h : 𝒮[mx] = 𝒮[my]) : 𝒟[mx] = 𝒟[my] :=
+  congrArg (fun p => p.toMeasure) h

--- a/VCVio/OracleComp/EvalDist/Measure.lean
+++ b/VCVio/OracleComp/EvalDist/Measure.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.OracleComp.EvalDist
+public import VCVio.EvalDist.Monad.Measure
+
+/-!
+# Measure congruence from structural support
+
+Continuations that denote the same measure on all syntactically reachable outputs may
+be interchanged. The proof inducts on the free program, so no probability/support bridge
+or positivity assumption on query answers is necessary.
+-/
+
+public section
+
+open OracleComp OracleSpec MeasureTheory
+
+namespace OracleComp
+
+/-- Equal continuation measures on structural support give equal composed measures. -/
+theorem evalDist_bind_congr_of_support {ι α β : Type} {spec : OracleSpec ι}
+    [∀ t, MeasurableSpace (spec.Range t)] [∀ t, DiscreteMeasurableSpace (spec.Range t)]
+    [MeasurableSpace β]
+    [EvalDistSemantics (OracleComp spec)] [LawfulEvalDistSemantics (OracleComp spec)]
+    (mx : OracleComp spec α) (f g : α → OracleComp spec β)
+    (h : ∀ a ∈ support mx, 𝒟[f a] = 𝒟[g a]) :
+    𝒟[mx >>= f] = 𝒟[mx >>= g] := by
+  induction mx using OracleComp.inductionOn with
+  | pure a => simpa only [pure_bind] using h a (by simp)
+  | query_bind t k ih =>
+    rw [bind_assoc, bind_assoc, evalDist_bind_of_discrete, evalDist_bind_of_discrete]
+    apply Measure.bind_congr_right
+    apply Filter.Eventually.of_forall
+    intro u
+    exact ih u fun a ha => h a ((mem_support_bind_iff _ _ _).mpr ⟨u, by simp, ha⟩)
+
+end OracleComp

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/EagerTable.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/EagerTable.lean
@@ -7,6 +7,8 @@ Authors: Oleksandr Vovkotrub
 module
 public import VCVio.OracleComp.QueryTracking.RandomOracle.Simulation
 public import VCVio.OracleComp.Constructions.SampleableType
+public import VCVio.OracleComp.Constructions.SampleableType.MeasureCompatibility
+public import VCVio.EvalDist.Monad.UniformTable
 
 /-!
 # Lazy Random Oracle Equals Eager Full-Table Sampling
@@ -72,8 +74,11 @@ same distribution as evaluating `ψ` on a directly drawn uniform table. -/
 lemma evalSPMF_uniformSample_bind_update_map {α : Type} (t : D) (ψ : (D → R) → α) :
     𝒮[do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (ψ (Function.update g t u))] =
       𝒮[do let g ← $ᵗ (D → R); pure (ψ g)] := by
-  rw [bind_pure_comp, evalSPMF_map, ← evalSPMF_uniformSample_bind_update t]
-  simp [map_bind, bind_pure_comp]
+  let : MeasurableSpace R := ⊤
+  let : MeasurableSpace α := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_bind_bind_update_map ($ᵗ R) ($ᵗ (D → R))
+    evalDist_uniformSample evalDist_uniformSample t ψ
 
 /-- **Two-cell marginalization, post-composed.** For any continuation `ψ : (D → R) → α` and any
 two distinct coordinates `t₁ ≠ t₂`, drawing fresh independent uniforms `u₁, u₂`, then a full
@@ -93,12 +98,11 @@ lemma evalSPMF_uniformSample_bind_update_two_map {α : Type} {t₁ t₂ : D} (hn
     𝒮[do let u₁ ← $ᵗ R; let u₂ ← $ᵗ R; let g ← $ᵗ (D → R);
          pure (ψ (Function.update (Function.update g t₁ u₁) t₂ u₂))] =
       𝒮[do let g ← $ᵗ (D → R); pure (ψ g)] := by
-  simp_rw [Function.update_comm hne]
-  rw [evalSPMF_bind]
-  refine (congrArg _ (funext fun u₁ =>
-    evalSPMF_uniformSample_bind_update_map t₂ fun h => ψ (Function.update h t₁ u₁))).trans ?_
-  rw [← evalSPMF_bind]
-  exact evalSPMF_uniformSample_bind_update_map t₁ ψ
+  let : MeasurableSpace R := ⊤
+  let : MeasurableSpace α := ⊤
+  apply evalSPMF_eq_of_evalDist_eq
+  exact evalDist_bind_bind_bind_update_two_map ($ᵗ R) ($ᵗ (D → R))
+    evalDist_uniformSample evalDist_uniformSample hne ψ
 
 omit [Finite D] [Finite R] [Nonempty R] in
 /-- Pure-case base step for `evalSPMF_simulateQ_randomOracle_run'_eq_tableExtending`: running

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -7,10 +7,12 @@ public import VCVioTest.CryptoFoundations.ComplexityAdapters
 public import VCVioTest.CryptoFoundations.ComplexityTactics
 public import VCVioTest.CryptoFoundations.ComputationalComplexitySoundness
 public import VCVioTest.CryptoFoundations.OracleClosure
+public import VCVioTest.CryptoFoundations.PRFTableMeasure
 public import VCVioTest.CryptoFoundations.SignatureAlg
 public import VCVioTest.CryptoFoundations.SymmEncAlgMeasure
 public import VCVioTest.EvalDist.IndependentDraws
 public import VCVioTest.EvalDist.MeasureBridge
+public import VCVioTest.EvalDist.UniformTable
 public import VCVioTest.ForkMeasure
 public import VCVioTest.Forking.WithoutReplacement
 public import VCVioTest.GrindFailFast

--- a/VCVioTest/CryptoFoundations/PRFTableMeasure.lean
+++ b/VCVioTest/CryptoFoundations/PRFTableMeasure.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import Examples.PRFTagReader.MultipleToHybrid.EagerSetup
+public import VCVio.EvalDist.PFunctorMeasure.Core
+
+/-!
+# Measure-based cache and observation checks
+
+The core dependency check follows theorem proofs and types. The cache-list example
+uses native free-program semantics with explicit sampling laws and repeated keys.
+-/
+
+public section
+
+open OracleSpec OracleComp MeasureTheory ProbabilityTheory
+
+run_cmd do
+  let env ← Lean.getEnv
+  let mut pending := [``OracleComp.evalDist_bind_congr_of_support,
+    ``evalDist_bind_bind_update, ``evalDist_bind_cell_extract,
+    ``evalDist_bind_bind_bind_update_two_map, ``evalDist_map_table_comp_injective]
+  let mut visited : Std.HashSet Lean.Name := {}
+  while let name :: rest := pending do
+    pending := rest
+    unless visited.contains name do
+      visited := visited.insert name
+      for forbidden in [`PMF, `SPMF, `evalSPMF, `probEvent, `probOutput, `expectedValue] do
+        if forbidden.isPrefixOf name then
+          throwError "native table proof depends on the discrete declaration {name}"
+      if let some info := env.find? name then
+        pending := info.getUsedConstantsAsSet.toList ++ pending
+
+namespace VCVioTest.PRFTableMeasure
+
+variable [unifSpec.toPFunctor.IsMeasureSpec]
+
+example (hvalue : 𝒟[$ᵗ Bool] = uniformOn Set.univ)
+    (htable : 𝒟[$ᵗ (Fin 3 → Bool)] = uniformOn Set.univ)
+    (cont : (Fin 3 → Bool) → ProbComp ℝ) :
+    𝒟[do let r ← PRFTagReader.idealCacheMapM [0, 2, 0, 2] ∅
+          let g ← $ᵗ (Fin 3 → Bool)
+          cont (tableExtending r.2 g)] =
+      𝒟[do let g ← $ᵗ (Fin 3 → Bool); cont g] := by
+  simpa only [tableExtending_empty] using
+    PRFTagReader.evalDist_idealCacheMapM_bind_uniformTable_comp hvalue htable [0, 2, 0, 2] ∅ cont
+
+end VCVioTest.PRFTableMeasure

--- a/VCVioTest/EvalDist/UniformTable.lean
+++ b/VCVioTest/EvalDist/UniformTable.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.EvalDist.Monad.UniformTable
+public import VCVio.EvalDist.PFunctorMeasure.Core
+
+/-!
+# Native uniform-table regression checks
+
+These imports exclude discrete probability compatibility machinery. Tests cover two
+cell updates, restriction to an empty domain, and continuations with missing mass.
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory
+
+run_cmd do
+  let env ← Lean.getEnv
+  for name in [`PMF, `SPMF] do
+    if env.contains name then
+      throwError "native table imports unexpectedly include {name}"
+
+namespace VCVioTest.UniformTable
+
+example :
+    (uniformOn Set.univ : Measure (Fin 3 → Bool)).map (fun g => g ∘ Fin.elim0) =
+      (uniformOn Set.univ : Measure (Fin 0 → Bool)) :=
+  uniformOn_univ_map_comp_injective (Function.injective_of_subsingleton _)
+
+example (t : Fin 3) :
+    ((uniformOn Set.univ : Measure Bool).bind (fun u =>
+      (uniformOn Set.univ : Measure (Fin 3 → Bool)).map (fun g => Function.update g t u))).bind
+        (fun g => (1 / 2 : ENNReal) • Measure.dirac (g 0)) =
+      (uniformOn Set.univ : Measure (Fin 3 → Bool)).bind
+        (fun g => (1 / 2 : ENNReal) • Measure.dirac (g 0)) := by
+  rw [uniformOn_univ_bind_map_update]
+
+example (t : Fin 3) :
+    ((uniformOn Set.univ : Measure Bool).bind (fun u =>
+      (uniformOn Set.univ : Measure (Fin 3 → Bool)).map (fun g => Function.update g t u))).bind
+        (fun _ => (0 : Measure ℝ)) = 0 := by
+  simp
+
+example {m : Type → Type*} [Monad m] [LawfulMonad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] (value : m Bool) (table : m (Fin 3 → Bool))
+    (hvalue : 𝒟[value] = uniformOn Set.univ) (htable : 𝒟[table] = uniformOn Set.univ) :
+    𝒟[value >>= fun u => value >>= fun v => table >>= fun g =>
+      pure ((Function.update (Function.update g 0 u) 2 v) 1)] =
+      𝒟[table >>= fun g => pure (g 1)] := by
+  exact evalDist_bind_bind_bind_update_two_map value table hvalue htable (by decide) (fun g => g 1)
+
+end VCVioTest.UniformTable

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -16,6 +16,15 @@ live in `VCVio.EvalDist.Defs.Measure.Core`; the direct free-program instances li
 continuations and `evalDist_bind_bind_bind_rotate` for discrete intermediate results. Their
 measure-level proofs use Tonelli's theorem and preserve subprobability mass.
 
+`VCVio.EvalDist.Monad.UniformTable` supplies cell resampling/extraction, permutation,
+and injective restriction laws with explicit uniform-measure hypotheses. Its native counting
+proofs live in `ToMathlib.MeasureTheory.Measure.UniformTable`. The continuation may lose mass.
+`VCVio.OracleComp.EvalDist.Measure` gives `evalDist_bind_congr_of_support` by structural
+induction, without a probability/support bridge. These laws power the PRF tag/reader cache,
+composed-handler, and shared-observation proofs. `SampleableType.MeasureCompatibility`
+calibrates the existing sampler at the compatibility boundary; native proofs take that
+calibration as an explicit hypothesis.
+
 The finite distribution API is
 explicit as `evalSPMF mx` / `𝒮[mx]`, and `Pr[...]` remains the discrete compatibility façade. One
 class connects the two: `DiscreteEvalDistCompatible m` says that integrating a measurable


### PR DESCRIPTION
The tag/reader proofs repeated long draw reorderings and success/bad-event projections, while their eager-table foundations used discrete distribution lemmas. This change proves table resampling, extraction, permutations, and injective restriction directly with measures, then uses those laws in the composed cache/table and fine-to-coarse bridges. Explicit sampler calibration remains at the compatibility boundary.

The tag cases share observation normalization and replace four long rotations with the independent-draw law. Reader and headline composition proofs share their normalization as well. The distinct zero-slot, positive-slot, accepting-reader, and rejecting-reader arguments and their error terms remain explicit. Auxiliary fine-table sampling retains its success-mass factor.

Validation: `./scripts/validate.sh --lint --test --axioms` passes. New checks cover missing mass, empty table restrictions, two-cell updates, repeated cache keys under native semantics, and transitive dependency rejection of PMF/SPMF in the core proofs. Axiom sweep: 18,216 declarations, 575 modules, unchanged 40 existing sorry-tainted declarations, no nonstandard axioms. PMF boundary ratchet passes.

Stacked on #693; this PR contains the PRF table and observation stage of the long-proof refactor.
