### PR TITLE
refactor(KEMDEM): share measure-based hybrid proofs

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -45,6 +45,7 @@ public import ToMathlib.Logic.Basic
 public import ToMathlib.MeasureTheory.DiscreteInstances
 public import ToMathlib.MeasureTheory.MeasurableSpace.Except
 public import ToMathlib.MeasureTheory.MeasurableSpace.Option
+public import ToMathlib.MeasureTheory.Measure.Bool
 public import ToMathlib.MeasureTheory.Measure.Bounds
 public import ToMathlib.MeasureTheory.Measure.Coupling
 public import ToMathlib.MeasureTheory.Measure.IndependentDraws

--- a/ToMathlib/MeasureTheory/Measure/Bool.lean
+++ b/ToMathlib/MeasureTheory/Measure/Bool.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma, Quang Dao
+-/
+
+module
+public import ToMathlib.MeasureTheory.Measure.Subprobability
+public import Mathlib.MeasureTheory.Integral.Lebesgue.Countable
+import Mathlib.Tactic.Linarith
+
+/-!
+# Boolean observation distances
+
+The distance of the `true` event and Boolean bias are expressed in real numbers.
+The hidden-bit identity requires total branches explicitly; missing mass cannot be
+silently identified with the `false` outcome.
+-/
+
+public section
+
+open MeasureTheory
+
+namespace MeasureTheory.Measure
+/-- Absolute difference between the masses of the two Boolean outcomes. -/
+@[expose]
+noncomputable def boolBias (μ : Measure Bool) : ℝ :=
+  |(μ {true}).toReal - (μ {false}).toReal|
+/-- Absolute difference between two measures on the event `{true}`. -/
+@[expose]
+noncomputable def boolDist (μ ν : Measure Bool) : ℝ :=
+  |(μ {true}).toReal - (ν {true}).toReal|
+/-- The Boolean event distance satisfies the triangle inequality. -/
+lemma boolDist_triangle (μ ν ρ : Measure Bool) :
+    μ.boolDist ρ ≤ μ.boolDist ν + ν.boolDist ρ := abs_sub_le _ _ _
+/-- Boolean event distance is symmetric. -/
+lemma boolDist_comm (μ ν : Measure Bool) : μ.boolDist ν = ν.boolDist μ := abs_sub_comm _ _
+/-- A fair hidden-bit guessing experiment has the event distance of its two total branches. -/
+lemma boolBias_bind_coin (coin μ ν : Measure Bool)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hcT : coin {true} = 1 / 2) (hcF : coin {false} = 1 / 2)
+    (hμ : μ {true} + μ {false} = 1) (hν : ν {true} + ν {false} = 1) :
+    (coin.bind fun b => (if b then μ else ν).bind
+      fun z => Measure.dirac (b == z)).boolBias = μ.boolDist ν := by
+  have hgame : ∀ x : Bool, (coin.bind fun b => (if b then μ else ν).bind
+        fun z => Measure.dirac (b == z)) {x} = (μ {x} + ν {!x}) / 2 := by
+    intro x
+    simp only [Measure.bind_apply (MeasurableSet.singleton x) Measurable.of_discrete.aemeasurable,
+      lintegral_fintype, Fintype.sum_bool, hcT, hcF]
+    cases x <;> simp [Measure.dirac_apply', div_eq_mul_inv, mul_add, mul_comm]
+  have hm := congrArg ENNReal.toReal hμ
+  have hn := congrArg ENNReal.toReal hν
+  simp only [ENNReal.toReal_add (measure_ne_top _ _) (measure_ne_top _ _),
+    ENNReal.toReal_one] at hm hn
+  unfold boolBias boolDist
+  rw [hgame true, hgame false]
+  simp only [Bool.not_true, Bool.not_false, ENNReal.toReal_div,
+    ENNReal.toReal_ofNat, ENNReal.toReal_add (measure_ne_top _ _) (measure_ne_top _ _)]
+  congr 1
+  linarith
+end MeasureTheory.Measure
+

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -71,6 +71,7 @@ public import VCVio.CryptoFoundations.HardnessAssumptions.TweakableHash.ToFinalV
 public import VCVio.CryptoFoundations.HashCommitment
 public import VCVio.CryptoFoundations.IdenSchemeWithAbort
 public import VCVio.CryptoFoundations.KEMDEM
+public import VCVio.CryptoFoundations.KEMDEM.Measure
 public import VCVio.CryptoFoundations.KeyEncapMech
 public import VCVio.CryptoFoundations.MacAlg
 public import VCVio.CryptoFoundations.MacFromPRF

--- a/VCVio/CryptoFoundations/KEMDEM.lean
+++ b/VCVio/CryptoFoundations/KEMDEM.lean
@@ -9,7 +9,8 @@ module
 public import VCVio.CryptoFoundations.DataEncapMech
 public import VCVio.CryptoFoundations.KeyEncapMech
 public import VCVio.CryptoFoundations.AsymmEncAlg.INDCPA.OneTime
-public import VCVio.ProgramLogic.Relational.Quantitative
+public import VCVio.CryptoFoundations.KEMDEM.Measure
+public import VCVio.OracleComp.Constructions.SampleableType.MeasureCompatibility
 
 /-!
 # KEM + DEM Composition
@@ -22,7 +23,7 @@ reduction skeleton against the repo's existing KEM and one-time IND-CPA interfac
 
 universe u v
 
-open OracleSpec OracleComp ENNReal
+open OracleSpec OracleComp ENNReal MeasureTheory
 
 namespace KEMScheme
 
@@ -137,6 +138,9 @@ def composeWithDEM_toDEMReduction
 bounded by two KEM IND-CPA advantages plus one DEM IND-CPA advantage, using the canonical
 left/right and DEM reductions defined above.
 
+The probability-free games and shared hybrid argument live in
+`VCVio.CryptoFoundations.KEMDEM.Measure`. This theorem calibrates them to the bundled runtime.
+
 The runtime coherence hypotheses require `runtime.evalSPMF` to be a monad morphism (preserves
 `pure` and distributes `>>=`) and to produce total distributions on `Bool` (no failure mass).
 These hold for all standard runtime constructions, including `withStateOracle`. -/
@@ -161,199 +165,62 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
       kem.IND_CPA_Advantage runtime (kem.composeWithDEM_toKEMRightReduction dem adversary) +
       dem.IND_CPA_Advantage runtime
         (kem.composeWithDEM_toDEMReduction dem adversary) := by
-  let real_m₀ : SPMF Bool := runtime.evalSPMF do
+  let : MeasurableSpace K := ⊤
+  let : MeasurableSpace (CKEM × K) := ⊤
+  let : MeasurableSpace (PK × M × M × adversary.State) := ⊤
+  let : EvalDistSemantics (OracleComp spec) := {
+    denote mx := (runtime.evalSPMF mx).toMeasure
+    apply_univ_le_one mx := SPMF.toMeasure_apply_univ_le_one _ }
+  let : LawfulEvalDistSemantics (OracleComp spec) := {
+    denote_pure a := by
+      change (runtime.evalSPMF (pure a)).toMeasure = _
+      rw [heval_pure, SPMF.toMeasure_pure]
+    denote_bind mx f hf := by
+      change (runtime.evalSPMF (mx >>= f)).toMeasure = _
+      rw [heval_bind]
+      exact SPMF.toMeasure_bind' _ _ hf }
+  let prepare : OracleComp spec (PK × M × M × adversary.State) := do
     let (pk, _) ← kem.keygen
-    let (m₀, _, st) ← adversary.chooseMessages pk
-    let (kc, k) ← kem.encaps pk
-    let dc ← dem.encrypt k m₀
-    adversary.distinguish st (kc, dc)
-  let rand_m₀ : SPMF Bool := runtime.evalSPMF do
-    let (pk, _) ← kem.keygen
-    let (m₀, _, st) ← adversary.chooseMessages pk
-    let (kc, _) ← kem.encaps pk
-    let kR ← runtime.liftProbComp ($ᵗ K)
-    let dc ← dem.encrypt kR m₀
-    adversary.distinguish st (kc, dc)
-  let rand_m₁ : SPMF Bool := runtime.evalSPMF do
-    let (pk, _) ← kem.keygen
-    let (_, m₁, st) ← adversary.chooseMessages pk
-    let (kc, _) ← kem.encaps pk
-    let kR ← runtime.liftProbComp ($ᵗ K)
-    let dc ← dem.encrypt kR m₁
-    adversary.distinguish st (kc, dc)
-  let real_m₁ : SPMF Bool := runtime.evalSPMF do
-    let (pk, _) ← kem.keygen
-    let (_, m₁, st) ← adversary.chooseMessages pk
-    let (kc, k) ← kem.encaps pk
-    let dc ← dem.encrypt k m₁
-    adversary.distinguish st (kc, dc)
-  have bind_swap : ∀ {α β γ : Type} (mx : SPMF α) (my : SPMF β) (f : α → β → SPMF γ),
-      (mx >>= fun a => my >>= fun b => f a b) =
-      (my >>= fun b => mx >>= fun a => f a b) := by
-    intro α β γ mx my f
-    ext x
-    simpa only [probOutput_def, evalSPMF_id] using
-      probOutput_bind_bind_swap mx my (fun a b => f a b) x
-  have hite_false : (false : Bool) = true ↔ False := ⟨Bool.noConfusion, False.elim⟩
-  have hite_true : (true : Bool) = true ↔ True := ⟨fun _ => trivial, fun _ => rfl⟩
-  have coin_branch : ∀ X Y : SPMF Bool, Pr[= true | X] + Pr[= false | X] = 1 →
-      Pr[= true | Y] + Pr[= false | Y] = 1 →
-      (𝒮[$ᵗ Bool] >>= fun b =>
-          (if b then X else Y) >>= fun z => pure (b == z)).boolBiasAdvantage =
-        SPMF.boolDistAdvantage X Y := fun X Y hX hY =>
-    SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch (𝒮[$ᵗ Bool]) X Y
-      (by simp [Fintype.card_bool]) (by simp [Fintype.card_bool]) hX hY
-  have h_composed : AsymmEncAlg.IND_CPA_OneTime_biasAdvantage
-      (kem.composeWithDEM dem) runtime adversary =
-      SPMF.boolDistAdvantage real_m₀ real_m₁ := by
-    have hspmf : AsymmEncAlg.IND_CPA_OneTime_Game (encAlg := kem.composeWithDEM dem)
-        adversary runtime =
-        𝒮[$ᵗ Bool] >>= fun b =>
-          (if b then real_m₀ else real_m₁) >>= fun z => pure (b == z) := by
-      simp only [AsymmEncAlg.IND_CPA_OneTime_Game, KEMScheme.composeWithDEM,
-        heval_bind, heval_liftProbComp]
-      congr 1; funext b
-      simp only [heval_pure]
-      cases b
-      · simp only [hite_false, ite_false, bind_assoc, pure_bind]
-        change _ = (runtime.evalSPMF do
-          let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
-          let (kc, k) ← kem.encaps pk; let dc ← dem.encrypt k m₁
-          adversary.distinguish st (kc, dc)) >>= fun a => pure (false == a)
-        simp only [heval_bind, bind_assoc]
-      · simp only [ite_true, bind_assoc, pure_bind]
-        change _ = (runtime.evalSPMF do
-          let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
-          let (kc, k) ← kem.encaps pk; let dc ← dem.encrypt k m₀
-          adversary.distinguish st (kc, dc)) >>= fun a => pure (true == a)
-        simp only [heval_bind, bind_assoc]
-    change (AsymmEncAlg.IND_CPA_OneTime_Game (encAlg := kem.composeWithDEM dem) adversary
-        runtime).boolBiasAdvantage = _
-    rw [hspmf, coin_branch _ _ (hno_fail _) (hno_fail _)]
-  have h_kem_left : kem.IND_CPA_Advantage runtime
-      (kem.composeWithDEM_toKEMLeftReduction dem adversary) =
-      SPMF.boolDistAdvantage real_m₀ rand_m₀ := by
-    have hspmf : KEMScheme.IND_CPA_Game runtime
-        (kem.composeWithDEM_toKEMLeftReduction dem adversary) =
-        𝒮[$ᵗ Bool] >>= fun b =>
-          (if b then real_m₀ else rand_m₀) >>= fun z => pure (b == z) := by
-      simp only [KEMScheme.IND_CPA_Game, composeWithDEM_toKEMLeftReduction,
-        heval_bind, heval_pure, heval_liftProbComp]
-      simp_rw [bind_swap (my := 𝒮[$ᵗ Bool])]
-      congr 1; funext b
-      conv_lhs => simp only [bind_assoc, pure_bind]
-      cases b
-      · simp only [hite_false, ite_false]
-        change _ = (runtime.evalSPMF do
-          let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
-          let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
-          let dc ← dem.encrypt kR m₀; adversary.distinguish st (kc, dc)) >>= fun z =>
-          pure (false == z)
-        simp only [heval_bind, heval_liftProbComp, bind_assoc]
-      · simp only [ite_true]
-        change _ = (runtime.evalSPMF do
-          let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
-          let (kc, k) ← kem.encaps pk
-          let dc ← dem.encrypt k m₀; adversary.distinguish st (kc, dc)) >>= fun z =>
-          pure (true == z)
-        simp only [heval_bind, bind_assoc]
-        congr 1; funext pksk; congr 1; funext cms; congr 1; funext ckr
-        exact OracleComp.ProgramLogic.Relational.spmf_bind_const_of_no_failure
-          (OracleComp.ProgramLogic.Relational.probFailure_evalSPMF_eq_zero _) _
-    change (KEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
-    rw [hspmf, coin_branch _ _ (hno_fail _) (hno_fail _)]
-  have h_kem_right : kem.IND_CPA_Advantage runtime
-      (kem.composeWithDEM_toKEMRightReduction dem adversary) =
-      SPMF.boolDistAdvantage real_m₁ rand_m₁ := by
-    have hspmf : KEMScheme.IND_CPA_Game runtime
-        (kem.composeWithDEM_toKEMRightReduction dem adversary) =
-        𝒮[$ᵗ Bool] >>= fun b =>
-          (if b then real_m₁ else rand_m₁) >>= fun z => pure (b == z) := by
-      simp only [KEMScheme.IND_CPA_Game, composeWithDEM_toKEMRightReduction,
-        heval_bind, heval_pure, heval_liftProbComp]
-      simp_rw [bind_swap (my := 𝒮[$ᵗ Bool])]
-      congr 1; funext b
-      conv_lhs => simp only [bind_assoc, pure_bind]
-      cases b
-      · simp only [hite_false, ite_false]
-        change _ = (runtime.evalSPMF do
-          let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
-          let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
-          let dc ← dem.encrypt kR m₁; adversary.distinguish st (kc, dc)) >>= fun z =>
-          pure (false == z)
-        simp only [heval_bind, heval_liftProbComp, bind_assoc]
-      · simp only [ite_true]
-        change _ = (runtime.evalSPMF do
-          let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
-          let (kc, k) ← kem.encaps pk
-          let dc ← dem.encrypt k m₁; adversary.distinguish st (kc, dc)) >>= fun z =>
-          pure (true == z)
-        simp only [heval_bind, bind_assoc]
-        congr 1; funext pksk; congr 1; funext cms; congr 1; funext ckr
-        exact OracleComp.ProgramLogic.Relational.spmf_bind_const_of_no_failure
-          (OracleComp.ProgramLogic.Relational.probFailure_evalSPMF_eq_zero _) _
-    change (KEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
-    rw [hspmf, coin_branch _ _ (hno_fail _) (hno_fail _)]
-  have h_dem : dem.IND_CPA_Advantage runtime
-      (kem.composeWithDEM_toDEMReduction dem adversary) =
-      SPMF.boolDistAdvantage rand_m₀ rand_m₁ := by
-    have hspmf : DEMScheme.IND_CPA_Game runtime
-        (kem.composeWithDEM_toDEMReduction dem adversary) =
-        𝒮[$ᵗ Bool] >>= fun b =>
-          (if b then rand_m₁ else rand_m₀) >>= fun z => pure (b == z) := by
-      simp only [DEMScheme.IND_CPA_Game, KEMScheme.composeWithDEM_toDEMReduction,
-        heval_bind, heval_pure, heval_liftProbComp]
-      congr 1; funext b
-      conv_lhs => rw [bind_swap]
-      conv_lhs => simp only [bind_assoc, pure_bind]
-      cases b
-      · simp only [hite_false, ite_false]
-        change _ = (runtime.evalSPMF do
-          let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
-          let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
-          let dc ← dem.encrypt kR m₀; adversary.distinguish st (kc, dc)) >>= fun a =>
-          pure (false == a)
-        simp only [heval_bind, heval_liftProbComp, bind_assoc]
-      · simp only [ite_true]
-        change _ = (runtime.evalSPMF do
-          let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
-          let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
-          let dc ← dem.encrypt kR m₁; adversary.distinguish st (kc, dc)) >>= fun a =>
-          pure (true == a)
-        simp only [heval_bind, heval_liftProbComp, bind_assoc]
-    change (DEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
-    rw [hspmf, coin_branch _ _ (hno_fail _) (hno_fail _)]
-    unfold SPMF.boolDistAdvantage; rw [abs_sub_comm]
-  rw [h_composed]
-  calc SPMF.boolDistAdvantage real_m₀ real_m₁
-    _ ≤ SPMF.boolDistAdvantage real_m₀ rand_m₀ +
-        SPMF.boolDistAdvantage rand_m₀ rand_m₁ +
-        SPMF.boolDistAdvantage rand_m₁ real_m₁ := by
-      have := SPMF.boolDistAdvantage_triangle real_m₀ rand_m₀ real_m₁
-      have := SPMF.boolDistAdvantage_triangle rand_m₀ rand_m₁ real_m₁
-      linarith
-    _ = kem.IND_CPA_Advantage runtime
-          (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
-        SPMF.boolDistAdvantage rand_m₀ rand_m₁ +
-        SPMF.boolDistAdvantage rand_m₁ real_m₁ := by rw [← h_kem_left]
-    _ = kem.IND_CPA_Advantage runtime
-          (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
-        dem.IND_CPA_Advantage runtime
-          (kem.composeWithDEM_toDEMReduction dem adversary) +
-        SPMF.boolDistAdvantage rand_m₁ real_m₁ := by rw [← h_dem]
-    _ = kem.IND_CPA_Advantage runtime
-          (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
-        dem.IND_CPA_Advantage runtime
-          (kem.composeWithDEM_toDEMReduction dem adversary) +
-        SPMF.boolDistAdvantage real_m₁ rand_m₁ := by
-      congr 1; unfold SPMF.boolDistAdvantage; rw [abs_sub_comm]
-    _ = kem.IND_CPA_Advantage runtime
-          (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
-        kem.IND_CPA_Advantage runtime
-          (kem.composeWithDEM_toKEMRightReduction dem adversary) +
-        dem.IND_CPA_Advantage runtime
-          (kem.composeWithDEM_toDEMReduction dem adversary) := by
-      rw [← h_kem_right]; ring
+    let (m₀, m₁, st) ← adversary.chooseMessages pk
+    pure (pk, m₀, m₁, st)
+  let encaps (p : PK × M × M × adversary.State) := kem.encaps p.1
+  let finish (p : PK × M × M × adversary.State) (kc : CKEM) (k : K) (side : Bool) := do
+    let dc ← dem.encrypt k (if side then p.2.1 else p.2.2.1)
+    adversary.distinguish p.2.2.2 (kc, dc)
+  have hcoin (b : Bool) : 𝒟[runtime.liftProbComp ($ᵗ Bool)] {b} = 1 / 2 := by
+    change (runtime.evalSPMF (runtime.liftProbComp ($ᵗ Bool))).toMeasure {b} = _
+    rw [heval_liftProbComp, SPMF.toMeasure_apply_singleton]
+    change Pr[= b | $ᵗ Bool] = _
+    simp [Fintype.card_bool]
+  have hkey : 𝒟[runtime.liftProbComp ($ᵗ K)] Set.univ = 1 := by
+    change (runtime.evalSPMF (runtime.liftProbComp ($ᵗ K))).toMeasure Set.univ = _
+    rw [heval_liftProbComp]
+    change 𝒟[$ᵗ K] Set.univ = _
+    rw [evalDist_uniformSample]
+    simp
+  have htotal (real side : Bool) :
+      𝒟[KEMDEM.hybrid prepare encaps finish (runtime.liftProbComp ($ᵗ K)) real side] {true} +
+      𝒟[KEMDEM.hybrid prepare encaps finish (runtime.liftProbComp ($ᵗ K)) real side] {false} =
+        1 := by
+    change (runtime.evalSPMF _).toMeasure {true} + (runtime.evalSPMF _).toMeasure {false} = _
+    simpa only [SPMF.toMeasure_apply_singleton, probOutput_def, evalSPMF_id] using hno_fail
+      (KEMDEM.hybrid prepare encaps finish (runtime.liftProbComp ($ᵗ K)) real side)
+  have h := KEMDEM.bias_compose_le prepare encaps finish
+    (runtime.liftProbComp ($ᵗ Bool)) (runtime.liftProbComp ($ᵗ K))
+    (hcoin true) (hcoin false) hkey htotal
+  change (runtime.evalSPMF _).toMeasure.boolBias ≤
+    (runtime.evalSPMF _).toMeasure.boolBias + (runtime.evalSPMF _).toMeasure.boolBias +
+    (runtime.evalSPMF _).toMeasure.boolBias at h
+  have hnot (b : Bool) (x y : M) : (if !b then x else y) = (if b then y else x) := by
+    cases b <;> rfl
+  simpa only [Measure.boolBias, SPMF.toMeasure_apply_singleton,
+    AsymmEncAlg.IND_CPA_OneTime_biasAdvantage, KEMScheme.IND_CPA_Advantage,
+    DEMScheme.IND_CPA_Advantage, SPMF.boolBiasAdvantage, probOutput_def, evalSPMF_id,
+    AsymmEncAlg.IND_CPA_OneTime_Game, KEMScheme.IND_CPA_Game, DEMScheme.IND_CPA_Game,
+    KEMDEM.composedGame, KEMDEM.kemGame, KEMDEM.demGame, prepare, encaps, finish,
+    composeWithDEM, composeWithDEM_toKEMLeftReduction, composeWithDEM_toKEMRightReduction,
+    composeWithDEM_toDEMReduction, bind_assoc, pure_bind, ite_true, Bool.false_eq_true,
+    ite_false, hnot] using h
 
 end IND_CPA
 

--- a/VCVio/CryptoFoundations/KEMDEM/Measure.lean
+++ b/VCVio/CryptoFoundations/KEMDEM/Measure.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma, Quang Dao
+-/
+
+module
+public import VCVio.EvalDist.Monad.Measure
+public import ToMathlib.MeasureTheory.Measure.Bool
+
+/-!
+# Measure-based KEM–DEM hybrid argument
+
+The computations take a preparation phase, encapsulation, and a final observation.
+They preserve the original effect order. Probability enters only through a lawful
+measure interpretation, a fair coin, a lossless independent key, and total hybrid
+outputs. The KEM identity is shared by both message branches.
+-/
+
+public section
+
+open MeasureTheory
+
+namespace KEMDEM
+variable {m : Type → Type*} [Monad m]
+  {A B K : Type}
+/-- Run one message branch using either the encapsulated key or an independent key. -/
+@[expose]
+def hybrid (prepare : m A) (encaps : A → m (B × K))
+    (finish : A → B → K → Bool → m Bool) (key : m K) (real side : Bool) : m Bool := do
+  let a ← prepare
+  let (c, k) ← encaps a
+  let k' ← if real then pure k else key
+  finish a c k' side
+
+/-- The KEM guessing experiment for one fixed message branch. -/
+@[expose]
+def kemGame (prepare : m A) (encaps : A → m (B × K))
+    (finish : A → B → K → Bool → m Bool) (coin : m Bool) (key : m K)
+    (side : Bool) : m Bool := do
+  let a ← prepare
+  let b ← coin
+  let (c, k) ← encaps a
+  let kr ← key
+  let z ← finish a c (if b then k else kr) side
+  pure (b == z)
+
+/-- The composed encryption guessing experiment, with its challenge bit sampled first. -/
+@[expose]
+def composedGame (prepare : m A) (encaps : A → m (B × K))
+    (finish : A → B → K → Bool → m Bool) (coin : m Bool) : m Bool := do
+  let b ← coin
+  let a ← prepare
+  let (c, k) ← encaps a
+  let z ← finish a c k b
+  pure (b == z)
+
+/-- The DEM guessing experiment, with the independent key sampled before preparation. -/
+@[expose]
+def demGame (prepare : m A) (encaps : A → m (B × K))
+    (finish : A → B → K → Bool → m Bool) (coin : m Bool) (key : m K) : m Bool := do
+  let b ← coin
+  let kr ← key
+  let a ← prepare
+  let (c, _) ← encaps a
+  let z ← finish a c kr (!b)
+  pure (b == z)
+
+/-- The composed experiment is a hidden-bit choice between its two real-key branches. -/
+lemma composedGame_eq [LawfulMonad m]
+    (prepare : m A) (encaps : A → m (B × K))
+    (finish : A → B → K → Bool → m Bool) (coin : m Bool) (key : m K) :
+    composedGame prepare encaps finish coin =
+    (coin >>= fun b => (if b then hybrid prepare encaps finish key true true
+      else hybrid prepare encaps finish key true false) >>= fun z => pure (b == z)) := by
+  apply bind_congr
+  intro b
+  cases b <;> simp [hybrid]
+
+variable [LawfulMonad m] [EvalDistSemantics m] [LawfulEvalDistSemantics m]
+  [MeasurableSpace A] [DiscreteMeasurableSpace A]
+  [MeasurableSpace (B × K)] [DiscreteMeasurableSpace (B × K)]
+  [MeasurableSpace K] [DiscreteMeasurableSpace K] [Countable K]
+  (prepare : m A) (encaps : A → m (B × K))
+  (finish : A → B → K → Bool → m Bool) (coin : m Bool) (key : m K)
+
+omit [Countable K] in
+/-- Both KEM message branches share the same measure decomposition into real and random keys. -/
+lemma evalDist_kemGame (hkey : 𝒟[key] Set.univ = 1) (side : Bool) :
+    𝒟[kemGame prepare encaps finish coin key side] =
+      𝒟[coin >>= fun b => (if b then hybrid prepare encaps finish key true side
+        else hybrid prepare encaps finish key false side) >>= fun z => pure (b == z)] := by
+  unfold kemGame
+  rw [evalDist_bind_bind_swap prepare coin _
+    (measurable_from_prod_countable_left fun _ => .of_discrete)]
+  rw [evalDist_bind_of_discrete coin, evalDist_bind_of_discrete coin]
+  apply Measure.bind_congr_right
+  apply Filter.Eventually.of_forall
+  intro b
+  cases b
+  · simp only [Bool.false_eq_true, ite_false, hybrid, bind_assoc]
+  · simp only [ite_true, hybrid, bind_assoc, pure_bind]
+    simp only [evalDist_bind_of_discrete]
+    apply Measure.bind_congr_right (Filter.Eventually.of_forall fun a => ?_)
+    apply Measure.bind_congr_right (Filter.Eventually.of_forall fun ck => ?_)
+    rw [Measure.bind_const, hkey, one_smul]
+
+/-- Independent-key interchange identifies the DEM experiment with the two random-key branches. -/
+lemma evalDist_demGame :
+    𝒟[demGame prepare encaps finish coin key] =
+      𝒟[coin >>= fun b => (if b then hybrid prepare encaps finish key false false
+        else hybrid prepare encaps finish key false true) >>= fun z => pure (b == z)] := by
+  unfold demGame
+  rw [evalDist_bind_of_discrete coin, evalDist_bind_of_discrete coin]
+  apply Measure.bind_congr_right (Filter.Eventually.of_forall fun b => ?_)
+  cases b <;> simp only [Bool.false_eq_true, ite_false, ite_true, Bool.not_false,
+    Bool.not_true, hybrid, bind_assoc]
+  all_goals
+    rw [evalDist_bind_bind_swap key prepare _
+      (measurable_from_prod_countable_right fun _ => .of_discrete)]
+    rw [evalDist_bind_of_discrete prepare, evalDist_bind_of_discrete prepare]
+    apply Measure.bind_congr_right (Filter.Eventually.of_forall fun a => ?_)
+    exact evalDist_bind_bind_swap key (encaps a) _
+      (measurable_from_prod_countable_right fun _ => .of_discrete)
+
+/-- The composed bias is bounded by the two KEM biases and the DEM bias. -/
+lemma bias_compose_le
+    (hcT : 𝒟[coin] {true} = 1 / 2) (hcF : 𝒟[coin] {false} = 1 / 2)
+    (hkey : 𝒟[key] Set.univ = 1)
+    (htotal : ∀ real side, 𝒟[hybrid prepare encaps finish key real side] {true} +
+      𝒟[hybrid prepare encaps finish key real side] {false} = 1) :
+    (𝒟[composedGame prepare encaps finish coin]).boolBias ≤
+      (𝒟[kemGame prepare encaps finish coin key true]).boolBias +
+      (𝒟[kemGame prepare encaps finish coin key false]).boolBias +
+      (𝒟[demGame prepare encaps finish coin key]).boolBias := by
+  have hbranch (p q : m Bool) (hp : 𝒟[p] {true} + 𝒟[p] {false} = 1)
+      (hq : 𝒟[q] {true} + 𝒟[q] {false} = 1) :
+      (𝒟[coin >>= fun b => (if b then p else q) >>= fun z => pure (b == z)]).boolBias =
+        (𝒟[p]).boolDist 𝒟[q] := by
+    simp only [evalDist_bind_of_discrete, evalDist_pure]
+    have hif (b : Bool) : 𝒟[if b then p else q] =
+        (if b then 𝒟[p] else 𝒟[q]) := by cases b <;> rfl
+    simp_rw [hif]
+    exact Measure.boolBias_bind_coin _ _ _ hcT hcF hp hq
+  rw [composedGame_eq prepare encaps finish coin key,
+    evalDist_kemGame prepare encaps finish coin key hkey true,
+    evalDist_kemGame prepare encaps finish coin key hkey false,
+    evalDist_demGame prepare encaps finish coin key,
+    hbranch _ _ (htotal true true) (htotal true false),
+    hbranch _ _ (htotal true true) (htotal false true),
+    hbranch _ _ (htotal true false) (htotal false false),
+    hbranch _ _ (htotal false false) (htotal false true)]
+  have h₁ := Measure.boolDist_triangle
+    𝒟[hybrid prepare encaps finish key true true]
+    𝒟[hybrid prepare encaps finish key false true]
+    𝒟[hybrid prepare encaps finish key true false]
+  have h₂ := Measure.boolDist_triangle
+    𝒟[hybrid prepare encaps finish key false true]
+    𝒟[hybrid prepare encaps finish key false false]
+    𝒟[hybrid prepare encaps finish key true false]
+  rw [Measure.boolDist_comm 𝒟[hybrid prepare encaps finish key false false]
+    𝒟[hybrid prepare encaps finish key true false],
+    Measure.boolDist_comm 𝒟[hybrid prepare encaps finish key false true]
+      𝒟[hybrid prepare encaps finish key false false]] at h₂
+  linarith
+
+end KEMDEM

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -6,6 +6,7 @@ public import VCVioTest.CryptoFoundations.BR93Measure
 public import VCVioTest.CryptoFoundations.ComplexityAdapters
 public import VCVioTest.CryptoFoundations.ComplexityTactics
 public import VCVioTest.CryptoFoundations.ComputationalComplexitySoundness
+public import VCVioTest.CryptoFoundations.KEMDEMMeasure
 public import VCVioTest.CryptoFoundations.OracleClosure
 public import VCVioTest.CryptoFoundations.PRFTableMeasure
 public import VCVioTest.CryptoFoundations.SignatureAlg

--- a/VCVioTest/CryptoFoundations/KEMDEMMeasure.lean
+++ b/VCVioTest/CryptoFoundations/KEMDEMMeasure.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import VCVio.CryptoFoundations.KEMDEM.Measure
+public import VCVio.EvalDist.PFunctorMeasure.Core
+import Mathlib.Tactic.NormNum
+
+/-!
+# Native KEM–DEM and Boolean-bias checks
+
+The native hybrid proof imports no discrete probability backend. A direct free-program
+interpretation exercises the whole bound; a lossy branch demonstrates why the hidden-bit
+identity needs its totality hypotheses.
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory PFunctor
+
+run_cmd do
+  let env ← Lean.getEnv
+  for name in [`PMF, `SPMF] do
+    if env.contains name then
+      throwError "native KEM–DEM imports unexpectedly include {name}"
+
+namespace VCVioTest.KEMDEMMeasure
+
+/-- A native fair-coin query interface. -/
+@[expose, reducible] def coinSpec : PFunctor.{0, 0} := ⟨Unit, fun _ => Bool⟩
+
+instance : coinSpec.Fintype where
+  fintypeB _ := inferInstance
+
+instance : coinSpec.Inhabited where
+  inhabitedB _ := inferInstance
+
+noncomputable instance : coinSpec.IsMeasureSpec :=
+  IsMeasureSpec.uniformOfFintypeInhabited _
+
+example (prepare : FreeM coinSpec Unit) (encaps : Unit → FreeM coinSpec (Bool × Bool))
+    (finish : Unit → Bool → Bool → Bool → FreeM coinSpec Bool) :
+    (𝒟[KEMDEM.composedGame prepare encaps finish (FreeM.lift ())]).boolBias ≤
+      (𝒟[KEMDEM.kemGame prepare encaps finish (FreeM.lift ()) (FreeM.lift ()) true]).boolBias +
+      (𝒟[KEMDEM.kemGame prepare encaps finish (FreeM.lift ()) (FreeM.lift ()) false]).boolBias +
+      (𝒟[KEMDEM.demGame prepare encaps finish (FreeM.lift ()) (FreeM.lift ())]).boolBias := by
+  let (mx : FreeM coinSpec Bool) : IsProbabilityMeasure 𝒟[mx] :=
+    FreeM.isProbabilityMeasure_denote mx
+  have hcoin (b : Bool) : (uniformOn Set.univ : Measure Bool) {b} = 1 / 2 := by
+    rw [uniformOn_univ]
+    simp [Fintype.card_bool]
+  apply KEMDEM.bias_compose_le
+  · rw [FreeM.evalDist_lift (P := coinSpec)]
+    exact hcoin _
+  · rw [FreeM.evalDist_lift (P := coinSpec)]
+    exact hcoin _
+  · exact measure_univ
+  · intro real side
+    have h : ∫⁻ _, (1 : ENNReal)
+        ∂𝒟[KEMDEM.hybrid prepare encaps finish (FreeM.lift ()) real side] = 1 := by
+      rw [lintegral_one]
+      exact measure_univ
+    simpa only [lintegral_fintype, Fintype.sum_bool, one_mul] using h
+
+example :
+    ((uniformOn Set.univ : Measure Bool).bind fun b =>
+      (if b then 0 else Measure.dirac true).bind fun z => Measure.dirac (b == z)).boolBias =
+        1 / 2 := by
+  have hcoin (b : Bool) : (uniformOn Set.univ : Measure Bool) {b} = 1 / 2 := by
+    rw [uniformOn_univ]
+    simp [Fintype.card_bool]
+  unfold Measure.boolBias
+  simp only [Measure.bind_apply (MeasurableSet.singleton _) Measurable.of_discrete.aemeasurable,
+    lintegral_fintype, Fintype.sum_bool, hcoin]
+  norm_num [Measure.dirac_apply']
+
+example : (0 : Measure Bool).boolDist (Measure.dirac true) = 1 := by
+  norm_num [Measure.boolDist, Measure.dirac_apply']
+
+end VCVioTest.KEMDEMMeasure

--- a/docs/agents/crypto.md
+++ b/docs/agents/crypto.md
@@ -140,6 +140,19 @@ structure BoundedAdversary {ι : Type u} [DecidableEq ι]
 
 All return `ℝ` via `.toReal` conversion from `ℝ≥0∞`. This is essential since subtraction on `ℝ≥0∞` is truncated.
 
+### KEM–DEM hybrid composition
+
+`VCVio.CryptoFoundations.KEMDEM.Measure` defines the preparation, encapsulation, and final
+observation games independently of probability. `KEMDEM.bias_compose_le` proves the
+composition bound with native measures. Both KEM message branches use `evalDist_kemGame`;
+`evalDist_demGame` performs independent-key interchange. Supply a fair coin, a lossless key
+sampler, and total Boolean hybrid outputs explicitly. Preparation and encapsulation effects
+retain their order. The `ProbCompRuntime` theorem in `KEMDEM.lean` is a compatibility adapter.
+
+`ToMathlib.MeasureTheory.Measure.Bool` provides Boolean event distance and bias algebra.
+`Measure.boolBias_bind_coin` requires total branches: missing mass is distinct from returning
+`false`, so the assumption cannot be dropped.
+
 ### Forking bounds and measure semantics
 
 `VCVio/CryptoFoundations/SeededFork.lean` and `ReplayFork.lean` prove the


### PR DESCRIPTION
The KEM–DEM composition theorem repeated the KEM game decomposition for each message and mixed game normalization with Boolean probability algebra. The new probability-free games preserve preparation and encapsulation effect order, and a shared native-measure proof supplies both KEM branches and independent-key interchange for the DEM branch. The existing runtime theorem now calibrates this argument through a compatibility adapter.

The measure core imports no PMF/SPMF machinery. Fairness, key-sampler mass, and hybrid totality are explicit hypotheses. Boolean bias and event-distance lemmas live below the crypto layer; a lossy regression example demonstrates why branch totality is necessary.

Validation: `./scripts/validate.sh --lint --test --axioms` passes, including the native free-program composition canary and a check excluding discrete probability imports. Axiom sweep: 18,229 declarations, 577 modules, unchanged 40 existing sorry-tainted declarations, no nonstandard axioms. PMF boundary ratchet passes.

Stacked on #694; this PR contains the KEM–DEM stage of the long-proof refactor.
