### PR TITLE
chore(SLHDSA): credit surviving authorship across the SLH-DSA modules

### DIFF
--- a/HashSig/SLHDSA/Address.lean
+++ b/HashSig/SLHDSA/Address.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/C13/Concrete.lean
+++ b/HashSig/SLHDSA/C13/Concrete.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Nicolas Consigny. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Codec.lean
+++ b/HashSig/SLHDSA/Codec.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny, Quang Dao
+Authors: Nicolas Consigny, Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Codec.lean
+++ b/HashSig/SLHDSA/Concrete/Codec.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/FIPS.lean
+++ b/HashSig/SLHDSA/Concrete/FIPS.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Fors.lean
+++ b/HashSig/SLHDSA/Concrete/Fors.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Hypertree.lean
+++ b/HashSig/SLHDSA/Concrete/Hypertree.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Instance.lean
+++ b/HashSig/SLHDSA/Concrete/Instance.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Nicolas Consigny. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Keccak.lean
+++ b/HashSig/SLHDSA/Concrete/Keccak.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Vitalik Buterin, Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Vitalik Buterin, Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Vitalik Buterin, Nicolas Consigny
+Authors: Vitalik Buterin, Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Prehash.lean
+++ b/HashSig/SLHDSA/Concrete/Prehash.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Quang Dao, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Sha2.lean
+++ b/HashSig/SLHDSA/Concrete/Sha2.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Wots.lean
+++ b/HashSig/SLHDSA/Concrete/Wots.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Concrete/Xmss.lean
+++ b/HashSig/SLHDSA/Concrete/Xmss.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny, Bolton Bailey
+Authors: Nicolas Consigny, Bolton Bailey, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/DepthOneCompatibility.lean
+++ b/HashSig/SLHDSA/DepthOneCompatibility.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Quang Dao, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Encoding.lean
+++ b/HashSig/SLHDSA/Encoding.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/EncodingLemmas.lean
+++ b/HashSig/SLHDSA/EncodingLemmas.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/External.lean
+++ b/HashSig/SLHDSA/External.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Quang Dao, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/FipsParams.lean
+++ b/HashSig/SLHDSA/FipsParams.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/ForsConformance.lean
+++ b/HashSig/SLHDSA/ForsConformance.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/GeneralScheme.lean
+++ b/HashSig/SLHDSA/GeneralScheme.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Quang Dao, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/GeneralSchemeQueryBound.lean
+++ b/HashSig/SLHDSA/GeneralSchemeQueryBound.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Quang Dao, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/HypertreeConformance.lean
+++ b/HashSig/SLHDSA/HypertreeConformance.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Params.lean
+++ b/HashSig/SLHDSA/Params.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Nicolas Consigny. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Primitives.lean
+++ b/HashSig/SLHDSA/Primitives.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Nicolas Consigny. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/RandomOracle.lean
+++ b/HashSig/SLHDSA/RandomOracle.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Nicolas Consigny. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/Security/ReachableTargets.lean
+++ b/HashSig/SLHDSA/Security/ReachableTargets.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Quang Dao, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao, Alexander Hicks
 -/

--- a/HashSig/SLHDSA/Security/TargetCounts.lean
+++ b/HashSig/SLHDSA/Security/TargetCounts.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nicolas Consigny, Alexander Hicks
 -/

--- a/HashSig/SLHDSA/Wots.lean
+++ b/HashSig/SLHDSA/Wots.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Nicolas Consigny. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/WotsChecksum.lean
+++ b/HashSig/SLHDSA/WotsChecksum.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Vitalik Buterin, Nicolas Consigny. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Vitalik Buterin, Nicolas Consigny
+Authors: Vitalik Buterin, Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/WotsEncoding.lean
+++ b/HashSig/SLHDSA/WotsEncoding.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSig/SLHDSA/XmssConformance.lean
+++ b/HashSig/SLHDSA/XmssConformance.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny, Bolton Bailey
+Authors: Nicolas Consigny, Bolton Bailey, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/DataCodecTests.lean
+++ b/HashSigTest/SLHDSA/DataCodecTests.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny, Quang Dao
+Authors: Nicolas Consigny, Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/External.lean
+++ b/HashSigTest/SLHDSA/External.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Quang Dao, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/ForsConstructionTests.lean
+++ b/HashSigTest/SLHDSA/ForsConstructionTests.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/GeneralScheme.lean
+++ b/HashSigTest/SLHDSA/GeneralScheme.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Quang Dao, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/HypertreeConformanceTests.lean
+++ b/HashSigTest/SLHDSA/HypertreeConformanceTests.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/Oracle.lean
+++ b/HashSigTest/SLHDSA/Oracle.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/PrimitiveTests.lean
+++ b/HashSigTest/SLHDSA/PrimitiveTests.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/WotsConstructionTests.lean
+++ b/HashSigTest/SLHDSA/WotsConstructionTests.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/WotsEncoding.lean
+++ b/HashSigTest/SLHDSA/WotsEncoding.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Alexander Hicks
 -/
 
 module

--- a/HashSigTest/SLHDSA/XmssConstructionTests.lean
+++ b/HashSigTest/SLHDSA/XmssConstructionTests.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Nicolas Consigny. All rights reserved.
+Copyright (c) 2026 Nicolas Consigny, Alexander Hicks. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny, Bolton Bailey
+Authors: Nicolas Consigny, Bolton Bailey, Alexander Hicks
 -/
 
 module


### PR DESCRIPTION
Across `HashSig/SLHDSA` and `HashSigTest/SLHDSA` there are files whose `Authors:` header
names nobody who wrote the file as it now stands. On seventeen library modules and nine
test modules, **every surviving line** is by Alexander Hicks, yet the header names only
Nicolas Consigny, Quang Dao, Bolton Bailey or Vitalik Buterin.

Those people authored the original versions and remain credited for them — nothing is
removed here. But because theirs are the only names a reader sees, questions about the
current content reach people who did not write it. That is the problem this fixes.

### How the line was drawn

Attribution is measured, not assumed. For each file, `git blame` over `main` gives the
share of surviving lines by author. Where Alexander Hicks' share is **at least 25%** the
name is added to the copyright line and to `Authors:`; **below 25%** it is added to
`Authors:` only. Two files were already corrected in the first commit on this branch.

| Share of surviving lines | Files | Change |
|---|---|---|
| 100% | 26 | copyright + `Authors:` |
| 25–99% | 5 | copyright + `Authors:` |
| 1–24% | 9 | `Authors:` only |

The repository already writes multi-name copyright lines in fourteen files, so this
follows existing practice.

<details>
<summary>Per-file measurements (share, blamed lines, change applied)</summary>

```
HashSigTest/SLHDSA/XmssConstructionTests.lean         100%  148/148      authors+copyright
HashSigTest/SLHDSA/PrimitiveTests.lean                100%  426/426      authors+copyright
HashSigTest/SLHDSA/HypertreeConformanceTests.lean     100%  283/283      authors+copyright
HashSigTest/SLHDSA/GeneralScheme.lean                 100%  166/166      authors+copyright
HashSigTest/SLHDSA/ForsConstructionTests.lean         100%  190/190      authors+copyright
HashSigTest/SLHDSA/External.lean                      100%  312/312      authors+copyright
HashSigTest/SLHDSA/DataCodecTests.lean                100%  276/276      authors+copyright
HashSig/SLHDSA/XmssConformance.lean                   100%  318/318      authors+copyright
HashSig/SLHDSA/WotsEncoding.lean                      100%  270/270      authors+copyright
HashSig/SLHDSA/HypertreeConformance.lean              100%  156/156      authors+copyright
HashSig/SLHDSA/GeneralSchemeQueryBound.lean           100%  110/110      authors+copyright
HashSig/SLHDSA/GeneralScheme.lean                     100%  207/207      authors+copyright
HashSig/SLHDSA/FipsParams.lean                        100%  85/85        authors+copyright
HashSig/SLHDSA/External.lean                          100%  277/277      authors+copyright
HashSig/SLHDSA/EncodingLemmas.lean                    100%  210/210      authors+copyright
HashSig/SLHDSA/DepthOneCompatibility.lean             100%  310/310      authors+copyright
HashSig/SLHDSA/Concrete/Xmss.lean                     100%  123/123      authors+copyright
HashSig/SLHDSA/Concrete/Wots.lean                     100%  70/70        authors+copyright
HashSig/SLHDSA/Concrete/Prehash.lean                  100%  343/343      authors+copyright
HashSig/SLHDSA/Concrete/Hypertree.lean                100%  103/103      authors+copyright
HashSig/SLHDSA/Concrete/Fors.lean                     100%  162/162      authors+copyright
HashSig/SLHDSA/Concrete/FIPS.lean                     100%  401/401      authors+copyright
HashSig/SLHDSA/Concrete/Codec.lean                    100%  367/367      authors+copyright
HashSig/SLHDSA/Codec.lean                             100%  824/824      authors+copyright
HashSigTest/SLHDSA/WotsEncoding.lean                   99%  245/247      authors+copyright
HashSigTest/SLHDSA/WotsConstructionTests.lean          99%  126/127      authors+copyright
HashSig/SLHDSA/ForsConformance.lean                    98%  282/285      authors+copyright
HashSig/SLHDSA/Address.lean                            72%  338/466      authors+copyright
HashSig/SLHDSA/Concrete/Sha2.lean                      65%  255/389      authors+copyright
HashSig/SLHDSA/Concrete/Keccak.lean                    49%  83/168       authors+copyright
HashSig/SLHDSA/Encoding.lean                           37%  53/141       authors+copyright
HashSigTest/SLHDSA/Oracle.lean                         22%  41/180       authors-only
HashSig/SLHDSA/Primitives.lean                         16%  24/148       authors-only
HashSig/SLHDSA/Params.lean                              8%  31/362       authors-only
HashSig/SLHDSA/Wots.lean                                7%  62/833       authors-only
HashSig/SLHDSA/Concrete/Instance.lean                   6%  13/193       authors-only
HashSig/SLHDSA/C13/Concrete.lean                        6%  9/132        authors-only
HashSig/SLHDSA/Scheme.lean                              4%  18/421       authors-only
HashSig/SLHDSA/RandomOracle.lean                        4%  15/304       authors-only
HashSig/SLHDSA/WotsChecksum.lean                        1%  5/307        authors-only
```
</details>

### Scope

Header lines only. Every hunk is on line 2 or line 4; no statement, proof, attribute or
docstring is touched, and no header line exceeds 100 columns.

### Validation

`./scripts/validate.sh --lint --test --axioms`
