### PR TITLE
feat: add scoped sampling-block probability notation

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -157,6 +157,7 @@ public import VCVio.EvalDist.Monad.Basic
 public import VCVio.EvalDist.Monad.Disagreement
 public import VCVio.EvalDist.Monad.Map
 public import VCVio.EvalDist.Monad.Seq
+public import VCVio.EvalDist.Notation
 public import VCVio.EvalDist.Option
 public import VCVio.EvalDist.PFunctor
 public import VCVio.EvalDist.PFunctorMeasure

--- a/VCVio/EvalDist/Notation.lean
+++ b/VCVio/EvalDist/Notation.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import VCVio.EvalDist.Defs.Basic
+
+/-!
+# Sampling blocks for event probabilities
+
+With `open scoped ProbabilityTheory`, write
+```
+Pr_{
+  let x ← mx
+  let y ← f x
+}[R x y]
+```
+for the probability of the final event after the indicated computations. The sampling block uses
+Lean's `doSeq` parser. It is joined with the event into one ordinary `do` block, so dependent
+bindings, patterns, local declarations, and mutable variables have their usual Lean scope.
+
+The notation expands to `Pr{...}[...]`, which appends `return R x y` and observes the probability
+of returning `True`. The event has type `Prop`; Boolean events use Lean's usual coercion. Ordinary
+control flow is preserved: an early `return` supplies the result proposition directly and skips
+the appended event. The braces therefore contain the prelude of the combined block, rather than
+a separately elaborated computation whose result must be destructured by the event.
+
+The probability semantics and typeclass assumptions are those of `probOutput`; no normalization
+on successful termination is performed. `probOutput_true_eq_probEvent` identifies a single-sample
+block with `probEvent`, and the measure compatibility lemmas relate that event to `𝒟[mx]` under
+their measurability and interpretation hypotheses. The notation is independent of the concrete
+monad and does not select an initial state or a probability interpretation.
+-/
+
+public meta section
+
+open Lean Parser Term
+
+namespace ProbabilityTheory
+
+/-- Probability of the event at the end of an ordinary Lean sampling block. -/
+scoped syntax (name := probabilityBlock) "Pr_{" doSeq "}[" term "]" : term
+
+scoped macro_rules (kind := probabilityBlock)
+  | `(Pr_{{$items*}}[$event]) => `(Pr{{$items*}}[$event])
+  | `(Pr_{$items*}[$event]) => `(Pr{$items*}[$event])
+
+end ProbabilityTheory

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -9,6 +9,7 @@ public import VCVioTest.CryptoFoundations.OracleClosure
 public import VCVioTest.CryptoFoundations.SignatureAlg
 public import VCVioTest.CryptoFoundations.SymmEncAlgMeasure
 public import VCVioTest.EvalDist.MeasureBridge
+public import VCVioTest.EvalDist.Notation
 public import VCVioTest.ForkMeasure
 public import VCVioTest.Forking.WithoutReplacement
 public import VCVioTest.GrindFailFast

--- a/VCVioTest/EvalDist/Notation.lean
+++ b/VCVioTest/EvalDist/Notation.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import VCVio.EvalDist.Notation
+public import VCVio.EvalDist.Defs.Instances
+public import VCVio.EvalDist.Instances.OptionT
+public import VCVio.OracleComp.ProbComp
+
+/-!
+# Sampling-block notation checks
+
+These checks exercise ordinary `do` binding and control flow, generic probability lemmas,
+failure without normalization, and the raw-distribution observation used by ArkLib.
+-/
+
+public section
+
+open OracleComp
+open scoped ProbabilityTheory
+
+namespace VCVioTest.ProbabilityNotation
+
+section generic
+
+universe v
+
+variable {m : Type → Type v} [Monad m] [LawfulMonad m]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  {α β : Type}
+
+example (mx : m α) (p : α → Prop) :
+    Pr_{let x ← mx}[p x] = Pr[p | mx] :=
+  probOutput_true_eq_probEvent mx p
+
+example (mx : m α) (p : α → Prop) :
+    Pr_{{let x ← mx}}[p x] = Pr[p | mx] :=
+  probOutput_true_eq_probEvent mx p
+
+example (mx : m α) (p : α → Bool) :
+    Pr_{let x ← mx}[p x] = Pr[(fun x => p x = true) | mx] :=
+  probOutput_true_eq_probEvent mx _
+
+example (mx : m α) (f : α → m β) (p : β → Prop) :
+    Pr_{let x ← mx; let y ← f x}[p y] = Pr[p | mx >>= f] := by
+  simpa only [bind_assoc] using probOutput_true_eq_probEvent (mx >>= f) p
+
+example (mx : m (Nat × Nat)) :
+    Pr_{let (x, y) ← mx; let z := x + y}[z = y + x] = Pr[fun _ => True | mx] := by
+  simpa only [Nat.add_comm, eq_self] using
+    probOutput_true_eq_probEvent mx (fun _ => True)
+
+example (mx : m Nat) (p : Nat → Prop) :
+    Pr_{
+      let x ← mx
+      let mut y := x
+      y := y + 1
+    }[p y] = Pr[(fun x => p (x + 1)) | mx] :=
+  probOutput_true_eq_probEvent mx _
+
+example (mx : m Nat) :
+    Pr_{
+      let x ← mx
+      if x = 0 then return False
+    }[True] = Pr[(fun x => x ≠ 0) | mx] := by
+  have h : (fun x : Nat => if x = 0 then (pure False : m Prop) else pure True) =
+      (fun x => pure (x ≠ 0)) := by
+    funext x
+    by_cases hx : x = 0 <;> simp [hx]
+  change Pr[= True | mx >>= _] = _
+  rw [h]
+  exact probOutput_true_eq_probEvent mx _
+
+end generic
+
+example (p : PMF Nat) (event : Nat → Prop) :
+    Pr_{let x ← p}[event x] = (do let x ← p; return event x) True :=
+  PMF.probOutput_eq_apply _ _
+
+example (mx : ProbComp Bool) :
+    Pr_{let b ← mx}[b] = Pr[= true | mx] := by
+  simp only [probOutput_true_eq_probEvent, probEvent_eq_eq_probOutput]
+
+example : Pr_{let _ ← (failure : OptionT ProbComp Unit)}[True] = 0 := by
+  simp
+
+example (mx : OptionT ProbComp Nat) :
+    Pr_{let _ ← mx}[True] = 1 - Pr[⊥ | mx] := by
+  simp only [probOutput_true_eq_probEvent, probEvent_True_eq_sub]
+
+end VCVioTest.ProbabilityNotation

--- a/docs/agents/notation.md
+++ b/docs/agents/notation.md
@@ -20,11 +20,36 @@
 | `Pr[p \| mx]` | `probEvent mx p` | `VCVio/EvalDist/Defs/Basic.lean` |
 | `Pr[⊥ \| mx]` | `probFailure mx` | `VCVio/EvalDist/Defs/Basic.lean` |
 | `Pr[cond \| var ← src]` | `probEvent src (fun var => cond)` | `VCVio/EvalDist/Defs/Basic.lean` |
+| `Pr_{let x ← mx}[p x]` | event probability using an ordinary Lean sampling block | `VCVio/EvalDist/Notation.lean` |
+
+Import `VCVio.EvalDist.Notation` and use `open scoped ProbabilityTheory` for
+`Pr_{...}[...]`. The braces accept Lean's standard `doSeq` grammar, including multiple dependent
+samples, pattern bindings, local declarations, and mutable variables. The event is appended as the
+final return of the same `do` block; it can use all bindings still in scope. Early returns have their
+ordinary Lean meaning and return a proposition directly, skipping the appended event. The notation
+is an alias of `Pr{...}[...]`; it preserves failure mass and does not select an interpretation or
+initial state. `probOutput_true_eq_probEvent` connects a single-sample block to `Pr[p | mx]`.
 
 **NOTE**: Legacy code and comments may still use the old `[= x | comp]` notation (without `Pr` prefix). Always use `Pr[...]` in new code.
 
 `Pr[...]` is a discrete compatibility notation. Use `probOutput_eq_evalDist`,
 `probEvent_eq_evalDist`, or `probFailure_eq_evalDist` to move a scalar statement to `𝒟[...]`.
+
+### Coordinated ArkLib adoption
+
+ArkLib's `ArkLib/Data/Probability/Notation.lean` defines the same `Pr_{...}[...]` spelling in
+the `ProbabilityTheory` scope. Its local parser and macro must be removed when its VCVio dependency
+is updated to include this module: enabling both definitions produces ambiguous terms.
+Keep ArkLib's existing import path as a compatibility module importing `VCVio.EvalDist.Notation`
+and `VCVio.EvalDist.Defs.Instances`. Retain `$ᵖ` and the mathematical helper lemmas in ArkLib.
+Existing call sites and `open scoped ProbabilityTheory` declarations can keep their spelling.
+
+The probability is unchanged, but the expansion is no longer definitionally a raw distribution
+application. At a proof boundary, `PMF.probOutput_eq_apply` identifies the new observation with
+`(do ...; return event) True`. Use that public equation where an old `rfl` or restricted unfolding
+proof depended on the expansion; generic event proofs can use `probOutput_true_eq_probEvent`.
+Validate the combined dependency/import change and the ArkLib probability and coding-theory
+callers before coordinating the merge. The notation PR remains draft pending that validation.
 
 ## Sampling Notations
 

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -1,5 +1,12 @@
 # Probability Reasoning (EvalDist and ProbComp)
 
+For sampling-and-event statements, import `VCVio.EvalDist.Notation` and use
+`open scoped ProbabilityTheory`. The notation `Pr_{let x ← mx; let y ← f x}[R x y]` uses Lean's
+ordinary `do` parser and elaborator, with the event in the scope of the sampling prelude.
+It shares the existing scalar probability semantics and does not normalize away failure.
+See the [notation reference](notation.md#probability-notations) for control flow, measure
+correspondence, and coordinated ArkLib adoption.
+
 For the cross-project survey of SPMF, Mathlib measures and kernels, PolyFun
 coalgebraic limits, ArkLib, Bluebell/Iris, and possible long-term migration paths, see
 [`Probability Semantics for Computations: Landscape and Design Options`](../reading/probability-semantics-landscape.md).


### PR DESCRIPTION
Add `Pr_{let x ← mx; let y ← f x}[R x y]` as a scoped alias of VCVio's existing `Pr{...}[...]` event-probability notation. Import `VCVio.EvalDist.Notation` and open `ProbabilityTheory` to use the sampling-and-event spelling already familiar to ArkLib callers.

The implementation reuses Lean's ordinary `doSeq` parser and the existing macro. Dependent samples, patterns, local declarations, mutable variables, and early returns retain their ordinary Lean scope and control flow. Existing notation and probability definitions are unchanged; failure is not normalized away. Documentation explains the generic probability interface and its measure compatibility hypotheses.

Keep this PR **draft pending coordinated ArkLib adoption**. ArkLib's `Data/Probability/Notation.lean` currently defines the same spelling and scope; importing both definitions causes ambiguity. Its migration should remove the duplicate parser/macro and import the upstream notation through that existing module, retaining `$ᵖ` and its helper lemmas. Proofs that relied on raw distribution application can use `PMF.probOutput_eq_apply`; generic event proofs can use `probOutput_true_eq_probEvent`. Validate ArkLib's probability and coding-theory callers with that dependency change before aligning the merges. No ArkLib PR is included here.

Validation:

- `lake build VCVioTest.EvalDist.Notation`: single and dependent samples, braced blocks, patterns, local and mutable variables, Boolean events, early returns, raw distribution compatibility, and transformer failure mass.
- `bash scripts/validate.sh`: all seven proof libraries, warning budget, generated imports, import boundaries, style checks, and agent documentation pass. Existing admitted declarations elsewhere remain unchanged.
