### PR TITLE
fix(control): prefer standard StateT lifting paths

### DIFF
--- a/ToMathlib/Control/StateT.lean
+++ b/ToMathlib/Control/StateT.lean
@@ -22,7 +22,7 @@ namespace StateT
 variable {m : Type u → Type v} {m' : Type u → Type w}
   {σ α β : Type u}
 
-instance [MonadLift m m'] : MonadLift (StateT σ m) (StateT σ m') where
+instance (priority := low) [MonadLift m m'] : MonadLift (StateT σ m) (StateT σ m') where
   monadLift x := StateT.mk fun s => liftM ((x.run) s)
 
 @[simp]

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -38,6 +38,7 @@ public import VCVioTest.SMDTTCRFinalValidity
 public import VCVioTest.SMDTUDFinalValidity
 public import VCVioTest.SampleableType
 public import VCVioTest.Smoke
+public import VCVioTest.StateTLift
 public import VCVioTest.Tactic.Expectation
 public import VCVioTest.Tactic.Finiteness
 public import VCVioTest.Tactic.FunProp

--- a/VCVioTest/StateTLift.lean
+++ b/VCVioTest/StateTLift.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import ToMathlib.Control.StateT
+public import ToMathlib.Control.WriterT
+
+/-!
+# Canonical lifting through state and writer transformers
+
+Lifting a base effect uses the standard outer state lift. Explicitly lifting a stateful program
+between base monads continues to use the covariance instance. The equations check the selected
+instance paths under ordinary imports, without assuming laws about the supplied base lift.
+-/
+
+public section
+
+universe u v w
+
+/-- An unrelated base effect enters the writer transformer before the outer state transformer. -/
+example {m : Type u → Type v} {n : Type u → Type w} [Monad m] [MonadLiftT n m]
+    {α σ W : Type u} [Monoid W] (sample : n α) :
+    (liftM sample : StateT σ (WriterT W m) α) =
+      StateT.lift (liftM (liftM sample : m α) : WriterT W m α) := rfl
+
+/-- Covariant lifting still transports an already stateful program between base monads. -/
+example {m : Type u → Type v} {n : Type u → Type w} [MonadLift m n]
+    {α σ : Type u} (program : StateT σ m α) :
+    (liftM program : StateT σ n α) = StateT.mk (fun s => liftM (program.run s)) := rfl


### PR DESCRIPTION
## Summary

Lifting a base effect into `StateT σ (WriterT W m)` selected the generic state-transformer covariance instance before the standard outer state lift. This routed sampling through `StateT σ m` and then moved the writer under state, producing a different normal form and preventing standard transformer transport lemmas from matching.

Give the covariance instance low priority. Explicitly lifting an already stateful computation between base monads remains available. Two ordinary-import, universe-generic regressions check both paths. Restoring the old priority makes the first regression fail at `rfl`.

This was exposed by the measure-native recursive extraction work for #515, but the fix is independent of that development and of the PolyFun prerequisite PRs.

## Verification

- The two focused regressions pass on current VCVio main with this change.
- The negative regression fails with the old priority restored.
- The integrated measure/extraction branch passed `./scripts/validate.sh --lint --test --axioms`, including the complete framework tests and executable vectors, with no new axiom or sorry taint.
- On this standalone branch, `./scripts/validate.sh --lint --axioms` passed: all production builds, text/environment linters, boundaries, docs, and no new axiom/sorry taint across 18,152 declarations in 567 modules.
- `./scripts/update-lib.sh` leaves generated umbrellas unchanged.

## Checklist

- [x] Standard header, module docstring, and intrinsic declaration documentation.
- [x] New test file uses plain `public section`; no new exposed definitions.
- [x] Generated umbrellas and axiom check pass; baseline untouched.
- [x] No linter suppressions, deprecated aliases, or native FFI executable dependency.
- [x] Agent documentation checks pass; no documented API changes required.
- [x] Simp/grind/gcongr registries are unchanged; the instance-selection regressions are each one `rfl`.
